### PR TITLE
interaction step migration: part 1

### DIFF
--- a/src/migrations/2017-06-30-interaction-step-answer-option.js
+++ b/src/migrations/2017-06-30-interaction-step-answer-option.js
@@ -1,0 +1,36 @@
+import { r } from '../server/models'
+
+// For each answer_option on interaction steps with question:
+// - Move the value to the answer_option field of the child interaction step
+// - Set the parent_interaction_id of the child to the id of the parent
+// - TODO: Drop the answer_options field
+
+// Run this migration on a running dev or prod instance with the following command:
+// ./dev-tools/babel-run-with-env.js ./src/migrations/2017-06-30-interaction-step-answer-option.js
+
+(async function () {
+  console.log('migrating interaction steps to updated schema');
+  try {
+    const parentSteps = await r.db('spokedev')
+      .table('interaction_step')
+      .filter((step) => step('answer_options')
+      .ne([]))
+    console.log(parentSteps)
+    const parentCount = parentSteps.length
+    for (let i = 0; i < parentCount; i++) {
+      const answerCount = parentSteps[i]['answer_options'].length
+      for (let j = 0; j < answerCount; j++) {
+        const parentId = parentSteps[i]['id']
+        const answerOption = parentSteps[i]['answer_options'][j]
+        console.log(answerOption)
+        const answerStepUpdate = await r.db('spokedev')
+          .table('interaction_step')
+          .get(answerOption.interaction_step_id)
+          .update({'answer_option': answerOption.value, 'parent_interaction_id': parentId})
+        console.log(answerStepUpdate)
+      }
+    }
+  } catch (ex) {
+    console.log(ex)
+  }
+})()

--- a/src/migrations/2017-06-30-interaction-step-answer-option.js
+++ b/src/migrations/2017-06-30-interaction-step-answer-option.js
@@ -11,7 +11,7 @@ import { r } from '../server/models'
 (async function () {
   console.log('migrating interaction steps to updated schema');
   try {
-    const parentSteps = await r.db('spokedev')
+    const parentSteps = await r.db('spoke')
       .table('interaction_step')
       .filter((step) => step('answer_options')
       .ne([]))
@@ -23,7 +23,7 @@ import { r } from '../server/models'
         const parentId = parentSteps[i]['id']
         const answerOption = parentSteps[i]['answer_options'][j]
         console.log(answerOption)
-        const answerStepUpdate = await r.db('spokedev')
+        const answerStepUpdate = await r.db('spoke')
           .table('interaction_step')
           .get(answerOption.interaction_step_id)
           .update({'answer_option': answerOption.value, 'parent_interaction_id': parentId})

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -66,6 +66,9 @@ export const resolvers = {
       loaders.campaign.load(campaignContact.campaign_id)
     ),
     questionResponses: async (campaignContact) => (
+      //TODO: what are all the questionresponses
+      // -- join by value==[child]interactionstep.answer_option
+      // -- also join by interaction_step_id==[parent]interactionstep: "parent_interaction_step", "contact_response_value"
       r.table('question_response')
         .getAll(campaignContact.id, { index: 'campaign_contact_id' })
         .eqJoin('interaction_step_id', r.table('interaction_step'))

--- a/src/server/api/question.js
+++ b/src/server/api/question.js
@@ -19,6 +19,7 @@ export const schema = `
 export const resolvers = {
   Question: {
     text: async (interactionStep) => interactionStep.question,
+    //TODO: need to just query for parent_id = interactionstep.id
     answerOptions: async (interactionStep) => (
       interactionStep.answer_options.map((answer) => ({
         ...answer,

--- a/src/server/models/interaction-step.js
+++ b/src/server/models/interaction-step.js
@@ -5,8 +5,19 @@ import { requiredString, optionalString, timestamp } from './custom-types'
 const InteractionStep = thinky.createModel('interaction_step', type.object().schema({
   id: type.string(),
   campaign_id: requiredString(),
+  //PROMPTS:
   question: optionalString(),
   script: optionalString(),
+  //START NEW
+  //previously there were answer options, and no such thing as
+  // parents/ancestors.  This was pretty cool, in-theory
+  // since you could have many paths that led into a unified
+  // path.  However, the UI didn't allow it, so we are going
+  // to squash that dream, at least until after the db migration
+  // FIELDS FOR SUB-INTERACTIONS (only)
+  parent_interaction_id: optionalString(),
+  answer_option: optionalString(), //(was 'value')
+  //END NEW
   answer_options: type
     .array()
     .schema({

--- a/src/workers/job-handler.js
+++ b/src/workers/job-handler.js
@@ -40,6 +40,12 @@ async function uploadContacts(job) {
 async function createInteractionSteps(job) {
   const id = job.payload.id
   const interactionSteps = []
+  //TODO:
+  // * set parent_id
+  // * set answer_option
+  // this means going 'backwards' and propagating the options
+  // 1. create dictionary keyed by step.id
+  // 2. back-propagate answers/parents
   for (let index = 0; index < job.payload.interaction_steps.length; index++) {
     // We use r.uuid(step.id) so that
     // any new steps will get a proper


### PR DESCRIPTION
These changes are transitional prep for the migration to a relational database. They: 

- add new model fields to interaction_step while retaining the old model fields so things that depend on them still work
- provide a way to migrate data from old model to transitional model
- alter the instance save worker method to save the data in the new model fields

To check that this all works:

1. In the UI, create a campaign with title "Cats" and add interactions (a script) with at least one question with multiple answer options (you can change the campaign name if you don't like it - just make sure the filter in the query below matches).
2. Run this in the [data explorer](http://localhost:8080/#dataexplorer) to inspect the (script) interactions data before migration and resave:
`r.db('spokedev').table('interaction_step').innerJoin(r.db('spokedev').table('campaign'),function(interaction_step, campaign){return interaction_step["campaign_id"]==campaign["id"]}).filter({"right": {"title":"Cats"}}).pluck("left")`
My app database is named 'spokedev'; if yours is named differently you'll need to change the name where it appears in the query.
4. Run the migration (see src/migrations/2017-06-30-interaction-step-answer-option.js) to copy answer-option data from old model fields to transitional model fields. Note that if your db name is not 'spoke' (mine is 'spokedev') you'll have to edit it in the code before running the migration.
5. Repeat step 2 and note that the answer options are now in the answer_option fields on the response steps (as well as in the answer_options array fields on the question steps) and that interaction_parent_ids point to the question step id.
6. Navigate to campaign admin and edit and save your Cats campaign script. It should not hang on save, and the updated data should be inspectable in the db if you repeat step 2 a third time.

The next step is to fix all the things that will break with the new (postgres-compatible) interaction-step model. Once that all works, we can cut away all the old fields and migrate entirely to the new model in a future PR.


