### PR TITLE
make answerOptions more knex-supportable, and will do the same thing

### DIFF
--- a/src/server/api/question.js
+++ b/src/server/api/question.js
@@ -21,10 +21,7 @@ export const resolvers = {
     text: async (interactionStep) => interactionStep.question,
     answerOptions: async (interactionStep) => (
       r.table('interaction_step')
-      .filter({parent_interaction_id: interactionStep.id})
-        .eqJoin('parent_interaction_id', r.table('interaction_step'))
-        .pluck({'left': ['answer_option', 'id', 'parent_interaction_id']})
-        .zip()
+        .filter({parent_interaction_id: interactionStep.id})
         .map({
           value: r.row('answer_option'),
           interaction_step_id: r.row('id'),


### PR DESCRIPTION
I believe this does the same thing, because you end up selecting just from the left 'table' anyway.
Knex complains because the tables are the same, and so the fields fail -- probably will have to deal with that in another query, but for this one....