### PR TITLE
remove job queues/locking: if we do not do this, will have to rewrite…

### DIFF
--- a/src/workers/lib.js
+++ b/src/workers/lib.js
@@ -13,35 +13,17 @@ export async function updateJob(job, percentComplete) {
 }
 
 export async function getNextJob() {
-  const lockedQueues = await r.table('job_request')
-   .group({index: 'queue_name'})
-   .filter({
-     assigned: true,
-     locks_queue: true
-   })
-   .count()
-   .ungroup()
-   .filter((row) => row('reduction').gt(0))
-   .pluck('group')('group')
-
-  let availableQueues = await r.table('job_request')
-    .filter((row) => r.not(r.expr(lockedQueues).contains(row('queue_name'))))('queue_name')
-  availableQueues = availableQueues.sort()
-  const nextQueue = availableQueues[0]
-  let nextJob = null
-  if (nextQueue) {
-    nextJob = await r.table('job_request')
-      .getAll(nextQueue, { index: 'queue_name' })
+  let nextJob = await r.table('job_request')
+      .filter({'assigned': false})
       .orderBy('created_at')
       .limit(1)(0)
-    if (nextJob) {
+  if (nextJob) {
       const updateResults = await r.table('job_request')
         .get(nextJob.id)
         .update({ assigned: true })
       if (updateResults.replaced !== 1) {
         nextJob = null
       }
-    }
   }
   return nextJob
 }


### PR DESCRIPTION
… for knex support anyway.

rethink-knex-adapter doesn't implement `group()`, `ungroup()` nor the weird filter() meta-function thing (`filter()` for standard dict queries work).

I don't see a need for the job queues -- if someone does, perhaps this would be a good task to take on "the right way"