### PR TITLE
README: Link to Auth0 with an absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This is generated from [react-apollo-starter-kit](https://github.com/saikat/reac
 5. `cp .env.example .env`
 6. Start `rethinkdb` and load `localhost:8080` to confirm RethinkDB is properly installed. Then stop RethinkDB.
 7. Run `rethinkdb && ./dev-tools/babel-run-with-env.js ./dev-tools/db-startup.js` to restart RethinkDB and populate the tables. Check http://localhost:8080/#tables to confirm the tables were created. Then stop RethinkDB again.
-8. Create an [Auth0](auth0.com) account. In your Auth0 account, go to Settings -> Clients -> and then grab your Client ID, Client Secret, and your Auth0 domain (should look like xxx.auth0.com). Add those inside your `.env` file (AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN respectively).
+8. Create an [Auth0](https://auth0.com) account. In your Auth0 account, go to Settings -> Clients -> and then grab your Client ID, Client Secret, and your Auth0 domain (should look like xxx.auth0.com). Add those inside your `.env` file (AUTH0_CLIENT_ID, AUTH0_CLIENT_SECRET, AUTH0_DOMAIN respectively).
 9. Add the login callback and logout callback URL in `.env` (default `http://localhost:3000/login-callback` and `http://localhost:3000/logout-callback`) to your Auth0 app settings under "Allowed Callback URLs" and "Allowed Logout URLs" respectively.
 10. Run `npm run dev` to start the app. Wait until you see both "Node app is running ..." and "Webpack dev server is now running ..." before attempting to connect.
 11. Go to `localhost:3000` to load the app.


### PR DESCRIPTION
This fixes the broken link to Auth0 in the README. Not using the absolute path tries to open it as a relative file link.