### PR TITLE
Invite links update

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "thinky": "^2.3.3",
     "transform-loader": "^0.2.3",
     "twilio": "^2.11.0",
+    "uuid": "^3.1.0",
     "webpack": "^1.13.1",
     "webpack-manifest-plugin": "^1.0.1",
     "yup": "^0.19.0"

--- a/src/client/error-catcher.js
+++ b/src/client/error-catcher.js
@@ -8,11 +8,4 @@ export default (error) => {
 
   log.error(error)
 
-  if (window.location.href.split('/')[2].split(':')[0] !== 'localhost') {
-    setTimeout(() => {
-      alert(`Whoops! Something went wrong. We\'re looking into it,
-        but in the meantime please refresh your browser.`)
-      document.location.reload(true)
-    }, 2000)
-  }
 }

--- a/src/containers/CreateOrganization.jsx
+++ b/src/containers/CreateOrganization.jsx
@@ -97,7 +97,7 @@ class CreateOrganization extends React.Component {
           Spoke
         </div>
         <div className={css(styles.formContainer)}>
-          {this.props.inviteData.invite && this.props.inviteData.invite.isValid ? this.renderForm() : this.renderInvalid()}
+          {this.props.inviteData.inviteByHash && this.props.inviteData.inviteByHash[0].isValid ? this.renderForm() : this.renderInvalid()}
         </div>
       </div>
     )

--- a/src/containers/CreateOrganization.jsx
+++ b/src/containers/CreateOrganization.jsx
@@ -107,7 +107,7 @@ class CreateOrganization extends React.Component {
 const mapQueriesToProps = ({ ownProps }) => ({
   inviteData: {
     query: gql`query getInvite($inviteId: String!) {
-      invite(id: $inviteId) {
+      inviteByHash(hash: $inviteId) {
         id
         isValid
       }

--- a/src/containers/CreateOrganization.jsx
+++ b/src/containers/CreateOrganization.jsx
@@ -63,7 +63,7 @@ class CreateOrganization extends React.Component {
                 const newOrganization = await this.props.mutations.createOrganization(
                     formValues.name,
                     this.props.userData.currentUser.id,
-                    this.props.inviteData.invite.id
+                    this.props.inviteData.inviteByHash[0].id
                   )
                 this.props.router.push(`/admin/${newOrganization.data.createOrganization.id}`)
               }}

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -57,7 +57,7 @@ class Home extends React.Component {
       throw new Error(newInvite.errors)
     } else {
       // alert(newInvite.data.createInvite.id)
-      this.props.router.push(`/invite/${newInvite.data.createInvite.id}`)
+      this.props.router.push(`/invite/${newInvite.data.createInvite.hash}`)
     }
   }
 
@@ -127,7 +127,7 @@ const mapMutationsToProps = () => ({
     mutation: gql`
         mutation createInvite($invite: InviteInput!) {
           createInvite(invite: $invite) {
-            id
+            hash
           }
         }`,
     variables: { invite }

--- a/src/server/api/invite.js
+++ b/src/server/api/invite.js
@@ -5,6 +5,7 @@ export const schema = `
   type Invite {
     id: ID
     isValid: Boolean
+    hash: String
   }
 `
 
@@ -12,7 +13,8 @@ export const resolvers = {
   Invite: {
     ...mapFieldsToModel([
       'id',
-      'isValid'
+      'isValid',
+      'hash'
     ], Invite)
   }
 }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1,4 +1,3 @@
-import { log } from '../../lib'
 import { Campaign,
   CannedResponse,
   Invite,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -142,6 +142,7 @@ const rootSchema = `
   input InviteInput {
     id: String
     is_valid: Boolean
+    hash: String
     created_at: Date
   }
 
@@ -150,9 +151,9 @@ const rootSchema = `
     organization(id:String!): Organization
     campaign(id:String!): Campaign
     invite(id:String!): Invite
-    inviteByHash(hash:String!): Invite
-    contact(id:String!): CampaignContact,
-    assignment(id:String!): Assignment,
+    inviteByHash(hash:String!): [Invite]
+    contact(id:String!): CampaignContact
+    assignment(id:String!): Assignment
     organizations: [Organization]
   }
 

--- a/src/server/models/invite.js
+++ b/src/server/models/invite.js
@@ -8,6 +8,7 @@ const Invite = thinky.createModel('invite', type.object().schema({
     .boolean()
     .required()
     .allowNull(false),
+  hash: type.string(),
   created_at: timestamp()
 }).allowExtra(false))
 


### PR DESCRIPTION
For https://github.com/MoveOnOrg/Spoke/issues/86, this adds a hash column to the invite schema, populates it with UUID, and uses that instead of ID, so invite links are less guessable.