### PR TITLE
Remove availablephonenumbers

### DIFF
--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -18,18 +18,12 @@ export default class AdminIncomingMessageList extends Component {
     super(props)
 
     this.state = {
-      incomingmessages: [],
-      availablephonenumbers: []
+      incomingmessages: []
     }
   }
   componentDidMount() {
     axios.get('http://localhost:3000/allmessages')
       .then(response => this.setState({ incomingmessages: response.data }))
-  }
-
-  getAvailablePhoneNumbers() {
-    axios.get('http://localhost:3000/availablephonenumbers')
-      .then(response => response.data)
   }
 
   render() {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -127,16 +127,6 @@ app.get('/allmessages', (req, res) => {
   }
 })
 
-app.get('/availablephonenumbers', (req, res) => {
-  if (req.user && req.user.is_superadmin) {
-    client.incomingPhoneNumbers.list(
-      (err, data) => res.json(data.incomingPhoneNumbers)
-    )
-  } else {
-    return res.json([])
-  }
-})
-
 app.get('/logout-callback', (req, res) => {
   req.logOut()
   res.redirect('/')


### PR DESCRIPTION
For #97, I started looking at how the availablephonenumbers callback is used to make sure it's secure. What I found is that it's not used at all, so the simplest way to secure it is to remove it. It's called from a function, but that function is never called. It looks like that function was intended to update a state property, but that state is never used anywhere.