### PR TITLE
allmessages security

### DIFF
--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -22,7 +22,7 @@ export default class AdminIncomingMessageList extends Component {
     }
   }
   componentDidMount() {
-    axios.get('/allmessages')
+    axios.get(`/allmessages/${this.props.params.organizationId}`)
       .then(response => this.setState({ incomingmessages: response.data }))
   }
 
@@ -42,17 +42,14 @@ export default class AdminIncomingMessageList extends Component {
             </TableHeader>
             <TableBody>
               {this.state.incomingmessages.map(message => {
-                if (message.direction === 'inbound') {
-                  return (
-                    <TableRow key={message.id}>
-                      <TableRowColumn> {message.date_sent}</TableRowColumn>
-                      <TableRowColumn>{message.from}</TableRowColumn>
-                      <TableRowColumn>{message.to}</TableRowColumn>
-                      <TableRowColumn style={{ width: '40%' }}>{message.body}</TableRowColumn>
-                    </TableRow>
-                    )
-                }
-                return ''
+                return (
+                  <TableRow key={message.id}>
+                    <TableRowColumn> {message.created_at}</TableRowColumn>
+                    <TableRowColumn>{message.user_number}</TableRowColumn>
+                    <TableRowColumn>{message.contact_number}</TableRowColumn>
+                    <TableRowColumn style={{ width: '40%' }}>{message.text}</TableRowColumn>
+                  </TableRow>
+                  )
               }
               )}
             </TableBody>

--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -22,7 +22,7 @@ export default class AdminIncomingMessageList extends Component {
     }
   }
   componentDidMount() {
-    axios.get('http://localhost:3000/allmessages')
+    axios.get('/allmessages')
       .then(response => this.setState({ incomingmessages: response.data }))
   }
 

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -17,6 +17,7 @@ import { seedZipCodes } from './seeds/seed-zip-codes'
 import { setupUserNotificationObservers } from './notifications'
 import { Tracer } from 'apollo-tracer'
 import { TwimlResponse } from 'twilio'
+import { r } from './models'
 
 process.on('uncaughtException', (ex) => {
   log.error(ex)
@@ -112,20 +113,38 @@ app.post('/twilio-message-report', wrap(async (req, res) => {
 //   })
 // })
 
-app.get('/allmessages', (req, res) => {
-  if (req.user && req.user.is_superadmin) {
-    client.sms.messages.list((err, data) => {
-      if (err) {
-        log.error(err)
-      } else {
-        const listOfMessages = data.sms_messages
-        return res.json(listOfMessages)
-      }
+app.get('/allmessages/:organizationId', wrap(async (req, res) => {
+  const orgId = req.params.organizationId
+  const membership = await r.knex('user_organization')
+    .where({
+      user_id: req.user.id,
+      organization_id: orgId,
+      role: 'ADMIN'
     })
-  } else {
+    .first()
+
+  if (typeof membership === 'undefined') {
+    // Current user is not admin of the requested org, can't access messages.
     res.json([])
   }
-})
+  else {
+    const messages = await r.knex('message')
+      .select(
+          'message.id',
+          'message.text',
+          'message.user_number',
+          'message.contact_number',
+          'message.created_at'
+      )
+      .join('assignment', 'message.assignment_id', 'assignment.id')
+      .join('campaign', 'assignment.campaign_id', 'campaign.id')
+      .where('campaign.organization_id', orgId)
+      .where('message.is_from_contact', true)
+      .orderBy('message.created_at', 'desc')
+    return res.json(messages)
+  }
+
+}))
 
 app.get('/logout-callback', (req, res) => {
   req.logOut()


### PR DESCRIPTION
For #97, this changes the /allmessages callback to be org-specific (/allmessages/:organizationId), loads messages from local DB (since Twilio doesn't have org info), and checks that the current user is admin of the requested org.