### PR TITLE
#114 Fix autosplit

### DIFF
--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -105,9 +105,7 @@ export default class CampaignTextersForm extends React.Component {
   }
 
   onChange = (formValues) => {
-    console.log("onChange")
     const existingFormValues = this.formValues()
-    console.log("existingFormValues " + JSON.stringify(existingFormValues))
     const changedTexter = this.state.focusedTexter
     const newFormValues = {
       ...formValues
@@ -116,7 +114,6 @@ export default class CampaignTextersForm extends React.Component {
     let totalMessaged = 0
     const texterCountChanged = newFormValues.texters.length !== existingFormValues.texters.length
     newFormValues.texters = newFormValues.texters.map((newTexter) => {
-      console.log("newTexter" + JSON.stringify(newTexter))
       const existingTexter = existingFormValues.texters.filter((texter) => (texter.id === newTexter.id ? texter : null))[0]
       let messagedCount = 0
       if (existingTexter) {
@@ -128,18 +125,15 @@ export default class CampaignTextersForm extends React.Component {
       if (isNaN(convertedNeedsMessageCount)) {
         convertedNeedsMessageCount = 0
       }
-      console.log("this.formValues().contactsCount " + this.formValues().contactsCount)
       if (convertedNeedsMessageCount + messagedCount > this.formValues().contactsCount) {
         convertedNeedsMessageCount = this.formValues().contactsCount - messagedCount
       }
 
       if (convertedNeedsMessageCount < 0) {
-        console.log("convertedNeedsMessageCount < 0")
         convertedNeedsMessageCount = 0
       }
 
       if (texterCountChanged && this.state.autoSplit) {
-        console.log("texterCountChanged && this.state.autoSplit")
         convertedNeedsMessageCount = 0
       }
 
@@ -155,9 +149,7 @@ export default class CampaignTextersForm extends React.Component {
       }
     })
 
-    console.log("newFormValues AFTER " + JSON.stringify(newFormValues))
     let extra = totalNeedsMessage + totalMessaged - this.formValues().contactsCount
-    console.log('extra = totalNeedsMessage + totalMessaged - this.formValues().contactsCount = ' + totalNeedsMessage + " + " + totalMessaged + " - " + this.formValues().contactsCount)
     if (extra > 0) {
       let theTexter = newFormValues.texters[0]
       if (changedTexter) {
@@ -184,14 +176,11 @@ export default class CampaignTextersForm extends React.Component {
         newFormValues.texters[0].assignment.contactsCount = this.formValues().contactsCount
         newFormValues.texters[0].assignment.needsMessageCount = this.formValues().contactsCount - messagedCount
       } else if (newFormValues.texters.length > 1 && (extra > 0 || (extra < 0 && this.state.autoSplit))) {
-        console.log("newFormValues.texters.length > 1 && (extra > 0 || (extra < 0 && this.state.autoSplit))")
         while (extra !== 0) {
           const texter = newFormValues.texters[index]
           if (skipsByIndex[index] < texter.assignment.contactsCount - texter.assignment.needsMessageCount) {
             skipsByIndex[index]++
           } else {
-            console.log("changedTexter " + changedTexter)
-            console.log("texter.id " + texter.id)
             if (!changedTexter || texter.id !== changedTexter) {
               if (texter.assignment.needsMessageCount + factor >= 0) {
                 texter.assignment.needsMessageCount = texter.assignment.needsMessageCount + factor

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -421,7 +421,6 @@ export default class CampaignTextersForm extends React.Component {
                             }
                           })
                         )
-                        console.log(newTexters)
                         this.onChange({ ...this.formValues(), texters: newTexters })
                       }
                     })

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -105,7 +105,9 @@ export default class CampaignTextersForm extends React.Component {
   }
 
   onChange = (formValues) => {
+    console.log("onChange")
     const existingFormValues = this.formValues()
+    console.log("existingFormValues " + JSON.stringify(existingFormValues))
     const changedTexter = this.state.focusedTexter
     const newFormValues = {
       ...formValues
@@ -114,6 +116,7 @@ export default class CampaignTextersForm extends React.Component {
     let totalMessaged = 0
     const texterCountChanged = newFormValues.texters.length !== existingFormValues.texters.length
     newFormValues.texters = newFormValues.texters.map((newTexter) => {
+      console.log("newTexter" + JSON.stringify(newTexter))
       const existingTexter = existingFormValues.texters.filter((texter) => (texter.id === newTexter.id ? texter : null))[0]
       let messagedCount = 0
       if (existingTexter) {
@@ -125,15 +128,18 @@ export default class CampaignTextersForm extends React.Component {
       if (isNaN(convertedNeedsMessageCount)) {
         convertedNeedsMessageCount = 0
       }
+      console.log("this.formValues().contactsCount " + this.formValues().contactsCount)
       if (convertedNeedsMessageCount + messagedCount > this.formValues().contactsCount) {
         convertedNeedsMessageCount = this.formValues().contactsCount - messagedCount
       }
 
       if (convertedNeedsMessageCount < 0) {
+        console.log("convertedNeedsMessageCount < 0")
         convertedNeedsMessageCount = 0
       }
 
       if (texterCountChanged && this.state.autoSplit) {
+        console.log("texterCountChanged && this.state.autoSplit")
         convertedNeedsMessageCount = 0
       }
 
@@ -149,7 +155,9 @@ export default class CampaignTextersForm extends React.Component {
       }
     })
 
+    console.log("newFormValues AFTER " + JSON.stringify(newFormValues))
     let extra = totalNeedsMessage + totalMessaged - this.formValues().contactsCount
+    console.log('extra = totalNeedsMessage + totalMessaged - this.formValues().contactsCount = ' + totalNeedsMessage + " + " + totalMessaged + " - " + this.formValues().contactsCount)
     if (extra > 0) {
       let theTexter = newFormValues.texters[0]
       if (changedTexter) {
@@ -170,18 +178,26 @@ export default class CampaignTextersForm extends React.Component {
     } else {
       const factor = 1
       let index = 0
+      let skipsByIndex = new Array(newFormValues.texters.length).fill(0)
       if (newFormValues.texters.length === 1 && this.state.autoSplit) {
         const messagedCount = newFormValues.texters[0].assignment.contactsCount - newFormValues.texters[0].assignment.needsMessageCount
         newFormValues.texters[0].assignment.contactsCount = this.formValues().contactsCount
         newFormValues.texters[0].assignment.needsMessageCount = this.formValues().contactsCount - messagedCount
       } else if (newFormValues.texters.length > 1 && (extra > 0 || (extra < 0 && this.state.autoSplit))) {
+        console.log("newFormValues.texters.length > 1 && (extra > 0 || (extra < 0 && this.state.autoSplit))")
         while (extra !== 0) {
           const texter = newFormValues.texters[index]
-          if (!changedTexter || texter.id !== changedTexter) {
-            if (texter.assignment.needsMessageCount + factor >= 0) {
-              texter.assignment.needsMessageCount = texter.assignment.needsMessageCount + factor
-              texter.assignment.contactsCount = texter.assignment.contactsCount + factor
-              extra = extra + factor
+          if (skipsByIndex[index] < texter.assignment.contactsCount - texter.assignment.needsMessageCount) {
+            skipsByIndex[index]++
+          } else {
+            console.log("changedTexter " + changedTexter)
+            console.log("texter.id " + texter.id)
+            if (!changedTexter || texter.id !== changedTexter) {
+              if (texter.assignment.needsMessageCount + factor >= 0) {
+                texter.assignment.needsMessageCount = texter.assignment.needsMessageCount + factor
+                texter.assignment.contactsCount = texter.assignment.contactsCount + factor
+                extra = extra + factor
+              }
             }
           }
           index = index + 1
@@ -290,7 +306,6 @@ export default class CampaignTextersForm extends React.Component {
   showTexters() {
     return this.formValues().texters.map((texter, index) => {
       const messagedCount = texter.assignment.contactsCount - texter.assignment.needsMessageCount
-
       return (
         <div className={css(styles.texterRow)}>
           <div className={css(styles.leftSlider)}>
@@ -417,6 +432,7 @@ export default class CampaignTextersForm extends React.Component {
                             }
                           })
                         )
+                        console.log(newTexters)
                         this.onChange({ ...this.formValues(), texters: newTexters })
                       }
                     })

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -9,7 +9,6 @@ export const schema = `
     texter: User
     campaign: Campaign
     contacts(contactsFilter: ContactsFilter): [CampaignContact]
-    contactedCount(contactsFilter: ContactsFilter): Int
     contactsCount(contactsFilter: ContactsFilter): Int
     userCannedResponses: [CannedResponse]
     campaignCannedResponses: [CannedResponse]
@@ -92,7 +91,6 @@ export const resolvers = {
       loaders.user.load(assignment.user_id)
     ),
     campaign: async(assignment, _, { loaders }) => loaders.campaign.load(assignment.campaign_id),
-
     contactsCount: async (assignment, { contactsFilter }) => {
       const campaign = await r.table('campaign').get(assignment.campaign_id)
 
@@ -102,14 +100,6 @@ export const resolvers = {
       const result = await getContacts(assignment, contactsFilter, organization, campaign).count()
       return result[0].count
     },
-
-    contactedCount: async (assignment, { contactsFilter }) => {
-      // does
-      return r.table('campaign_contact')
-        .getAll('messaged', 'closed', 'needsResponse', { index: 'message_status' })
-        .filter({ 'assignment_id': assignment.id }).count()
-    },
-
     contacts: async (assignment, { contactsFilter }) => {
       const campaign = await r.table('campaign').get(assignment.campaign_id)
 


### PR DESCRIPTION
Autosplit behavior doesn't account for already messaged contacts. So if you have 10 new contacts to assign to texters A and B, and texter A has already messaged 6 contacts, A and B will still each get 5 new contacts. Whereas you'd expect Texter A to get just 2 more new contacts and B to get 8 more.
In working on this, I realized that Autosplit behaves more intuitively if it's something that happens once when you click a button rather than something that's auto-correcting numbers while it's toggled on. That's significantly more refactoring, though.

Thoughts? Maybe autosplit isn't all that valuable and we should focus on a feature that lets individual texters pull contact assignments off a queue.