### PR TITLE
joinOrganization security

### DIFF
--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -357,11 +357,11 @@ export default class CampaignTextersForm extends React.Component {
   }
 
   render() {
-    const { organizationId } = this.props
+    const { organizationUuid } = this.props
     let subtitle = ''
     subtitle = (
       <div>
-        <OrganizationJoinLink organizationId={organizationId} />
+        <OrganizationJoinLink organizationUuid={organizationUuid} />
       </div>
     )
 

--- a/src/components/OrganizationJoinLink.jsx
+++ b/src/components/OrganizationJoinLink.jsx
@@ -1,13 +1,13 @@
 import React from 'react'
 import TextField from 'material-ui/TextField'
 
-const OrganizationJoinLink = ({ organizationId }) => {
+const OrganizationJoinLink = ({ organizationUuid }) => {
   let baseUrl = 'http://base'
   if (typeof window !== 'undefined') {
     baseUrl = window.location.origin
   }
 
-  const joinUrl = `${baseUrl}/${organizationId}/join`
+  const joinUrl = `${baseUrl}/${organizationUuid}/join`
 
   return (
     <div>
@@ -25,7 +25,7 @@ const OrganizationJoinLink = ({ organizationId }) => {
 }
 
 OrganizationJoinLink.propTypes = {
-  organizationId: React.PropTypes.number
+  organizationUuid: React.PropTypes.string
 }
 
 export default OrganizationJoinLink

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -240,7 +240,7 @@ class AdminCampaignEdit extends React.Component {
       blocksStarting: false,
       extraProps: {
         orgTexters: this.props.organizationData.organization.texters,
-        organizationId: this.props.params.organizationId
+        organizationUuid: this.props.organizationData.organization.uuid
       }
     }, {
       title: 'Interactions',
@@ -535,6 +535,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
     query: gql`query getOrganizationData($organizationId: String!, $role: String!) {
       organization(id: $organizationId) {
         id
+        uuid
         optOuts {
           cell
         }

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -103,7 +103,7 @@ class AdminPersonList extends React.Component {
   }
 
   render() {
-    const { params } = this.props
+    const { params, organizationData } = this.props
 
     return (
       <div>
@@ -128,7 +128,7 @@ class AdminPersonList extends React.Component {
           onRequestClose={this.handleClose}
         >
           <OrganizationJoinLink
-            organizationId={params.organizationId}
+            organizationUuid={organizationData.organization.uuid}
           />
         </Dialog>
       </div>
@@ -140,7 +140,8 @@ AdminPersonList.propTypes = {
   mutations: React.PropTypes.object,
   params: React.PropTypes.object,
   personData: React.PropTypes.object,
-  userData: React.PropTypes.object
+  userData: React.PropTypes.object,
+  organizationData: React.PropTypes.object
 }
 
 const mapMutationsToProps = () => ({
@@ -177,6 +178,18 @@ const mapQueriesToProps = ({ ownProps }) => ({
       currentUser {
         id
         roles(organizationId: $organizationId)
+      }
+    }`,
+    variables: {
+      organizationId: ownProps.params.organizationId
+    },
+    forceFetch: true
+  },
+  organizationData: {
+    query: gql`query getOrganizationData($organizationId: String!) {
+      organization(id: $organizationId) {
+        id
+        uuid
       }
     }`,
     variables: {

--- a/src/containers/JoinTeam.jsx
+++ b/src/containers/JoinTeam.jsx
@@ -56,12 +56,12 @@ JoinTeam.propTypes = {
 const mapMutationsToProps = ({ ownProps }) => ({
   joinOrganization: () => ({
     mutation: gql`
-      mutation joinOrganization($organizationId: String!) {
-        joinOrganization(organizationId: $organizationId) {
+      mutation joinOrganization($organizationUuid: String!) {
+        joinOrganization(organizationUuid: $organizationUuid) {
           id
         }
       }`,
-    variables: { organizationId: ownProps.params.organizationId }
+    variables: { organizationUuid: ownProps.params.organizationUuid }
   })
 })
 

--- a/src/migrations/2017-08-10-organization_uuid.js
+++ b/src/migrations/2017-08-10-organization_uuid.js
@@ -1,0 +1,10 @@
+import { r } from '../server/models'
+
+async function migrate() {
+  await r.knex.schema.alterTable('organization', (table) => {
+    table.string('uuid');
+  })
+  console.log('added uuid column to organization table')
+}
+
+migrate()

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -75,7 +75,7 @@ export default function makeRoutes(requireAuth = () => {}) {
       </Route>
       <Route path='login' component={Login} />
       <Route path='invite/:inviteId' component={CreateOrganization} onEnter={requireAuth} />
-      <Route path=':organizationId/join' component={JoinTeam} onEnter={requireAuth} />
+      <Route path=':organizationUuid/join' component={JoinTeam} onEnter={requireAuth} />
       <Route path='privacy' component={Privacy} />
     </Route>
   )

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -5,6 +5,7 @@ import { accessRequired } from './errors'
 export const schema = `
   type Organization {
     id: ID
+    uuid: String
     name: String
     campaigns(campaignsFilter: CampaignsFilter): [Campaign]
     people(role: String): [User]
@@ -35,6 +36,13 @@ export const resolvers = {
 
       return query
     },
+    uuid: async (organization, _, { user }) => {
+      await accessRequired(user, organization.id, 'ADMIN')
+      const result = await r.knex('organization')
+        .column('uuid')
+        .where('id', organization.id)
+      return result[0].uuid
+    },
     optOuts: async (organization, _, { user }) => {
       await accessRequired(user, organization.id, 'ADMIN')
       return r.table('opt_out')
@@ -57,4 +65,3 @@ export const resolvers = {
     textingHoursEnd: (organization) => organization.texting_hours_end
   }
 }
-

--- a/src/server/models/organization.js
+++ b/src/server/models/organization.js
@@ -6,6 +6,7 @@ import { requiredString, timestamp } from './custom-types'
 
 const Organization = thinky.createModel('organization', type.object().schema({
   id: type.string(),
+  uuid: type.string(),
   name: requiredString(),
   created_at: timestamp(),
   features: type.string().required().default(''), // should be restricted by FEATURES

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -17,7 +17,12 @@ if (!DEBUG) {
   plugins.push(new ManifestPlugin({
     fileName: assetMapFile
   }))
-  plugins.push(new webpack.optimize.UglifyJsPlugin({ minimize: true }))
+  plugins.push(new webpack.optimize.UglifyJsPlugin({
+    compress: {
+        warnings: false
+    },
+    minimize: true
+  }))
 } else {
   plugins.push(new webpack.HotModuleReplacementPlugin())
   jsxLoaders.unshift('react-hot')
@@ -60,15 +65,13 @@ const config = {
   output: {
     filename: outputFile,
     path: DEBUG ? '/' : assetsDir,
-    publicPath: '/assets/',
-    sourceMapFilename: `${outputFile}.map`
+    publicPath: '/assets/'
   }
 }
 
 if (DEBUG) {
   config.devtool = '#inline-source-map'
-} else if (process.env.NODE_ENV === 'production') {
-  config.devtool = 'source-map'
+  config.output.sourceMapFilename = `${outputFile}.map`
 }
 
 module.exports = config


### PR DESCRIPTION
For https://github.com/MoveOnOrg/Spoke/issues/97 this adds UUIDs to organization model and changes the join links to use UUID, so join links are no longer guessable.

**Note:** this includes a migration with a schema update to run on deploy. Should not require wiping database.