### PR TITLE
remove invite resolver

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -152,7 +152,6 @@ const rootSchema = `
     currentUser: User
     organization(id:String!): Organization
     campaign(id:String!): Campaign
-    invite(id:String!): Invite
     inviteByHash(hash:String!): [Invite]
     contact(id:String!): CampaignContact
     assignment(id:String!): Assignment
@@ -650,10 +649,6 @@ const rootResolvers = {
     },
     organization: async(_, { id }, { loaders }) =>
       loaders.organization.load(id),
-    invite: async (_, { id }, { loaders, user }) => {
-      authRequired(user)
-      return loaders.invite.load(id)
-    },
     inviteByHash: async (_, { hash }, { loaders, user }) => {
       authRequired(user)
       return r.table('invite').filter({"hash": hash})


### PR DESCRIPTION
For https://github.com/MoveOnOrg/Spoke/issues/97 I'm pretty sure this resolver isn't used anywhere, so the best way to secure it is to remove it. It's hard to be fully confident in that assessment, as the word "invite" shows up a lot in the code, but I spent a while looking through all of that code and didn't find anything that looked like a graphQL request on this resolver.