### PR TITLE
add external_id and backend naive-implementation for contact_sql upload

### DIFF
--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -173,7 +173,6 @@ export default class CampaignContactsForm extends React.Component {
 
   renderForm() {
     const { contactUploadError } = this.state
-
     return (
       <div>
         <GSForm
@@ -237,6 +236,7 @@ export default class CampaignContactsForm extends React.Component {
 }
 
 CampaignContactsForm.propTypes = {
+  datawarehouseAvailable: type.bool,
   onChange: type.func,
   optOuts: type.array,
   formValues: type.object,

--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -209,8 +209,10 @@ export default class CampaignContactsForm extends React.Component {
         Your upload file should be in CSV format with column headings in
         the first row. You must include <span className={css(styles.csvHeader)}>firstName</span>,
         <span className={css(styles.csvHeader)}>lastName</span>, and
-        <span className={css(styles.csvHeader)}>cell</span> columns. If you include a <span className={css(styles.csvHeader)}>zip</span> column,
+        <span className={css(styles.csvHeader)}>cell</span> columns.
+        If you include a <span className={css(styles.csvHeader)}>zip</span> column,
         we'll use the zip to guess the contact's timezone for enforcing texting hours.
+        An optional column to map the contact to a CRM is <span className={css(styles.csvHeader)}>external_id</span>
         Any additional columns in your file will be available as custom fields to use in your texting scripts.
       </span>
     )

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -145,7 +145,8 @@ class AdminCampaignEdit extends React.Component {
             cell: contact.cell,
             firstName: contact.firstName,
             lastName: contact.lastName,
-            zip: contact.zip
+            zip: contact.zip,
+            external_id: contact.zip
           }
           Object.keys(contact).forEach((key) => {
             if (!contactInput.hasOwnProperty(key)) {

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -23,6 +23,7 @@ const campaignInfoFragment = `
   isStarted
   isArchived
   contactsCount
+  datawarehouseAvailable
   customFields
   texters {
     id
@@ -231,7 +232,8 @@ class AdminCampaignEdit extends React.Component {
       checkSaved: () => this.state.campaignFormValues.hasOwnProperty('contacts') === false,
       blocksStarting: true,
       extraProps: {
-        optOuts: this.props.organizationData.organization.optOuts
+        optOuts: this.props.organizationData.organization.optOuts,
+        datawarehouseAvailable: this.props.campaignData.campaign.datawarehouseAvailable
       }
     }, {
       title: 'Texters',

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -24,7 +24,7 @@ export {
   getChildren
 } from './interaction-step-helpers'
 const requiredUploadFields = ['firstName', 'lastName', 'cell']
-const topLevelUploadFields = ['firstName', 'lastName', 'cell', 'zip']
+const topLevelUploadFields = ['firstName', 'lastName', 'cell', 'zip', 'external_id']
 
 export { isRoleGreater, getHighestRole } from './permissions'
 

--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -9,7 +9,7 @@ export const delimit = (text) => {
 }
 
 // const REQUIRED_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell']
-const TOP_LEVEL_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell', 'zip']
+const TOP_LEVEL_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell', 'zip', 'external_id']
 const TEXTER_SCRIPT_FIELDS = ['texterFirstName', 'texterLastName']
 
 // TODO: This will include zipCode even if you ddin't upload it

--- a/src/migrations/2017-08-23-campaigncontact_external_id.js
+++ b/src/migrations/2017-08-23-campaigncontact_external_id.js
@@ -1,0 +1,10 @@
+import { r } from '../server/models'
+
+async function migrate() {
+  await r.knex.schema.alterTable('campaign_contact', (table) => {
+    table.string('external_id').nullable().default(null);
+  })
+  console.log('added external_id column to campaign_contact table')
+}
+
+migrate()

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -26,6 +26,7 @@ export const schema = `
     lastName: String
     cell: Phone
     zip: String
+    external_id: String
     customFields: JSON
     messages: [Message]
     location: Location
@@ -59,7 +60,8 @@ export const resolvers = {
       'zip',
       'customFields',
       'messageStatus',
-      'assignmentId'
+      'assignmentId',
+      'external_id'
     ], CampaignContact),
 
     campaign: async (campaignContact, _, { loaders }) => (

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -36,6 +36,7 @@ export const schema = `
     cannedResponses(userId: String): [CannedResponse]
     stats: CampaignStats,
     pendingJobs: [JobRequest]
+    datawarehouseAvailable: Boolean
   }
 `
 
@@ -87,6 +88,9 @@ export const resolvers = {
     ], Campaign),
     organization: async (campaign, _, { loaders }) => (
       loaders.organization.load(campaign.organization_id)
+    ),
+    datawarehouseAvailable: (campaign, _, { user }) => (
+      user.is_superadmin && process.env.WAREHOUSE_DB_HOST
     ),
     pendingJobs: async (campaign) => r.table('job_request')
       .filter({ campaign_id: campaign.id }),

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -762,6 +762,9 @@ const rootResolvers = {
       return r.table('organization')
     },
     availableActions: (_, __, { user }) => {
+      if (!process.env.ACTION_HANDLERS) {
+        return []
+      }
       const allHandlers = process.env.ACTION_HANDLERS.split(',')
       const availableHandlers = allHandlers.filter(handler => {
         try {

--- a/src/server/models/campaign-contact.js
+++ b/src/server/models/campaign-contact.js
@@ -6,6 +6,7 @@ const CampaignContact = thinky.createModel('campaign_contact', type.object().sch
   id: type.string(),
   campaign_id: requiredString(),
   assignment_id: optionalString(),
+  external_id: optionalString().stopReference(),
   first_name: optionalString(),
   last_name: optionalString(),
   cell: requiredString(),

--- a/src/server/models/datawarehouse.js
+++ b/src/server/models/datawarehouse.js
@@ -1,0 +1,19 @@
+import knex from 'knex'
+
+let config
+let warehouseConn
+
+if (process.env.WAREHOUSE_DB_TYPE) {
+  config = {
+    client: process.env.WAREHOUSE_DB_TYPE,
+    connection: {
+      host: process.env.WAREHOUSE_DB_HOST,
+      port: process.env.WAREHOUSE_DB_PORT,
+      database: process.env.WAREHOUSE_DB_NAME,
+      password: process.env.WAREHOUSE_DB_PASSWORD,
+      user: process.env.WAREHOUSE_DB_USER
+    }
+  }
+}
+
+export default (config ? knex(config) : null)

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -16,6 +16,7 @@ import Invite from './invite'
 import ZipCode from './zip-code'
 import JobRequest from './job-request'
 import thinky from './thinky'
+import datawarehouse from './datawarehouse'
 
 function createLoader(model, idKey = 'id') {
   return new DataLoader(async (keys) => {
@@ -42,6 +43,7 @@ const r = thinky.r
 export {
   createLoaders,
   r,
+  datawarehouse,
   Assignment,
   Campaign,
   CampaignContact,


### PR DESCRIPTION
this is a WIP to data from a data warehouse.  We will need to expose the frontend SQL form.  However, I think we should merge this in early because:
1. it adds external_id to the campaign_contact table which will probably be useful for Scott's actionkit_event connector
2. the backend does work, and does no harm.