### PR TITLE
Invalidate session if deserialization fails

### DIFF
--- a/src/server/setup-auth0-passport.js
+++ b/src/server/setup-auth0-passport.js
@@ -20,7 +20,7 @@ function setupAuth0Passport() {
 
   passport.deserializeUser(wrap(async (id, done) => {
     const user = await User.filter({ auth0_id: id })
-    done(null, user[0])
+    done(null, user[0] || false)
   }))
 }
 


### PR DESCRIPTION
During testing I saw a deserialization failed error popup more than once. Invalidating the session will require the user to re-login and not have to see a 500 error. 