### PR TITLE
absolute url from ENV makes apollo happy again

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ AUTH0_DOMAIN=XXXX.auth0.com
 AUTH0_CLIENT_ID=
 AUTH0_CLIENT_SECRET=
 BASE_URL=http://localhost:3000
+GRAPHQL_URL=http://localhost:3000/graphql
 SESSION_SECRET=set_this_in_production
 DEFAULT_SERVICE=twilio
 NEXMO_API_KEY=

--- a/src/network/apollo-client-singleton.js
+++ b/src/network/apollo-client-singleton.js
@@ -5,7 +5,7 @@ import fetch from 'isomorphic-fetch'
 import { graphQLErrorParser } from './errors'
 
 const responseMiddlewareNetworkInterface = new ResponseMiddlewareNetworkInterface(
-    '/graphql', { credentials: 'same-origin' }
+    process.env.GRAPHQL_URL, { credentials: 'same-origin' }
   )
 
 responseMiddlewareNetworkInterface.use({


### PR DESCRIPTION
Fixes the error `UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: ###) Error: Network error: only absolute urls are supported`  that we get on some graphQL requests, ostensibly since we added isomorphic-fetch to the repo.