### PR TITLE
Took down the polling interval on TexterToDo list from 10 seconds to 5 seconds

### DIFF
--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -89,7 +89,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         validTimezone: false
       }
     },
-    pollInterval: 10000
+    pollInterval: 5000
   }
 })
 


### PR DESCRIPTION
This is a quick fix for #162, with the caveat that we may need to revisit it if it makes the DB cack. Tested on my local by starting a new test campaign with myself as a contact and texter, loading my texter todo list (/app/[userid]/todos), sending myself a message, and then replying to myself and checking to see that the number of replies needed in the new test campaign updates appropriately.