### PR TITLE
Move opt-out form from dialog to card

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -12,9 +12,6 @@ import IconButton from 'material-ui/IconButton/IconButton'
 import { Toolbar, ToolbarGroup, ToolbarSeparator } from 'material-ui/Toolbar'
 import { Card, CardActions, CardTitle } from 'material-ui/Card'
 import Divider from 'material-ui/Divider'
-
-
-import Dialog from 'material-ui/Dialog'
 import { applyScript } from '../lib/scripts'
 import gql from 'graphql-tag'
 import loadData from './hoc/load-data'

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -10,6 +10,10 @@ import NavigateCloseIcon from 'material-ui/svg-icons/navigation/close'
 import { grey100 } from 'material-ui/styles/colors'
 import IconButton from 'material-ui/IconButton/IconButton'
 import { Toolbar, ToolbarGroup, ToolbarSeparator } from 'material-ui/Toolbar'
+import { Card, CardActions, CardTitle } from 'material-ui/Card'
+import Divider from 'material-ui/Divider'
+
+
 import Dialog from 'material-ui/Dialog'
 import { applyScript } from '../lib/scripts'
 import gql from 'graphql-tag'
@@ -558,19 +562,17 @@ class AssignmentTexterContact extends React.Component {
   }
 
   renderOptOutDialog() {
-    const actions = [
 
-    ]
-
+    if (!this.state.optOutDialogOpen) {
+      return ''
+    }
     return (
-      <div>
-        <Dialog
-          title='Opt out user'
-          actions={actions}
-          modal={false}
-          open={this.state.optOutDialogOpen}
-          onRequestClose={this.handleCloseDialog}
-        >
+      <Card>
+        <CardTitle
+          title="Opt out user"
+        />
+        <Divider />
+        <CardActions>
           <GSForm
             schema={this.optOutSchema}
             onChange={({ optOutMessageText }) => this.setState({ optOutMessageText })}
@@ -588,7 +590,7 @@ class AssignmentTexterContact extends React.Component {
                 style={inlineStyles.dialogButton}
                 label='Cancel'
                 onTouchTap={this.handleCloseDialog}
-              />,
+              />
               <Form.Button
                 type='submit'
                 style={inlineStyles.dialogButton}
@@ -597,9 +599,8 @@ class AssignmentTexterContact extends React.Component {
               />
             </div>
           </GSForm>
-        </Dialog>
-
-      </div>
+        </CardActions>
+      </Card>
     )
   }
 


### PR DESCRIPTION
For https://github.com/MoveOnOrg/Spoke/issues/208. This is a work-around to an issue with text inputs in material-ui dialogs. The work-around is to take the opt-out form out of a dialog and instead make it appear in a "card" below the opt-out button. Here's what it looks like after pressing the button:

<img width="1280" alt="screen shot 2017-09-14 at 2 58 00 pm" src="https://user-images.githubusercontent.com/108645/30455488-5f65548e-995d-11e7-9ef9-b7595c13a437.png">

That hides a lot on mobile sizes, but only while it's being used, which seems okay. Pressing "cancel" makes it go away.