### PR TITLE
temporarily remove polling on texter todo list

### DIFF
--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -93,8 +93,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         isOptedOut: false,
         validTimezone: false
       }
-    },
-    pollInterval: 5000
+    }
   }
 })
 


### PR DESCRIPTION
This is a temporary fix to an apparent problem of too much database traffic when many texters have this interface open. Longer-term we can probably find a better fix for this.