### PR TITLE
Fix unmessaged count

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ rethinkdb_data
 __test__/test_data/*
 production-env.json
 claudia.json
+test.sqlite

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -47,11 +47,7 @@ function getContacts(assignment, contactsFilter, organization, campaign) {
     }
 
     if (contactsFilter.hasOwnProperty('messageStatus') && contactsFilter.messageStatus !== null) {
-      if (pastDue && contactsFilter.messageStatus === 'needsMessage') {
-        query = query.where('message_status', '')
-      } else {
-        query = query.where('message_status', contactsFilter.messageStatus)
-      }
+      query = query.where('message_status', contactsFilter.messageStatus)
     } else {
       if (pastDue) {
         // by default if asking for 'send later' contacts we include only those that need replies


### PR DESCRIPTION
This makes the messaged count for past campaigns still report the right number.  This was a dumb "feature" -- probably related to weird behavior for timezones/send-later and stopping the messages, but we should unhack this and just ask for what we want on the client/server vs. due unpredictable things related to due by date