### PR TITLE
Persist test data

### DIFF
--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -10,15 +10,15 @@ async function clearTestData() {
   await r.knex.schema.dropTable('message')
   await r.knex.schema.dropTable('migrations')
   await r.knex.schema.dropTable('opt_out')
-  await r.knex.schema.dropTable('organization')
-  await r.knex.schema.dropTable('pending_message_part')
   await r.knex.schema.dropTable('question_response')
-  await r.knex.schema.dropTable('user_cell')
-  await r.knex.schema.dropTable('user')
-  await r.knex.schema.dropTable('campaign_contact')
   await r.knex.schema.dropTable('interaction_step')
+  await r.knex.schema.dropTable('campaign_contact')
   await r.knex.schema.dropTable('assignment')
   await r.knex.schema.dropTable('campaign')
+  await r.knex.schema.dropTable('organization')
+  await r.knex.schema.dropTable('pending_message_part')
+  await r.knex.schema.dropTable('user_cell')
+  await r.knex.schema.dropTable('user')
 }
 
 async function setupTest() {

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -1,9 +1,9 @@
 import DataLoader from 'dataloader'
 // Import models in order that creates referenced tables before foreign keys
 import User from './user'
-import Assignment from './assignment'
 import Organization from './organization'
 import Campaign from './campaign'
+import Assignment from './assignment'
 import CampaignContact from './campaign-contact'
 import InteractionStep from './interaction-step'
 import Message from './message'

--- a/src/server/models/pending-message-part.js
+++ b/src/server/models/pending-message-part.js
@@ -12,7 +12,7 @@ const PendingMessagePart = thinky.createModel('pending_message_part', type.objec
   id: type.string(),
   service: requiredString(),
   service_id: requiredString().stopReference(),
-  parent_id: optionalString(),
+  parent_id: optionalString().stopReference(),
   service_message: requiredString(), // JSON
   user_number: optionalString(),
   contact_number: requiredString(),


### PR DESCRIPTION
For https://github.com/MoveOnOrg/Spoke/issues/302 (part of https://github.com/MoveOnOrg/Spoke/issues/277), this avoids recreating data in each test, to avoid data creation changes having an outsized impact on test time.