### PR TITLE
remove stripe dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,6 @@
     "request": "^2.81.0",
     "rethink-knex-adapter": "^0.4.10",
     "rollbar": "^0.6.2",
-    "stripe": "^4.9.0",
     "thinky": "^2.3.3",
     "transform-loader": "^0.2.3",
     "twilio": "^2.11.0",


### PR DESCRIPTION
For #349, this removes stripe from the dependency list. Stripe doesn't appear anywhere in the code: https://github.com/MoveOnOrg/Spoke/search?utf8=%E2%9C%93&q=stripe&type=