### PR TITLE
remove bonzo, unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,6 @@
     "babel-runtime": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz",
     "babyparse": "^0.4.6",
     "body-parser": "^1.15.2",
-    "bonzo": "^2.0.0",
     "chart.js": "^1.1.1",
     "cookie-session": "^2.0.0-alpha.1",
     "dataloader": "^1.2.0",


### PR DESCRIPTION
For #349, this dependency isn't used anywhere: https://github.com/MoveOnOrg/Spoke/search?utf8=%E2%9C%93&q=bonzo&type=

https://www.npmjs.com/package/bonzo says this is for DOM manipulation, which we're doing with React, so not sure why this was ever added as a dependency.