### PR TITLE
Migrate prop-types to external package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "passport": "^0.3.2",
     "passport-auth0": "^0.5.2",
     "pg": "^6.4.0",
+    "prop-types": "^15.6.0",
     "query-string": "^4.1.0",
     "react": "^15.6.1",
     "react-addons-css-transition-group": "^15.2.1",

--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 import theme from '../styles/theme'
@@ -83,10 +84,10 @@ class AdminDashboard extends React.Component {
 }
 
 AdminDashboard.propTypes = {
-  router: React.PropTypes.object,
-  params: React.PropTypes.object,
-  children: React.PropTypes.object,
-  location: React.PropTypes.object
+  router: PropTypes.object,
+  params: PropTypes.object,
+  children: PropTypes.object,
+  location: PropTypes.object
 }
 
 export default withRouter(AdminDashboard)

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
 import muiTheme from '../styles/mui-theme'
@@ -38,7 +39,7 @@ const App = ({ children }) => (
 )
 
 App.propTypes = {
-  children: React.PropTypes.object
+  children: PropTypes.object
 }
 
 export default App

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import { Card, CardActions, CardTitle } from 'material-ui/Card'
 import { StyleSheet, css } from 'aphrodite'
@@ -199,14 +200,14 @@ class AssignmentSummary extends Component {
 }
 
 AssignmentSummary.propTypes = {
-  organizationId: React.PropTypes.string,
-  router: React.PropTypes.object,
-  assignment: React.PropTypes.object,
-  unmessagedCount: React.PropTypes.number,
-  unrepliedCount: React.PropTypes.number,
-  badTimezoneCount: React.PropTypes.number,
-  data: React.PropTypes.object,
-  mutations: React.PropTypes.object
+  organizationId: PropTypes.string,
+  router: PropTypes.object,
+  assignment: PropTypes.object,
+  unmessagedCount: PropTypes.number,
+  unrepliedCount: PropTypes.number,
+  badTimezoneCount: PropTypes.number,
+  data: PropTypes.object,
+  mutations: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { ToolbarTitle } from 'material-ui/Toolbar'
 import IconButton from 'material-ui/IconButton/IconButton'
@@ -177,12 +178,12 @@ class AssignmentTexter extends React.Component {
 }
 
 AssignmentTexter.propTypes = {
-  currentUser: React.PropTypes.object,
-  assignment: React.PropTypes.object,      // current assignment
-  contacts: React.PropTypes.array,   // contacts for current assignment
-  router: React.PropTypes.object,
-  organizationId: React.PropTypes.string,
-  onRefreshAssignmentContacts: React.PropTypes.func
+  currentUser: PropTypes.object,
+  assignment: PropTypes.object,      // current assignment
+  contacts: PropTypes.array,   // contacts for current assignment
+  router: PropTypes.object,
+  organizationId: PropTypes.string,
+  onRefreshAssignmentContacts: PropTypes.func
 }
 
 export default withRouter(AssignmentTexter)

--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import { grey50 } from 'material-ui/styles/colors'
 import { Card, CardHeader, CardText } from 'material-ui/Card'
@@ -149,11 +150,11 @@ class AssignmentTexterSurveys extends Component {
 }
 
 AssignmentTexterSurveys.propTypes = {
-  contact: React.PropTypes.object,
-  interactionSteps: React.PropTypes.array,
-  currentInteractionStep: React.PropTypes.object,
-  questionResponses: React.PropTypes.object,
-  onQuestionResponseChange: React.PropTypes.func
+  contact: PropTypes.object,
+  interactionSteps: PropTypes.array,
+  currentInteractionStep: PropTypes.object,
+  questionResponses: PropTypes.object,
+  onQuestionResponseChange: PropTypes.func
 }
 
 export default AssignmentTexterSurveys

--- a/src/components/CampaignBasicsForm.jsx
+++ b/src/components/CampaignBasicsForm.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Form from 'react-formal'
 import moment from 'moment'
@@ -78,14 +79,14 @@ export default class CampaignBasicsForm extends React.Component {
 }
 
 CampaignBasicsForm.propTypes = {
-  formValues: React.PropTypes.shape({
-    title: React.PropTypes.string,
-    description: React.PropTypes.string,
-    dueBy: React.PropTypes.any
+  formValues: PropTypes.shape({
+    title: PropTypes.string,
+    description: PropTypes.string,
+    dueBy: PropTypes.any
   }),
-  onChange: React.PropTypes.func,
-  onSubmit: React.PropTypes.func,
-  saveLabel: React.PropTypes.string,
-  saveDisabled: React.PropTypes.bool,
-  ensureComplete: React.PropTypes.bool
+  onChange: PropTypes.func,
+  onSubmit: PropTypes.func,
+  saveLabel: PropTypes.string,
+  saveDisabled: PropTypes.bool,
+  ensureComplete: PropTypes.bool
 }

--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import { StyleSheet, css } from 'aphrodite'
 import yup from 'yup'
 import GSForm from './forms/GSForm'

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import CampaignCannedResponseForm from './CampaignCannedResponseForm'
 import FlatButton from 'material-ui/FlatButton'
 import Form from 'react-formal'

--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import RaisedButton from 'material-ui/RaisedButton'
 import GSForm from '../components/forms/GSForm'
 import Form from 'react-formal'

--- a/src/components/CampaignFormSectionHeading.jsx
+++ b/src/components/CampaignFormSectionHeading.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 import theme from '../styles/theme'
@@ -18,8 +19,8 @@ const CampaignFormSectionHeading = ({ title, subtitle }) => (
 )
 
 CampaignFormSectionHeading.propTypes = {
-  title: React.PropTypes.string,
-  subtitle: React.PropTypes.any
+  title: PropTypes.string,
+  subtitle: PropTypes.any
 }
 
 export default CampaignFormSectionHeading

--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import ReactDOM from 'react-dom'
 import Divider from 'material-ui/Divider'
 import ContentClear from 'material-ui/svg-icons/content/clear'

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import Slider from './Slider'
 import AutoComplete from 'material-ui/AutoComplete'
 import IconButton from 'material-ui/IconButton'

--- a/src/components/CannedResponseForm.jsx
+++ b/src/components/CannedResponseForm.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import Form from 'react-formal'
 import yup from 'yup'
 import GSForm from './forms/GSForm'

--- a/src/components/CannedResponseMenu.jsx
+++ b/src/components/CannedResponseMenu.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import Popover from 'material-ui/Popover'
 import { List } from 'material-ui/List'
 import ScriptList from './ScriptList'

--- a/src/components/Chart.jsx
+++ b/src/components/Chart.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import { Pie } from 'react-chartjs'
 
 const Chart = ({ data }) => {

--- a/src/components/Chip.jsx
+++ b/src/components/Chip.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import _ from 'lodash'
 
@@ -38,11 +39,11 @@ function Chip({ text, iconRightClass, onIconRightTouchTap, onTouchTap, style = {
 }
 
 Chip.propTypes = {
-  text: React.PropTypes.element,
-  iconRightClass: React.PropTypes.string,
-  onIconRightTouchTap: React.PropTypes.func,
-  onTouchTap: React.PropTypes.func,
-  style: React.PropTypes.object
+  text: PropTypes.element,
+  iconRightClass: PropTypes.string,
+  onIconRightTouchTap: PropTypes.func,
+  onTouchTap: PropTypes.func,
+  style: PropTypes.object
 }
 
 export default Chip

--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar'
 import { getDisplayPhoneNumber } from '../lib/phone-format'
@@ -78,8 +79,8 @@ const ContactToolbar = function ContactToolbar(props) {
 }
 
 ContactToolbar.propTypes = {
-  campaignContact: React.PropTypes.object, // contacts for current assignment
-  rightToolbarIcon: React.PropTypes.element
+  campaignContact: PropTypes.object, // contacts for current assignment
+  rightToolbarIcon: PropTypes.element
 }
 
 export default ContactToolbar

--- a/src/components/Empty.jsx
+++ b/src/components/Empty.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 import theme from '../styles/theme'
@@ -34,8 +35,8 @@ const Empty = ({ title, icon }) => (
 )
 
 Empty.propTypes = {
-  title: React.PropTypes.string,
-  icon: React.PropTypes.object
+  title: PropTypes.string,
+  icon: PropTypes.object
 }
 
 export default Empty

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { isClient } from '../lib'
 
@@ -8,7 +9,7 @@ const Login = ({ location }) => (
 )
 
 Login.propTypes = {
-  location: React.PropTypes.object
+  location: PropTypes.object
 }
 
 export default Login

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { List, ListItem } from 'material-ui/List'
 import moment from 'moment'
@@ -55,7 +56,7 @@ const MessageList = function MessageList(props) {
 }
 
 MessageList.propTypes = {
-  contact: React.PropTypes.object
+  contact: PropTypes.object
 }
 
 export default MessageList

--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Paper from 'material-ui/Paper'
 import { List, ListItem } from 'material-ui/List'
@@ -31,9 +32,9 @@ const Navigation = function Navigation(props) {
 }
 
 Navigation.propTypes = {
-  sections: React.PropTypes.array,
-  switchListItem: React.PropTypes.object,
-  router: React.PropTypes.object
+  sections: PropTypes.array,
+  switchListItem: PropTypes.object,
+  router: PropTypes.object
 }
 
 export default withRouter(Navigation)

--- a/src/components/OrganizationJoinLink.jsx
+++ b/src/components/OrganizationJoinLink.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import TextField from 'material-ui/TextField'
 
@@ -25,7 +26,7 @@ const OrganizationJoinLink = ({ organizationUuid }) => {
 }
 
 OrganizationJoinLink.propTypes = {
-  organizationUuid: React.PropTypes.string
+  organizationUuid: PropTypes.string
 }
 
 export default OrganizationJoinLink

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import {
   EditorState,
@@ -61,7 +62,7 @@ const RecognizedField = (props) => (
 )
 
 RecognizedField.propTypes = {
-  children: React.PropTypes.arrayOf(React.PropTypes.element)
+  children: PropTypes.arrayOf(PropTypes.element)
 }
 
 const UnrecognizedField = (props) => (
@@ -69,7 +70,7 @@ const UnrecognizedField = (props) => (
 )
 
 UnrecognizedField.propTypes = {
-  children: React.PropTypes.arrayOf(React.PropTypes.element)
+  children: PropTypes.arrayOf(PropTypes.element)
 }
 
 class ScriptEditor extends React.Component {
@@ -189,10 +190,10 @@ class ScriptEditor extends React.Component {
 }
 
 ScriptEditor.propTypes = {
-  scriptFields: React.PropTypes.array,
-  scriptText: React.PropTypes.string,
-  onChange: React.PropTypes.func,
-  name: React.PropTypes.string
+  scriptFields: PropTypes.array,
+  scriptText: PropTypes.string,
+  onChange: PropTypes.func,
+  name: PropTypes.string
 }
 
 export default ScriptEditor

--- a/src/components/ScriptList.jsx
+++ b/src/components/ScriptList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import FlatButton from 'material-ui/FlatButton'
 import { List, ListItem } from 'material-ui/List'
@@ -155,15 +156,15 @@ class ScriptList extends React.Component {
 }
 
 ScriptList.propTypes = {
-  script: React.PropTypes.object,
-  scripts: React.PropTypes.arrayOf(React.PropTypes.object),
-  subheader: React.PropTypes.element,
-  onSelectCannedResponse: React.PropTypes.func,
-  showAddScriptButton: React.PropTypes.bool,
-  customFields: React.PropTypes.array,
-  campaignId: React.PropTypes.number,
-  mutations: React.PropTypes.object,
-  texterId: React.PropTypes.number
+  script: PropTypes.object,
+  scripts: PropTypes.arrayOf(PropTypes.object),
+  subheader: PropTypes.element,
+  onSelectCannedResponse: PropTypes.func,
+  showAddScriptButton: PropTypes.bool,
+  customFields: PropTypes.array,
+  campaignId: PropTypes.number,
+  mutations: PropTypes.object,
+  texterId: PropTypes.number
 }
 
 const mapMutationsToProps = () => ({

--- a/src/components/SendButton.jsx
+++ b/src/components/SendButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 import { StyleSheet, css } from 'aphrodite'
@@ -45,9 +46,9 @@ class SendButton extends Component {
 }
 
 SendButton.propTypes = {
-  threeClickEnabled: React.PropTypes.boolean,
-  onFinalTouchTap: React.PropTypes.function,
-  disabled: React.PropTypes.boolean
+  threeClickEnabled: PropTypes.boolean,
+  onFinalTouchTap: PropTypes.function,
+  disabled: PropTypes.boolean
 }
 
 export default SendButton

--- a/src/components/SendButtonArrow.jsx
+++ b/src/components/SendButtonArrow.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import IconButton from 'material-ui/IconButton'
 import NavigationArrowForward from 'material-ui/svg-icons/navigation/arrow-forward'
@@ -52,9 +53,9 @@ class SendButtonArrow extends Component {
 }
 
 SendButtonArrow.propTypes = {
-  threeClickEnabled: React.PropTypes.boolean,
-  onClick: React.PropTypes.function,
-  disabled: React.PropTypes.boolean
+  threeClickEnabled: PropTypes.boolean,
+  onClick: PropTypes.function,
+  disabled: PropTypes.boolean
 }
 
 export default SendButtonArrow

--- a/src/components/Slider.jsx
+++ b/src/components/Slider.jsx
@@ -1,4 +1,5 @@
-import React, { PropTypes as type } from 'react'
+import type from 'prop-types';
+import React from 'react';
 import theme from '../styles/theme'
 
 const Slider = ({ maxValue, value, color, direction }) => {

--- a/src/components/TexterDashboard.jsx
+++ b/src/components/TexterDashboard.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 import theme from '../styles/theme'
@@ -32,13 +33,13 @@ class TexterDashboard extends React.Component {
 }
 
 TexterDashboard.propTypes = {
-  router: React.PropTypes.object,
-  params: React.PropTypes.object,
-  children: React.PropTypes.object,
-  location: React.PropTypes.object,
-  main: React.PropTypes.element,
-  topNav: React.PropTypes.element,
-  fullScreen: React.PropTypes.bool
+  router: PropTypes.object,
+  params: PropTypes.object,
+  children: PropTypes.object,
+  location: PropTypes.object,
+  main: PropTypes.element,
+  topNav: PropTypes.element,
+  fullScreen: PropTypes.bool
 }
 
 export default withRouter(TexterDashboard)

--- a/src/components/TexterStats.jsx
+++ b/src/components/TexterStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import LinearProgress from 'material-ui/LinearProgress'
 
@@ -34,6 +35,6 @@ class TexterStats extends React.Component {
 }
 
 TexterStats.propTypes = {
-  campaign: React.PropTypes.object
+  campaign: PropTypes.object
 }
 export default TexterStats

--- a/src/components/TopNav.jsx
+++ b/src/components/TopNav.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import IconButton from 'material-ui/IconButton'
 import ArrowBackIcon from 'material-ui/svg-icons/navigation/arrow-back'
@@ -77,8 +78,8 @@ class TopNav extends React.Component {
 }
 
 TopNav.propTypes = {
-  backToURL: React.PropTypes.string,
-  title: React.PropTypes.string.isRequired
+  backToURL: PropTypes.string,
+  title: PropTypes.string.isRequired
 }
 
 export default TopNav

--- a/src/components/forms/GSForm.jsx
+++ b/src/components/forms/GSForm.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Form from 'react-formal'
 import GSSubmitButton from './GSSubmitButton'
@@ -16,10 +17,10 @@ const styles = StyleSheet.create({
 })
 export default class GSForm extends React.Component {
   static propTypes = {
-    value: React.PropTypes.object,
-    defaultValue: React.PropTypes.object,
-    onChange: React.PropTypes.func,
-    children: React.PropTypes.array
+    value: PropTypes.object,
+    defaultValue: PropTypes.object,
+    onChange: PropTypes.func,
+    children: PropTypes.array
   }
 
   state = {
@@ -123,5 +124,5 @@ export default class GSForm extends React.Component {
 }
 
 GSForm.propTypes = {
-  onSubmit: React.PropTypes.func
+  onSubmit: PropTypes.func
 }

--- a/src/components/forms/GSFormField.jsx
+++ b/src/components/forms/GSFormField.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 
 class GSFormField extends React.Component {
@@ -7,8 +8,8 @@ class GSFormField extends React.Component {
 }
 
 GSFormField.propTypes = {
-  floatingLabelText: React.PropTypes.string,
-  label: React.PropTypes.string
+  floatingLabelText: PropTypes.string,
+  label: PropTypes.string
 }
 
 

--- a/src/components/forms/GSSubmitButton.jsx
+++ b/src/components/forms/GSSubmitButton.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 import CircularProgress from 'material-ui/CircularProgress'
@@ -39,7 +40,7 @@ const GSSubmitButton = (props) => {
 }
 
 GSSubmitButton.propTypes = {
-  isSubmitting: React.PropTypes.bool
+  isSubmitting: PropTypes.bool
 }
 
 export default GSSubmitButton

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import WarningIcon from 'material-ui/svg-icons/alert/warning'
 import DoneIcon from 'material-ui/svg-icons/action/done'
@@ -556,13 +557,13 @@ class AdminCampaignEdit extends React.Component {
 }
 
 AdminCampaignEdit.propTypes = {
-  campaignData: React.PropTypes.object,
-  mutations: React.PropTypes.object,
-  organizationData: React.PropTypes.object,
-  params: React.PropTypes.object,
-  location: React.PropTypes.object,
-  pendingJobsData: React.PropTypes.object,
-  availableActionsData: React.PropTypes.object
+  campaignData: PropTypes.object,
+  mutations: PropTypes.object,
+  organizationData: PropTypes.object,
+  params: PropTypes.object,
+  location: PropTypes.object,
+  pendingJobsData: PropTypes.object,
+  availableActionsData: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import CampaignList from './CampaignList'
 import FloatingActionButton from 'material-ui/FloatingActionButton'
@@ -81,10 +82,10 @@ class AdminCampaignList extends React.Component {
 }
 
 AdminCampaignList.propTypes = {
-  data: React.PropTypes.object,
-  params: React.PropTypes.object,
-  mutations: React.PropTypes.object,
-  router: React.PropTypes.object
+  data: PropTypes.object,
+  params: PropTypes.object,
+  mutations: PropTypes.object,
+  router: PropTypes.object
 }
 
 const mapMutationsToProps = () => ({

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import RaisedButton from 'material-ui/RaisedButton'
 import Chart from '../components/Chart'
@@ -92,8 +93,8 @@ const Stat = ({ title, count }) => (
 )
 
 Stat.propTypes = {
-  title: React.PropTypes.string,
-  count: React.PropTypes.number
+  title: PropTypes.string,
+  count: PropTypes.number
 }
 
 class AdminCampaignStats extends React.Component {
@@ -235,10 +236,10 @@ class AdminCampaignStats extends React.Component {
 }
 
 AdminCampaignStats.propTypes = {
-  mutations: React.PropTypes.object,
-  data: React.PropTypes.object,
-  params: React.PropTypes.object,
-  router: React.PropTypes.object
+  mutations: PropTypes.object,
+  data: PropTypes.object,
+  params: PropTypes.object,
+  router: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AdminCampaigns.jsx
+++ b/src/containers/AdminCampaigns.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import CampaignList from './CampaignList'
 // import FloatingActionButton from 'material-ui/FloatingActionButton'
@@ -80,8 +81,8 @@ export class AdminCampaigns extends Component {
 }
 
 AdminCampaigns.propTypes = {
-  campaigns: React.PropTypes.array,
-  organizationId: React.PropTypes.number
+  campaigns: PropTypes.array,
+  organizationId: PropTypes.number
 }
 
 export default AdminCampaigns

--- a/src/containers/AdminNavigation.jsx
+++ b/src/containers/AdminNavigation.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Navigation from '../components/Navigation'
 import { ListItem } from 'material-ui/List'
@@ -59,10 +60,10 @@ class AdminNavigation extends React.Component {
 }
 
 AdminNavigation.propTypes = {
-  data: React.PropTypes.object,
-  organizationId: React.PropTypes.string,
-  router: React.PropTypes.object,
-  params: React.PropTypes.object
+  data: PropTypes.object,
+  organizationId: PropTypes.string,
+  router: PropTypes.object,
+  params: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AdminOptOutList.jsx
+++ b/src/containers/AdminOptOutList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { List, ListItem } from 'material-ui/List'
 import ProhibitedIcon from 'material-ui/svg-icons/av/not-interested'
@@ -29,7 +30,7 @@ const AdminOptOutList = function AdminOptOutList(props) {
 }
 
 AdminOptOutList.propTypes = {
-  data: React.PropTypes.object
+  data: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Empty from '../components/Empty'
 import OrganizationJoinLink from '../components/OrganizationJoinLink'
@@ -138,11 +139,11 @@ class AdminPersonList extends React.Component {
 }
 
 AdminPersonList.propTypes = {
-  mutations: React.PropTypes.object,
-  params: React.PropTypes.object,
-  personData: React.PropTypes.object,
-  userData: React.PropTypes.object,
-  organizationData: React.PropTypes.object
+  mutations: PropTypes.object,
+  params: PropTypes.object,
+  personData: PropTypes.object,
+  userData: PropTypes.object,
+  organizationData: PropTypes.object
 }
 
 const mapMutationsToProps = () => ({

--- a/src/containers/AdminReplySender.jsx
+++ b/src/containers/AdminReplySender.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -108,8 +109,8 @@ class AdminReplySender extends React.Component {
 }
 
 AdminReplySender.propTypes = {
-  mutations: React.PropTypes.object,
-  data: React.PropTypes.object
+  mutations: PropTypes.object,
+  data: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { StyleSheet, css } from 'aphrodite'
 import ContactToolbar from '../components/ContactToolbar'
@@ -812,17 +813,17 @@ class AssignmentTexterContact extends React.Component {
 }
 
 AssignmentTexterContact.propTypes = {
-  contact: React.PropTypes.object,
-  campaign: React.PropTypes.object,
-  assignment: React.PropTypes.object,
-  texter: React.PropTypes.object,
-  navigationToolbarChildren: React.PropTypes.array,
-  onFinishContact: React.PropTypes.func,
-  router: React.PropTypes.object,
-  data: React.PropTypes.object,
-  mutations: React.PropTypes.object,
-  onExitTexter: React.PropTypes.func,
-  onRefreshAssignmentContacts: React.PropTypes.func
+  contact: PropTypes.object,
+  campaign: PropTypes.object,
+  assignment: PropTypes.object,
+  texter: PropTypes.object,
+  navigationToolbarChildren: PropTypes.array,
+  onFinishContact: PropTypes.func,
+  router: PropTypes.object,
+  data: PropTypes.object,
+  mutations: PropTypes.object,
+  onExitTexter: PropTypes.func,
+  onRefreshAssignmentContacts: PropTypes.func
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AssignmentTexterSurveyDropdown.jsx
+++ b/src/containers/AssignmentTexterSurveyDropdown.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import SelectField from 'material-ui/SelectField'
 import MenuItem from 'material-ui/MenuItem'
@@ -96,11 +97,11 @@ class AssignmentTexterSurveyDropdown extends Component {
 }
 
 AssignmentTexterSurveyDropdown.propTypes = {
-  step: React.PropTypes.object,
-  answerValue: React.PropTypes.object,
-  isCurrentStep: React.PropTypes.boolean,
-  campaignContactId: React.PropTypes.number,
-  mutations: React.PropTypes.object
+  step: PropTypes.object,
+  answerValue: PropTypes.object,
+  isCurrentStep: PropTypes.boolean,
+  campaignContactId: PropTypes.number,
+  mutations: PropTypes.object
 }
 
 const mapMutationsToProps = () => ({

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import { List, ListItem } from 'material-ui/List'
 import moment from 'moment'
@@ -127,17 +128,17 @@ class CampaignList extends React.Component {
 }
 
 CampaignList.propTypes = {
-  campaigns: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      dueBy: React.PropTypes.string,
-      title: React.PropTypes.string,
-      description: React.PropTypes.string
+  campaigns: PropTypes.arrayOf(
+    PropTypes.shape({
+      dueBy: PropTypes.string,
+      title: PropTypes.string,
+      description: PropTypes.string
     })
   ),
-  router: React.PropTypes.object,
-  organizationId: React.PropTypes.string,
-  data: React.PropTypes.object,
-  mutations: React.PropTypes.object
+  router: PropTypes.object,
+  organizationId: PropTypes.string,
+  data: PropTypes.object,
+  mutations: PropTypes.object
 }
 
 const mapMutationsToProps = () => ({

--- a/src/containers/CreateOrganization.jsx
+++ b/src/containers/CreateOrganization.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -128,10 +129,10 @@ const mapQueriesToProps = ({ ownProps }) => ({
 })
 
 CreateOrganization.propTypes = {
-  mutations: React.PropTypes.object,
-  router: React.PropTypes.object,
-  userData: React.PropTypes.object,
-  inviteData: React.PropTypes.object
+  mutations: PropTypes.object,
+  router: PropTypes.object,
+  userData: PropTypes.object,
+  inviteData: PropTypes.object
 }
 
 const mapMutationsToProps = () => ({

--- a/src/containers/DashboardLoader.jsx
+++ b/src/containers/DashboardLoader.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import gql from 'graphql-tag'
 import { withRouter } from 'react-router'
@@ -20,9 +21,9 @@ class DashboardLoader extends React.Component {
 }
 
 DashboardLoader.propTypes = {
-  data: React.PropTypes.object,
-  router: React.PropTypes.object,
-  path: React.PropTypes.string
+  data: PropTypes.object,
+  router: PropTypes.object,
+  path: PropTypes.string
 }
 
 const mapQueriesToProps = () => ({

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -104,9 +105,9 @@ class Home extends React.Component {
 }
 
 Home.propTypes = {
-  mutations: React.PropTypes.object,
-  router: React.PropTypes.object,
-  data: React.PropTypes.object
+  mutations: PropTypes.object,
+  router: PropTypes.object,
+  data: PropTypes.object
 }
 
 const mapQueriesToProps = () => ({

--- a/src/containers/JoinTeam.jsx
+++ b/src/containers/JoinTeam.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -49,8 +50,8 @@ class JoinTeam extends React.Component {
 }
 
 JoinTeam.propTypes = {
-  mutations: React.PropTypes.object,
-  router: React.PropTypes.object
+  mutations: PropTypes.object,
+  router: PropTypes.object
 }
 
 const mapMutationsToProps = ({ ownProps }) => ({

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
@@ -158,9 +159,9 @@ class Settings extends React.Component {
 }
 
 Settings.propTypes = {
-  data: React.PropTypes.object,
-  params: React.PropTypes.object,
-  mutations: React.PropTypes.object
+  data: PropTypes.object,
+  params: PropTypes.object,
+  mutations: PropTypes.object
 }
 
 const mapMutationsToProps = ({ ownProps }) => ({

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import AssignmentTexter from '../components/AssignmentTexter'
 import { withRouter } from 'react-router'
@@ -30,10 +31,10 @@ class TexterTodo extends React.Component {
 }
 
 TexterTodo.propTypes = {
-  contactsFilter: React.PropTypes.string,
-  params: React.PropTypes.object,
-  data: React.PropTypes.object,
-  router: React.PropTypes.object
+  contactsFilter: PropTypes.string,
+  params: PropTypes.object,
+  data: PropTypes.object,
+  router: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React from 'react'
 import Check from 'material-ui/svg-icons/action/check-circle'
 import Empty from '../components/Empty'
@@ -54,9 +55,9 @@ class TexterTodoList extends React.Component {
 }
 
 TexterTodoList.propTypes = {
-  organizationId: React.PropTypes.string,
-  params: React.PropTypes.object,
-  data: React.PropTypes.object
+  organizationId: PropTypes.string,
+  params: PropTypes.object,
+  data: PropTypes.object
 }
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/UserMenu.jsx
+++ b/src/containers/UserMenu.jsx
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types';
 import React, { Component } from 'react'
 import Popover from 'material-ui/Popover'
 import Menu from 'material-ui/Menu'
@@ -101,8 +102,8 @@ class UserMenu extends Component {
 }
 
 UserMenu.propTypes = {
-  data: React.PropTypes.object,
-  router: React.PropTypes.object
+  data: PropTypes.object,
+  router: PropTypes.object
 }
 
 const mapQueriesToProps = () => ({


### PR DESCRIPTION
`React.PropTypes` is deprecated in react 15.6 and gone in 16.x. Migrated to external package as described in https://reactjs.org/blog/2017/04/07/react-v15.5.0.html#migrating-from-react.proptypes.