### PR TITLE
Fix and test empty campaign contact count.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ claudia.json
 stage.json
 stage-env.json
 test.sqlite
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -28,5 +28,5 @@ module.exports = {
     "\\.(jpg|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
     "\\.(css|less)$": "<rootDir>/__mocks__/styleMock.js"
   },
-  collectCoverageFrom : ["**/*.{js,jsx}", "!**/node_modules/**", "!**/__test__/**", "!**/deploy/**"]
+  collectCoverageFrom : ["**/*.{js,jsx}", "!**/node_modules/**", "!**/__test__/**", "!**/deploy/**", "!**/coverage/**"]
 };

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -132,11 +132,11 @@ export const resolvers = {
       return Number(Object.values(count)[0])
     },
     hasUnassignedContacts: async (campaign) => {
-      const hasContacts = await r.table('campaign_contact')
-        .getAll([campaign.id, ''], { index: 'campaign_assignment' })
-        .limit(1)(0)
-        .default(null)
-      return !!hasContacts
+      const contacts = await r.knex('campaign_contact')
+        .select('id')
+        .where({campaign_id: campaign.id, assignment_id: null})
+        .limit(1)
+      return contacts.length > 0
     },
     customFields: async (campaign) => {
       const campaignContacts = await r.table('campaign_contact')

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -121,14 +121,16 @@ export const resolvers = {
         .filter({ user_id: userId || '' })
     ),
     contacts: async (campaign) => (
-      r.table('campaign_contact')
-        .getAll(campaign.id, { index: 'campaign_id' })
+      r.knex('campaign_contact')
+        .where({campaign_id: campaign.id})
     ),
-    contactsCount: async (campaign) => (
-      r.table('campaign_contact')
-        .getAll(campaign.id, { index: 'campaign_id' })
-        .count()
-    ),
+    contactsCount: async (campaign) => {
+      const counts = await r.knex('campaign_contact')
+        .where({campaign_id: campaign.id})
+        .count('*')
+      const count = counts[0]
+      return Number(Object.values(count)[0])
+    },
     hasUnassignedContacts: async (campaign) => {
       const hasContacts = await r.table('campaign_contact')
         .getAll([campaign.id, ''], { index: 'campaign_assignment' })

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -129,7 +129,8 @@ export const resolvers = {
         .where({campaign_id: campaign.id})
         .count('*')
       const count = counts[0]
-      return Number(Object.values(count)[0])
+      const key = Object.keys(count)[0]
+      return Number(count[key])
     },
     hasUnassignedContacts: async (campaign) => {
       const contacts = await r.knex('campaign_contact')


### PR DESCRIPTION
* Rewrite `contacts` and `contactsCount` methods using vanilla knex
* Add regression tests so that we don't break these methods (in the same way) again

Currently, `contactsCount` returns `null` when it should return `0` when using sqlite. Turns out this is related to a bug in the rethink knex adapter at https://github.com/MoveOnOrg/rethink-knex-adapter/blob/master/query.js#L253: if the sqlite count key is falsy, return the postgres count key. But if the sqlite key is 0, we look up the postgres key, which returns `undefined`.

I decided to fix and test here rather than patching the adapter, since it looks like we're hoping to drop the adapter eventually based on #281. But the fix to the adapter would be simple if somebody wants to write that patch too.