### PR TITLE
Only upload test coverage on push builds.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ before_script:
 script:
 - npm run test-coverage
 after_script:
-- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+- if [ "${TRAVIS_PULL_REQUEST}" == "false" ]; then ./cc-test-reporter after-build --exit-code "${TRAVIS_TEST_RESULT}"; fi


### PR DESCRIPTION
I forgot to mention this earlier @shakalee14, but code climate recommends uploading test coverage only for push builds: https://docs.codeclimate.com/v1.0/docs/travis-ci-test-coverage#section-troubleshooting.