### PR TITLE
Support for multimedia (#266)

### DIFF
--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -111,11 +111,11 @@ async function sendMessage(message) {
     }
 
     // Image extraction
-    const extractor = new RegExp(/\[.*http(.*)\]/)
+    const extractor = new RegExp(/\[\s*(http[^\]\s]*)\s*\]/)
     let mediaUrl
     if (message.text.match(extractor)) {
       const results = extractor.exec(message.text)
-      mediaUrl = `http${results[1].trim()}`
+      mediaUrl = results[1]
     }
 
     const messageParams = Object.assign({

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -109,15 +109,26 @@ async function sendMessage(message) {
     if (message.service !== 'twilio') {
       log.warn('Message not marked as a twilio message', message.id)
     }
-    const messageParams = {
+
+    // Image extraction
+    const extractor = new RegExp(/\[.*http(.*)\]/)
+    let mediaUrl
+    if (message.text.match(extractor)) {
+      const results = extractor.exec(message.text)
+      mediaUrl = `http${results[1].trim()}`
+    }
+
+    const messageParams = Object.assign({
       to: message.contact_number,
       messagingServiceSid: process.env.TWILIO_MESSAGE_SERVICE_SID,
-      body: message.text,
+      body: message.text.replace(extractor, ''), // replace extractor so user doesn't get an img url
       statusCallback: process.env.TWILIO_STATUS_CALLBACK_URL
-    }
+    }, mediaUrl ? { mediaUrl } : {})
+
     if (process.env.TWILIO_MESSAGE_VALIDITY_PERIOD) {
       messageParams.validityPeriod = process.env.TWILIO_MESSAGE_VALIDITY_PERIOD
     }
+
     twilio.messages.create(messageParams, (err, response) => {
       const messageToSave = {
         ...message


### PR DESCRIPTION
Hey!

This adds support for images in texts. The syntax is, in any message, `[https://image-url.com/image-is-here]`.

<img width="932" alt="screen shot 2017-12-03 at 2 19 54 pm" src="https://user-images.githubusercontent.com/10324926/33529329-32dc9b04-d835-11e7-85bb-b333c9173ddf.png">

And the result:

![img_0122](https://user-images.githubusercontent.com/10324926/33529356-69378b0a-d835-11e7-9c05-0799b7b93242.PNG)