### PR TITLE
Fix iPad vertical view not showing bottom toolbar

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -605,7 +605,7 @@ class AssignmentTexterContact extends React.Component {
           </Toolbar>
         </div>
       )
-    } else if (size > 768 || messageStatus === 'needsMessage') {
+    } else if (size >= 768 || messageStatus === 'needsMessage') {
       return (
         <div>
           <Toolbar style={inlineStyles.actionToolbarFirst}>


### PR DESCRIPTION
The size checks didn't account for the iPad width which is exactly 768.
Widths between 450 and 768 are still unaccounted for.