### PR TITLE
Reverts this logic back to newIndex instead of the first index

### DIFF
--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -51,7 +51,7 @@ class AssignmentTexter extends React.Component {
 
   updateCurrentContactIndex(newIndex) {
     this.setState({
-      currentContactIndex: 0
+      currentContactIndex: newIndex
     })
   }
 


### PR DESCRIPTION
For #435 
- Tested locally for a campaign with dynamic assignment turned on and a campaign where dynamic assignment is turned off. Skips with dynamic assignment turned off and doesn't skip when it's turned on (I think that's the ideal behavior). 
- This change was introduced here:
https://github.com/MoveOnOrg/Spoke/commit/b5d92a173b82cdb73cc7790d27eef0847e1521e0#diff-bd86771e517cac3b787b7ee14ea16881