### PR TITLE
fix people add button, which doesnt have bindings in enough places

### DIFF
--- a/src/components/OrganizationJoinLink.jsx
+++ b/src/components/OrganizationJoinLink.jsx
@@ -9,7 +9,7 @@ const OrganizationJoinLink = ({ organizationUuid, campaignId }) => {
   }
 
   const joinUrl = ((campaignId)
-                   ? `${baseUrl}/${organizationUuid}/join${campaignId}`
+                   ? `${baseUrl}/${organizationUuid}/join/${campaignId}`
                    : `${baseUrl}/${organizationUuid}/join`)
 
   return (

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -26,6 +26,15 @@ const organizationFragment = `
   }
 `
 class AdminPersonList extends React.Component {
+
+  constructor(props) {
+    super(props)
+    this.handleOpen = this.handleOpen.bind(this)
+    this.handleClose = this.handleClose.bind(this)
+    this.handleChange = this.handleChange.bind(this)
+    this.updateUser = this.updateUser.bind(this)
+  }
+
   state = {
     open: false,
     userEdit: false
@@ -137,7 +146,7 @@ class AdminPersonList extends React.Component {
           <UserEdit
             organizationId={organizationData.organization.id}
             userId={this.state.userEdit}
-            onRequestClose={this.updateUser.bind(this)}
+            onRequestClose={this.updateUser}
           />
         </Dialog>
         <Dialog


### PR DESCRIPTION
On the main branch, the `[+]` button on the People admin page doesn't work -- we need some bindings on the methods or it doesn't retain the `this` variable -- a bit silly that they didn't fix this somehow in es6 `#js-gotchas`