### PR TITLE
hide optout/skip buttons on first needsMessage

### DIFF
--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -146,68 +146,7 @@ AssignmentSummary.propTypes = {
   assignment: PropTypes.object,
   unmessagedCount: PropTypes.number,
   unrepliedCount: PropTypes.number,
-  badTimezoneCount: PropTypes.number,
-  data: PropTypes.object,
-  mutations: PropTypes.object
+  badTimezoneCount: PropTypes.number
 }
 
-const mapQueriesToProps = ({ ownProps }) => ({
-  data: {
-    query: gql`query getContacts($assignmentId: String!, $contactsFilter: ContactsFilter!) {
-      assignment(id: $assignmentId) {
-        id
-        texter {
-          id
-          firstName
-          lastName
-          assignedCell
-        }
-        campaign {
-          id
-          isArchived
-          customFields
-          useDynamicAssignment
-          organization {
-            id
-            textingHoursEnforced
-            textingHoursStart
-            textingHoursEnd
-            threeClickEnabled
-          }
-        }
-        contacts(contactsFilter: $contactsFilter) {
-          id
-          firstName
-          lastName
-          cell
-          zip
-          customFields
-          optOut {
-            id
-            createdAt
-          }
-          currentInteractionStepScript
-          location {
-            city
-            state
-            timezone {
-              offset
-              hasDST
-            }
-          }
-        }
-      }
-    }`,
-    variables: {
-      contactsFilter: {
-        messageStatus: 'needsMessage',
-        isOptedOut: false,
-        validTimezone: true
-      },
-      assignmentId: ownProps.assignment.id
-    },
-    forceFetch: true
-  }
-})
-
-export default loadData(withRouter(AssignmentSummary), { mapQueriesToProps })
+export default withRouter(AssignmentSummary)

--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -135,7 +135,7 @@ class AssignmentTexterSurveys extends Component {
           style={styles.cardText}
         >
           {showAllQuestions ? '' : this.renderStep(currentInteractionStep, true)}
-        </CardText>q
+        </CardText>
         <CardText
           style={styles.cardText}
           expandable

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -38,6 +38,7 @@ class TexterTodo extends React.Component {
 
   render() {
     const { assignment } = this.props.data
+    console.log('assignment', contacts)
     const contacts = assignment.contacts
     const allContacts = assignment.allContacts
     return (
@@ -96,6 +97,19 @@ const mapQueriesToProps = ({ ownProps }) => ({
             threeClickEnabled
           }
           customFields
+          interactionSteps {
+            id
+            question {
+              text
+              answerOptions {
+                value
+                nextInteractionStep {
+                  id
+                  script
+                }
+              }
+            }
+          }
         }
         contacts(contactsFilter: $contactsFilter) {
           id

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -123,6 +123,7 @@ export const resolvers = {
     interactionSteps: async (campaign) => (
       r.table('interaction_step')
         .getAll(campaign.id, { index: 'campaign_id' })
+        .filter({ is_deleted: false })
     ),
     cannedResponses: async (campaign, { userId }) => (
       r.table('canned_response')

--- a/src/server/api/question.js
+++ b/src/server/api/question.js
@@ -8,6 +8,7 @@ export const schema = `
   }
 
   type AnswerOption {
+    interactionStepId: Int
     value: String
     action: String
     nextInteractionStep: InteractionStep
@@ -35,6 +36,7 @@ export const resolvers = {
   },
   AnswerOption: {
     value: (answer) => answer.value,
+    interactionStepId: (answer) => answer.interaction_step_id,
     nextInteractionStep: async (answer) => r.table('interaction_step').get(answer.interaction_step_id),
     responders: async (answer) => (
       r.table('question_response')


### PR DESCRIPTION
This fixes the very-old-issue fixes #213 

It also simplifies some of the data that is used (or not used at all!) related to calling getContact with interactions steps, etc.
Basically it:
* removes getContact on the todos screen since it's not used at all
* removes a stray `q` in the html which shouldn't be there
* gets the interactionsteps only once on the campaign, and then instead of getting all the interactionsteps per-contact it just gets the questionResponses from them.

The latter work is a bit of prep before we try to optimize/reorganize contact-getting.
