### PR TITLE
21 copy campaigns

### DIFF
--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -21,7 +21,8 @@ import {
   sortInteractionSteps,
   getInteractionPath,
   getChildren,
-  findParent
+  findParent,
+  makeTree
 } from '../lib'
 
 const styles = {
@@ -56,19 +57,8 @@ export default class CampaignInteractionStepsForm extends React.Component {
   }
 
   onSave = async () => {
-    await this.props.onChange({ interactionSteps: this.makeTree(this.state.interactionSteps) })
+    await this.props.onChange({ interactionSteps: makeTree(this.state.interactionSteps) })
     this.props.onSubmit()
-  }
-
-  makeTree(interactionSteps, id = null) {
-    const root = interactionSteps.filter((is) => id ? is.id === id : is.parentInteractionId === null)[0]
-    const children = interactionSteps.filter((is) => is.parentInteractionId === root.id)
-    return {
-      ...root,
-      interactionSteps: children.map((c) => {
-        return this.makeTree(interactionSteps, c.id)
-      })
-    }
   }
 
   addStep(parentInteractionId) {
@@ -211,7 +201,7 @@ export default class CampaignInteractionStepsForm extends React.Component {
   }
 
   render() {
-    const tree = this.makeTree(this.state.interactionSteps)
+    const tree = makeTree(this.state.interactionSteps)
 
     return (
       <div>

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -383,9 +383,6 @@ class AdminCampaignEdit extends React.Component {
         }}
       >
         This campaign is running!
-        <div>
-        {this.renderCopyButton()}
-        </div>
       </div>
       ) :
       this.renderStartButton()
@@ -415,15 +412,6 @@ class AdminCampaignEdit extends React.Component {
             </div>
           ) : notStarting}
       </div>
-    )
-  }
-
-  renderCopyButton(){
-    return(
-      <RaisedButton
-        label='Copy Campaign'
-        onTouchTap={async() => await this.props.mutations.copyCampaign(this.props.campaignData.campaign.id)}
-      />
     )
   }
 
@@ -682,17 +670,6 @@ const mapMutationsToProps = () => ({
         campaignId,
         campaign
       }
-    })
-  },
-  copyCampaign(campaignId, campaign) {
-    return({
-      mutation: gql`
-        mutation copyCampaign($campaignId: String!, $campaign: CampaignInput!){
-          copyCampaign(id: $campaignId, campaign: $campaign){
-            ${campaignInfoFragment}
-          }
-        }
-      `
     })
   }
 })

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -383,6 +383,9 @@ class AdminCampaignEdit extends React.Component {
         }}
       >
         This campaign is running!
+        <div>
+        {this.renderCopyButton()}
+        </div>
       </div>
       ) :
       this.renderStartButton()
@@ -412,6 +415,15 @@ class AdminCampaignEdit extends React.Component {
             </div>
           ) : notStarting}
       </div>
+    )
+  }
+
+  renderCopyButton(){
+    return(
+      <RaisedButton
+        label='Copy Campaign'
+        onTouchTap={async() => await this.props.mutations.copyCampaign(this.props.campaignData.campaign.id)}
+      />
     )
   }
 
@@ -671,6 +683,18 @@ const mapMutationsToProps = () => ({
         campaign
       }
     })
+  },
+  copyCampaign(campaignId, campaign) {
+    console.log(' campaign? ');
+    // return({
+    //   mutation: gql`
+    //     mutation editCampaign($campaignId: String!, $campaign: CampaignInput!){
+    //       eidtCampaign(id: $campaignId, campaign: $campaign){
+    //         ${campaignInfoFragment}
+    //       }
+    //     }
+    //   `
+    // })
   }
 })
 

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -685,16 +685,15 @@ const mapMutationsToProps = () => ({
     })
   },
   copyCampaign(campaignId, campaign) {
-    console.log(' campaign? ');
-    // return({
-    //   mutation: gql`
-    //     mutation editCampaign($campaignId: String!, $campaign: CampaignInput!){
-    //       eidtCampaign(id: $campaignId, campaign: $campaign){
-    //         ${campaignInfoFragment}
-    //       }
-    //     }
-    //   `
-    // })
+    return({
+      mutation: gql`
+        mutation copyCampaign($campaignId: String!, $campaign: CampaignInput!){
+          copyCampaign(id: $campaignId, campaign: $campaign){
+            ${campaignInfoFragment}
+          }
+        }
+      `
+    })
   }
 })
 

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -137,6 +137,15 @@ class AdminCampaignStats extends React.Component {
     })
   }
 
+  renderCopyButton(){
+    return(
+      <RaisedButton
+        label='Copy Campaign'
+        onTouchTap={async() => await this.props.mutations.copyCampaign(this.props.params.campaignId, this.props.data.campaign)}
+      />
+    )
+  }
+
   render() {
     const { data, params } = this.props
     const { organizationId, campaignId } = params
@@ -177,6 +186,7 @@ class AdminCampaignStats extends React.Component {
                     label={exportLabel}
                     disabled={shouldDisableExport}
                   />
+
                 </div>
                 <div className={css(styles.inline)}>
                   {campaign.isArchived ? (
@@ -195,6 +205,7 @@ class AdminCampaignStats extends React.Component {
                     />
                   ]}
                 </div>
+                {this.renderCopyButton()}
               </div>
             </div>
           </div>
@@ -322,6 +333,14 @@ const mapMutationsToProps = () => ({
       }
     }`,
     variables: { campaignId }
+  }),
+  copyCampaign: (campaignId, campaign) => ({
+    mutation: gql`mutation copyCampaign($campaignId: String!, $campaign: CampaignInput!){
+      copyCampaign(id: $campaignId, campaign: $campaign){
+       ${id}
+      }
+    }`,
+    variables: { campaignId, campaign }
   })
 })
 

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -141,7 +141,7 @@ class AdminCampaignStats extends React.Component {
     return(
       <RaisedButton
         label='Copy Campaign'
-        onTouchTap={async() => await this.props.mutations.copyCampaign(this.props.params.campaignId, this.props.data.campaign)}
+        onTouchTap={async() => await this.props.mutations.copyCampaign(this.props.params.campaignId)}
       />
     )
   }
@@ -334,13 +334,13 @@ const mapMutationsToProps = () => ({
     }`,
     variables: { campaignId }
   }),
-  copyCampaign: (campaignId, campaign) => ({
-    mutation: gql`mutation copyCampaign($campaignId: String!, $campaign: CampaignInput!){
-      copyCampaign(id: $campaignId, campaign: $campaign){
-       ${id}
+  copyCampaign: (campaignId) => ({
+    mutation: gql`mutation copyCampaign($campaignId: String!){
+      copyCampaign(id: $campaignId){
+       id
       }
     }`,
-    variables: { campaignId, campaign }
+    variables: { campaignId }
   })
 })
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -23,7 +23,8 @@ export {
   sortInteractionSteps,
   interactionStepForId,
   getTopMostParent,
-  getChildren
+  getChildren,
+  makeTree
 } from './interaction-step-helpers'
 const requiredUploadFields = ['firstName', 'lastName', 'cell']
 const topLevelUploadFields = ['firstName', 'lastName', 'cell', 'zip', 'external_id']

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -80,3 +80,14 @@ export function sortInteractionSteps(interactionSteps) {
 export function getTopMostParent(interactionSteps, isModel) {
   return getInteractionTree(interactionSteps, isModel)[0][0].interactionStep
 }
+
+export function makeTree(interactionSteps, id = null) {
+  const root = interactionSteps.filter((is) => id ? is.id === id : is.parentInteractionId === null)[0]
+  const children = interactionSteps.filter((is) => is.parentInteractionId === root.id)
+  return {
+    ...root,
+    interactionSteps: children.map((c) => {
+      return makeTree(interactionSteps, c.id)
+    })
+  }
+}

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -637,9 +637,10 @@ const rootMutations = {
       })
       const newCampaign = await campaignInstance.save()
       const newCampaignId = newCampaign.id
+      const oldCampaignId = campaign.id
 
       let interactions = await r.knex('interaction_step')
-        .where({campaign_id: id })
+        .where({campaign_id: oldCampaignId })
 
       const interactionsArr = []
       interactions.forEach((interaction, index) => {
@@ -674,17 +675,21 @@ const rootMutations = {
 
       await createSteps
 
-      let cannedResponses = await r.knex('canned_response')
-        .where({campaign_id: id })
+      let createCannedResponses = r.knex('canned_response')
+        .where({campaign_id: oldCampaignId })
+        .then(function(res){
+          res.forEach((response, index) => {
+            const copiedCannedResponse =
+              new CannedResponse({
+                campaign_id: newCampaignId,
+                title: response.title,
+                text: response.text
+              }).save()
+            }
+          )
+        })
 
-      cannedResponses.forEach((response, index) => {
-        const copiedCannedResponse =
-          new CannedResponse({
-            campaign_id: newCampaignId,
-            title: response.title,
-            text: response.text
-          }).save()
-      })
+      await createCannedResponses
 
       return newCampaign
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -637,8 +637,6 @@ const rootMutations = {
       })
       const newCampaign = await campaignInstance.save()
 
-      // TODO: get interaction steps associated with campaign id, and make new ones with other campaign id and other interaction ids
-
       let interactions = await r.knex('interaction_step')
         .where({campaign_id: id })
 
@@ -655,11 +653,17 @@ const rootMutations = {
           }).save()
       })
 
-
-      // return editCampaign(id, newCampaign, loaders, user, origCampaign)
+      let newParentInteractionId = await r.knex('interaction_step')
+        .where({campaign_id: newCampaign.id})
+        .whereNull('parent_interaction_id')
+        .then(function(result) {
+          console.log(result);
+          return result
+        })
 
       let cannedResponses = await r.knex('canned_response')
         .where({campaign_id: id })
+
 
       cannedResponses.forEach((response, index) => {
         const copiedCannedResponse =

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -208,6 +208,7 @@ const rootSchema = `
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
     editCampaign(id:String!, campaign:CampaignInput!): Campaign
+    copyCampaign(id: String!, campaign:CampaignInput!): Campaign
     exportCampaign(id:String!): JobRequest
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
@@ -622,6 +623,11 @@ const rootMutations = {
       const newCampaign = await campaignInstance.save()
       return editCampaign(newCampaign.id, campaign, loaders)
     },
+    copyCampaign: async (_, { campaign }, { user, loaders }) => {
+      await accessRequired(user, campaign.organizationId, 'ADMIN')
+
+      console.log('campaign');
+    },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {
       const campaign = await loaders.campaign.load(id)
       await accessRequired(user, campaign.organizationId, 'ADMIN')
@@ -661,6 +667,19 @@ const rootMutations = {
           })
       }
       return editCampaign(id, campaign, loaders, user, origCampaign)
+    },
+    copyCampaign: async (_, { id, campaign }, { user, loaders }) => {
+      if(campaign.organizationId) {
+        await accessRequired(user, campaign.organizationId, 'ADMIN')
+        console.log(' getting here!');
+      }
+      // if (!campaign.contacts) {
+      //     throw new GraphQLError({
+      //         status: 400,
+      //         message: 'Not allowed to add contacts after the campaign starts'
+      //     })
+      // }
+      // return editCampaign(id, campaign, loaders, user, origCampaign)
     },
     createCannedResponse: async (_, { cannedResponse }, { user, loaders }) => {
       authRequired(user)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -636,7 +636,13 @@ const rootMutations = {
         is_archived: false
       })
       const newCampaign = await campaignInstance.save()
-      
+
+      const cannedResponseInstance = new CannedResponse({
+        campaign_id: newCampaign.id,
+        title: 'copy canned response',
+        text: 'copy text'
+      }).save()
+
       return newCampaign
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -623,10 +623,21 @@ const rootMutations = {
       const newCampaign = await campaignInstance.save()
       return editCampaign(newCampaign.id, campaign, loaders)
     },
-    copyCampaign: async (_, { campaign }, { user, loaders }) => {
+    copyCampaign: async (_, { id, campaign }, { user, loaders }) => {
+      console.log('getting here-->', id);
+      
       await accessRequired(user, campaign.organizationId, 'ADMIN')
+      // const campaignInstance = new Campaign({
+      //   organization_id: campaign.organizationId,
+      //   title: campaign.title,
+      //   description: campaign.description,
+      //   due_by: campaign.dueBy,
+      //   is_started: false,
+      //   is_archived: false
+      // })
+      // const newCampaign = await campaignInstance.save()
 
-      console.log('campaign:', campaign.id);
+      console.log('campaign getting here? in schema:', campaign + ' ' + id);
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {
       const campaign = await loaders.campaign.load(id)
@@ -667,19 +678,6 @@ const rootMutations = {
           })
       }
       return editCampaign(id, campaign, loaders, user, origCampaign)
-    },
-    copyCampaign: async (_, { id, campaign }, { user, loaders }) => {
-      if(campaign.organizationId) {
-        await accessRequired(user, campaign.organizationId, 'ADMIN')
-        console.log(' getting here!');
-      }
-      // if (!campaign.contacts) {
-      //     throw new GraphQLError({
-      //         status: 400,
-      //         message: 'Not allowed to add contacts after the campaign starts'
-      //     })
-      // }
-      // return editCampaign(id, campaign, loaders, user, origCampaign)
     },
     createCannedResponse: async (_, { cannedResponse }, { user, loaders }) => {
       authRequired(user)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -624,22 +624,20 @@ const rootMutations = {
       return editCampaign(newCampaign.id, campaign, loaders)
     },
     copyCampaign: async (_, { id }, { user, loaders }) => {
-      console.log('getting here-->', id);
       const campaign = await loaders.campaign.load(id)
+      await accessRequired(user, campaign.organization_id, 'ADMIN')
 
-      await accessRequired(user, campaign.organizationId, 'ADMIN')
-      // const campaignInstance = new Campaign({
-      //   organization_id: campaign.organizationId,
-      //   title: campaign.title,
-      //   description: campaign.description,
-      //   due_by: campaign.dueBy,
-      //   is_started: false,
-      //   is_archived: false
-      // })
-      // const newCampaign = await campaignInstance.save()
-
-      console.log('campaign getting here? in schema:', campaign + ' ' + id);
-      return campaign
+      const campaignInstance = new Campaign({
+        organization_id: campaign.organization_id,
+        title: 'COPY - ' + campaign.title,
+        description: campaign.description,
+        due_by: campaign.dueBy,
+        is_started: false,
+        is_archived: false
+      })
+      const newCampaign = await campaignInstance.save()
+      
+      return newCampaign
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {
       const campaign = await loaders.campaign.load(id)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -646,11 +646,11 @@ const rootMutations = {
         if(interaction.parent_interaction_id){
           let is = {
             id: 'new'+interaction.id,
-            question: interaction.question,
+            questionText: interaction.question,
             script: interaction.script,
-            answer_option: interaction.answer_option,
-            answer_actions: interaction.answer_actions,
-            is_deleted: interaction.is_deleted,
+            answerOption: interaction.answer_option,
+            answerActions: interaction.answer_actions,
+            isDeleted: interaction.is_deleted,
             campaign_id: newCampaignId,
             parentInteractionId: 'new'+interaction.parent_interaction_id
           }
@@ -658,19 +658,17 @@ const rootMutations = {
         } else if (!interaction.parent_interaction_id){
           let is = {
             id: 'new'+interaction.id,
-            question: interaction.question,
+            questionText: interaction.question,
             script: interaction.script,
-            answer_option: interaction.answer_option,
-            answer_actions: interaction.answer_actions,
-            is_deleted: interaction.is_deleted,
+            answerOption: interaction.answer_option,
+            answerActions: interaction.answer_actions,
+            isDeleted: interaction.is_deleted,
             campaign_id: newCampaignId,
             parentInteractionId: interaction.parent_interaction_id
           }
           interactionsArr.push(is)
         }
       })
-
-      // todo --> fix camelcasing for front end 
 
       let createSteps = updateInteractionSteps(newCampaignId, [makeTree(interactionsArr, id = null)], campaign, {})
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -626,7 +626,7 @@ const rootMutations = {
     copyCampaign: async (_, { campaign }, { user, loaders }) => {
       await accessRequired(user, campaign.organizationId, 'ADMIN')
 
-      console.log('campaign');
+      console.log('campaign:', campaign.id);
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {
       const campaign = await loaders.campaign.load(id)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -637,6 +637,31 @@ const rootMutations = {
       })
       const newCampaign = await campaignInstance.save()
 
+      // TODO: get interaction steps associated with campaign id, and make new ones with other campaign id and other interaction ids
+
+      let interactions = await r.knex('interaction_step')
+        .where({campaign_id: id })
+
+      console.log('interaction', interactions);
+
+      interactions.forEach((interaction, index) => {
+        const copiedIteraction =
+          new InteractionStep({
+            question: interaction.question,
+            script: interaction.script,
+            answer_option: interaction.answer_option,
+            answer_actions: interaction.answer_actions,
+            is_deleted: interaction.is_deleted,
+            campaign_id: newCampaign.id,
+            parent_interaction_id: interaction.parent_interaction_id
+          }).save()
+      })
+
+
+      // return editCampaign(id, newCampaign, loaders, user, origCampaign)
+
+      // todo: create new canned responses
+
       const cannedResponseInstance = new CannedResponse({
         campaign_id: newCampaign.id,
         title: 'copy canned response',

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -208,7 +208,7 @@ const rootSchema = `
     createInvite(invite:InviteInput!): Invite
     createCampaign(campaign:CampaignInput!): Campaign
     editCampaign(id:String!, campaign:CampaignInput!): Campaign
-    copyCampaign(id: String!, campaign:CampaignInput!): Campaign
+    copyCampaign(id: String!): Campaign
     exportCampaign(id:String!): JobRequest
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
@@ -623,9 +623,10 @@ const rootMutations = {
       const newCampaign = await campaignInstance.save()
       return editCampaign(newCampaign.id, campaign, loaders)
     },
-    copyCampaign: async (_, { id, campaign }, { user, loaders }) => {
+    copyCampaign: async (_, { id }, { user, loaders }) => {
       console.log('getting here-->', id);
-      
+      const campaign = await loaders.campaign.load(id)
+
       await accessRequired(user, campaign.organizationId, 'ADMIN')
       // const campaignInstance = new Campaign({
       //   organization_id: campaign.organizationId,
@@ -638,6 +639,7 @@ const rootMutations = {
       // const newCampaign = await campaignInstance.save()
 
       console.log('campaign getting here? in schema:', campaign + ' ' + id);
+      return campaign
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {
       const campaign = await loaders.campaign.load(id)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -642,10 +642,8 @@ const rootMutations = {
       let interactions = await r.knex('interaction_step')
         .where({campaign_id: id })
 
-      console.log('interaction', interactions);
-
       interactions.forEach((interaction, index) => {
-        const copiedIteraction =
+        const copiedInteraction =
           new InteractionStep({
             question: interaction.question,
             script: interaction.script,
@@ -660,14 +658,18 @@ const rootMutations = {
 
       // return editCampaign(id, newCampaign, loaders, user, origCampaign)
 
-      // todo: create new canned responses
+      let cannedResponses = await r.knex('canned_response')
+        .where({campaign_id: id })
 
-      const cannedResponseInstance = new CannedResponse({
-        campaign_id: newCampaign.id,
-        title: 'copy canned response',
-        text: 'copy text'
-      }).save()
-
+      cannedResponses.forEach((response, index) => {
+        const copiedCannedResponse =
+          new CannedResponse({
+            campaign_id: newCampaign.id,
+            title: response.title,
+            text: response.text
+          }).save()
+      })
+      
       return newCampaign
     },
     unarchiveCampaign: async (_, { id }, { user, loaders }) => {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -653,17 +653,23 @@ const rootMutations = {
           }).save()
       })
 
-      let newParentInteractionId = await r.knex('interaction_step')
-        .where({campaign_id: newCampaign.id})
+      let query = r.knex.select('id')
+        .from('interaction_step')
         .whereNull('parent_interaction_id')
-        .then(function(result) {
-          console.log(result);
-          return result
+        .andWhere({campaign_id: newCampaign.id})
+        .then(function(res) {
+          return r.knex('interaction_step')
+            .where({campaign_id: newCampaign.id})
+            .whereNotNull('parent_interaction_id')
+            .update({
+              parent_interaction_id: res[0].id,
+            })
         })
+
+      await query
 
       let cannedResponses = await r.knex('canned_response')
         .where({campaign_id: id })
-
 
       cannedResponses.forEach((response, index) => {
         const copiedCannedResponse =


### PR DESCRIPTION
Currently - copies a live campaign with the same title (with 'COPY'), description, canned responses and the first interaction step

Going to fix #21 

TODO: 
- [x] Make sure all interaction steps and q responses copy (update parent interaction id with interaction step id that has the same campaign id and a null parent interaction id - that's the 'root')