### PR TITLE
Reduce queries for needsMessage and other texter moments

### DIFF
--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -38,7 +38,6 @@ class TexterTodo extends React.Component {
 
   render() {
     const { assignment } = this.props.data
-    console.log('assignment', contacts)
     const contacts = assignment.contacts
     const allContacts = assignment.allContacts
     return (
@@ -57,6 +56,7 @@ class TexterTodo extends React.Component {
 
 TexterTodo.propTypes = {
   contactsFilter: PropTypes.string,
+  messageStatus: PropTypes.string,
   params: PropTypes.object,
   data: PropTypes.object,
   router: PropTypes.object

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -1,6 +1,6 @@
 import { CampaignContact, r } from '../models'
 import { mapFieldsToModel } from './lib/utils'
-import { log, getTopMostParent } from '../../lib'
+import { log, getTopMostParent, zipToTimeZone } from '../../lib'
 
 export const schema = `
   input ContactsFilter {
@@ -71,11 +71,14 @@ export const resolvers = {
     // To get that result to look like what the original code returned
     // without using the outgoing answer_options array field, try this:
     //
-    questionResponseValues: async (campaignContact, _, { loaders }) => (
-      await r.knex('question_response')
+    questionResponseValues: async (campaignContact, _, { loaders }) => {
+      if (campaignContact.message_status === 'needsMessage') {
+        return [] // it's the beginning, so there won't be any
+      }
+      return await r.knex('question_response')
         .where('question_response.campaign_contact_id', campaignContact.id)
         .select('value', 'interaction_step_id')
-    ),
+    },
     questionResponses: async (campaignContact, _, { loaders }) => {
       const results = await r.knex('question_response as qres')
         .where('qres.campaign_contact_id', campaignContact.id)
@@ -138,9 +141,7 @@ export const resolvers = {
       return Object.values(formatted)
     },
     location: async (campaignContact, _, { loaders }) => {
-      const mainZip = campaignContact.zip.split('-')[0]
-      const loc = await loaders.zipCode.load(mainZip)
-      if (!loc && campaignContact.timezone_offset) {
+      if (campaignContact.timezone_offset) {
         // couldn't look up the timezone by zip record, so we load it
         // from the campaign_contact directly if it's there
         const [offset, hasDst] = campaignContact.timezone_offset.split('_')
@@ -149,9 +150,20 @@ export const resolvers = {
           has_dst: (hasDst === '1')
         }
       }
-      return loc
+      const mainZip = campaignContact.zip.split('-')[0]
+      const calculated = zipToTimeZone(mainZip)
+      if (calculated) {
+        return {
+          timezone_offset: calculated[2],
+          has_dst: (calculated[3] === 1)
+        }
+      }
+      return await loaders.zipCode.load(mainZip)
     },
     messages: async (campaignContact) => {
+      if (campaignContact.message_status === 'needsMessage') {
+        return [] // it's the beginning, so there won't be any
+      }
       const messages = await r.table('message')
         .getAll(campaignContact.assignment_id, { index: 'assignment_id' })
         .filter({


### PR DESCRIPTION
This reduces some queries which are unnecessary in certain states.

1. Whenever we have a messageStatus=='needsMessage' we shortcut responses for messages and response values since there won't be any.
2. We don't need to lookup zip information if we already have it in the contact record and even if we don't we should try getting it programmatically first.

This PR is against the decoupling-prep branch, since it builds on that work.  After that branch is merged, we should either merge this one next, or edit the PR to go against `main`