### PR TITLE
fix #395 - upload contacts does not work in firefox

### DIFF
--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -176,18 +176,21 @@ export default class CampaignContactsForm extends React.Component {
   renderUploadButton() {
     const { uploading } = this.state
     return (
-      <RaisedButton
-        style={innerStyles.button}
-        label={uploading ? 'Uploading...' : 'Upload contacts'}
-        labelPosition='before'
-        disabled={uploading}
-      >
+      <div>
+        <RaisedButton
+          style={innerStyles.button}
+          label={uploading ? 'Uploading...' : 'Upload contacts'}
+          labelPosition='before'
+          disabled={uploading}
+          onClick={() => document.querySelector('#contact-upload').click()}
+        />
         <input
+          id='contact-upload'
           type='file'
           className={css(styles.exampleImageInput)}
           onChange={this.handleUpload}
         />
-      </RaisedButton>
+      </div>
     )
   }
 

--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -189,6 +189,7 @@ export default class CampaignContactsForm extends React.Component {
           type='file'
           className={css(styles.exampleImageInput)}
           onChange={this.handleUpload}
+          style={{display: 'none'}}
         />
       </div>
     )


### PR DESCRIPTION
Description of the reason for the problem can be found here: https://github.com/mui-org/material-ui/issues/647

Inputs inside buttons is apparently not part of the W3C spec, but Chrome does it anyways.

This fixes it and still users the same button component, and works in all other browsers too