### PR TITLE
Add/mailgun

### DIFF
--- a/app.json
+++ b/app.json
@@ -195,6 +195,7 @@
   },
 
   "addons": [
-    "heroku-postgresql:hobby-dev"
+    "heroku-postgresql:hobby-dev",
+    "mailgun:starter"
   ]
 }

--- a/docs/HOWTO_HEROKU_DEPLOY.md
+++ b/docs/HOWTO_HEROKU_DEPLOY.md
@@ -62,3 +62,8 @@ follow these steps:
 When using Twilio we recommend keeping the environment variable `JOBS_SAME_PROCESS` enabled and only running the `web` process/dyno.
 There is another mode mostly for non-Twilio backends, where you may need to run the additional processes to process messages and sending.  Most times, even at high scale, you will want to keep `JOBS_SAME_PROCESS` on and increase or upgrade the dynos for the `web` process.
 
+## Setting Up Mailgun
+In order to configure Mailgun to actually send emails, you'll need to configure a domain for it. To do so, navigate
+to Add-Ons in your Heroku app, click on Mailgun, and then click on Domains. You'll need to go to your DNS provider, add
+those TXT and MX records, wait a few minutes, and click the button to check for changes in DNS. After it says your domain
+is set up, you should be good to go.

--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "json-loader": "^0.5.4",
     "knex": "^0.13.0",
     "lodash": "^4.13.1",
+    "mailgun-js": "^0.16.0",
     "material-ui": "^0.15.2",
     "material-ui-color-picker": "^1.0.1",
     "minilog": "^3.0.1",

--- a/src/server/mail.js
+++ b/src/server/mail.js
@@ -5,26 +5,20 @@ import mailgunConstructor from 'mailgun-js'
 const mailgun =
   process.env.MAILGUN_API_KEY &&
   process.env.MAILGUN_DOMAIN &&
-  mailgunConstructor({
-    apiKey: process.env.MAILGUN_API_KEY,
-    domain: process.env.MAILGUN_DOMAIN
-  })
+  mailgunConstructor({ apiKey: process.env.MAILGUN_API_KEY, domain: process.env.MAILGUN_DOMAIN }) 
 
 const sender =
   process.env.MAILGUN_API_KEY && process.env.MAILGUN_DOMAIN
     ? {
-      sendMail: ({ from, to, subject, replyTo, text }) =>
-          new Promise((resolve, reject) =>
-            mailgun.messages.send(
+      sendMail: ({ from, to, subject, replyTo, text }) => 
+            mailgun.messages().send(
               {
-                from: `${from} <${replyTo}>`,
+                from: from,
+                'h:Reply-To': replyTo,
                 to,
                 subject,
                 text
-              },
-              (err, resp) => (err ? reject(err) : resolve(resp))
-            )
-          )
+              })
     }
     : nodemailer.createTransport({
       host: process.env.EMAIL_HOST,
@@ -58,5 +52,5 @@ export const sendEmail = async ({ to, subject, text, replyTo }) => {
     params['replyTo'] = replyTo
   }
 
-  return transporter.sendMail(params)
+  return sender.sendMail(params)
 }

--- a/src/server/mail.js
+++ b/src/server/mail.js
@@ -1,22 +1,52 @@
 import { log } from '../lib'
 import nodemailer from 'nodemailer'
+import mailgunConstructor from 'mailgun-js'
 
-let transporter = nodemailer.createTransport({
-  host: process.env.EMAIL_HOST,
-  port: process.env.EMAIL_HOST_PORT,
-  secure: typeof process.env.EMAIL_HOST_SECURE !== 'undefined' ? process.env.EMAIL_HOST_SECURE : true,
-  auth: {
-    user: process.env.EMAIL_HOST_USER,
-    pass: process.env.EMAIL_HOST_PASSWORD
-  }
-})
+const mailgun =
+  process.env.MAILGUN_API_KEY &&
+  process.env.MAILGUN_DOMAIN &&
+  mailgunConstructor({
+    apiKey: process.env.MAILGUN_API_KEY,
+    domain: process.env.MAILGUN_DOMAIN
+  })
+
+const sender =
+  process.env.MAILGUN_API_KEY && process.env.MAILGUN_DOMAIN
+    ? {
+      sendMail: ({ from, to, subject, replyTo, text }) =>
+          new Promise((resolve, reject) =>
+            mailgun.messages.send(
+              {
+                from: `${from} <${replyTo}>`,
+                to,
+                subject,
+                text
+              },
+              (err, resp) => (err ? reject(err) : resolve(resp))
+            )
+          )
+    }
+    : nodemailer.createTransport({
+      host: process.env.EMAIL_HOST,
+      port: process.env.EMAIL_HOST_PORT,
+      secure:
+          typeof process.env.EMAIL_HOST_SECURE !== 'undefined'
+            ? process.env.EMAIL_HOST_SECURE
+            : true,
+      auth: {
+        user: process.env.EMAIL_HOST_USER,
+        pass: process.env.EMAIL_HOST_PASSWORD
+      }
+    })
 
 export const sendEmail = async ({ to, subject, text, replyTo }) => {
   log.info(`Sending e-mail to ${to} with subject ${subject}.`)
+
   if (process.env.NODE_ENV === 'development') {
     log.debug(`Would send e-mail with subject ${subject} and text ${text}.`)
     return null
   }
+
   const params = {
     from: process.env.EMAIL_FROM,
     to,
@@ -27,5 +57,6 @@ export const sendEmail = async ({ to, subject, text, replyTo }) => {
   if (replyTo) {
     params['replyTo'] = replyTo
   }
+
   return transporter.sendMail(params)
 }


### PR DESCRIPTION
Hey! I saw you all removed mailgun a while back (https://github.com/MoveOnOrg/Spoke/pull/143). 

We want to use it, and it works nicely with the heroku button set up, and so this adds it back optionally and wraps it in the same api as `nodemailer`. If process.env.MAILGUN_API_KEY and process.env.MAILGUN_DOMAIN exist, it will use the mailgun adapter instead.

I also added free tier mailgun to the heroku deploy button, and instructions for how to set up a domain with mailgun in the heroku deploy instructions