### PR TITLE
Allow admins, superadmins, owners ability to be assigned contacts

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -614,11 +614,11 @@ const mapQueriesToProps = ({ ownProps }) => ({
     pollInterval: 60000
   },
   organizationData: {
-    query: gql`query getOrganizationData($organizationId: String!, $role: String!) {
+    query: gql`query getOrganizationData($organizationId: String!) {
       organization(id: $organizationId) {
         id
         uuid
-        texters: people(role: $role) {
+        texters: people {
           id
           firstName
           displayName
@@ -626,8 +626,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
       }
     }`,
     variables: {
-      organizationId: ownProps.params.organizationId,
-      role: 'TEXTER'
+      organizationId: ownProps.params.organizationId
     },
     pollInterval: 20000
   },


### PR DESCRIPTION
Our new role setup doesn't auto-create a TEXTER role for everyone -- instead it's just their 'maximum' role, and the rest is inferred, so we should allow any role to be assigned.