### PR TITLE
heroku knex ssl config / exports error handling

### DIFF
--- a/src/server/models/thinky.js
+++ b/src/server/models/thinky.js
@@ -10,10 +10,11 @@ import dumbThinky from 'rethink-knex-adapter'
 
 let config
 
+const use_ssl = process.env.DB_USE_SSL && (process.env.DB_USE_SSL.toLowerCase() === 'true' || process.env.DB_USE_SSL === '1')
+
 if (process.env.DB_JSON || global.DB_JSON) {
   config = JSON.parse(process.env.DB_JSON || global.DB_JSON)
 } else if (process.env.DB_TYPE) {
-  const use_ssl = process.env.DB_USE_SSL && (process.env.DB_USE_SSL.toLowerCase() === 'true' || process.env.DB_USE_SSL === '1')
   config = {
     client: 'pg',
     connection: {
@@ -37,7 +38,8 @@ if (process.env.DB_JSON || global.DB_JSON) {
     pool: {
       min: process.env.DB_MIN_POOL || 2,
       max: process.env.DB_MAX_POOL || 10
-    }
+    },
+    ssl: use_ssl
   }
 } else {
   config = {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -540,6 +540,10 @@ export async function exportCampaign(job) {
         text: `Your Spoke exports are ready! These URLs will be valid for 24 hours.
         Campaign export: ${campaignExportUrl}
         Message export: ${campaignMessagesExportUrl}`
+      }).catch((err) => {
+        log.error(err)
+        log.info(`Campaign Export URL - ${campaignExportUrl}`)
+        log.info(`Campaign Messages Export URL - ${campaignMessagesExportUrl}`)
       })
       log.info(`Successfully exported ${id}`)
     } catch (err) {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -521,28 +521,36 @@ export async function exportCampaign(job) {
   const messageCsv = Papa.unparse(finalCampaignMessages)
 
   if (process.env.AWS_ACCESS_AVAILABLE || (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY)) {
-    const s3bucket = new AWS.S3({ params: { Bucket: process.env.AWS_S3_BUCKET_NAME } })
-    const campaignTitle = campaign.title.replace(/ /g, '_').replace(/\//g, '_')
-    const key = `${campaignTitle}-${moment().format('YYYY-MM-DD-HH-mm-ss')}.csv`
-    const messageKey = `${key}-messages.csv`
-    let params = { Key: key, Body: campaignCsv }
-    await s3bucket.putObject(params).promise()
-    params = { Key: key, Expires: 86400 }
-    const campaignExportUrl = await s3bucket.getSignedUrl('getObject', params)
-    params = { Key: messageKey, Body: messageCsv }
-    await s3bucket.putObject(params).promise()
-    params = { Key: messageKey, Expires: 86400 }
-    const campaignMessagesExportUrl = await s3bucket.getSignedUrl('getObject', params)
-    await sendEmail({
-      to: user.email,
-      subject: `Export ready for ${campaign.title}`,
-      text: `Your Spoke exports are ready! These URLs will be valid for 24 hours.
-
-      Campaign export: ${campaignExportUrl}
-
-      Message export: ${campaignMessagesExportUrl}`
-    })
-    log.info(`Successfully exported ${id}`)
+    try {
+      const s3bucket = new AWS.S3({ params: { Bucket: process.env.AWS_S3_BUCKET_NAME } })
+      const campaignTitle = campaign.title.replace(/ /g, '_').replace(/\//g, '_')
+      const key = `${campaignTitle}-${moment().format('YYYY-MM-DD-HH-mm-ss')}.csv`
+      const messageKey = `${key}-messages.csv`
+      let params = { Key: key, Body: campaignCsv }
+      await s3bucket.putObject(params).promise()
+      params = { Key: key, Expires: 86400 }
+      const campaignExportUrl = await s3bucket.getSignedUrl('getObject', params)
+      params = { Key: messageKey, Body: messageCsv }
+      await s3bucket.putObject(params).promise()
+      params = { Key: messageKey, Expires: 86400 }
+      const campaignMessagesExportUrl = await s3bucket.getSignedUrl('getObject', params)
+      await sendEmail({
+        to: user.email,
+        subject: `Export ready for ${campaign.title}`,
+        text: `Your Spoke exports are ready! These URLs will be valid for 24 hours.
+        Campaign export: ${campaignExportUrl}
+        Message export: ${campaignMessagesExportUrl}`
+      })
+      log.info(`Successfully exported ${id}`)
+    } catch (err) {
+      log.error(err)
+      await sendEmail({
+        to: user.email,
+        subject: `Export failed for ${campaign.title}`,
+        text: `Your Spoke exports failed... please try again later.
+        Error: ${err.message}`
+      })
+    }
   } else {
     log.debug('Would have saved the following to S3:')
     log.debug(campaignCsv)
@@ -550,8 +558,20 @@ export async function exportCampaign(job) {
   }
 
   if (job.id) {
-    await r.table('job_request').get(job.id).delete()
-  }
+    let retries = 0
+    const deleteJob = async () => {
+      try {
+        await r.table('job_request').get(job.id).delete()
+      } catch (err) {
+        if (retries < 5) {
+          retries += 1
+          await deleteJob()
+        } else log.error(`Could not delete job. Err: ${err.message}`)
+      }
+    }
+
+    await deleteJob()
+  } else log.debug(job)
 }
 
 // add an in-memory guard that the same messages are being sent again and again


### PR DESCRIPTION
1. We found that using 'standard'+ tier Heroku PG plans require the essentially undocumented `ssl` knex config option. See: http://cek.io/blog/2016/10/24/knex-configuration-heroku/

>Note: obviously you could just go with the env variable option for this, so it's not super critical.

2. I noticed that if an export failed it would simply result in an unhandled promise rejection, and the user wouldn't be notified or even really be able to tell what happened via the logs. I wrapped the export block in a try/catch and send an email + log the error message upon failure. 

3. If the job deletion fails for some reason you have to manually delete the job from the db to update the UI (the export button will just remain disabled if the job still exists), so I added retries to the job deletion attempt.