### PR TITLE
Add *sqlite to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ test.sqlite
 *#
 coverage/
 .idea/
+*sqlite


### PR DESCRIPTION
When using sqlite in a dev environment, developers shouldn't track the
development database(s). This commit adds them to the gitignore, so we
don't get any dbs committed on accident.