### PR TITLE
Add a `test-sqlite` npm script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Generally, the first steps are:
 ### Working on an issue
 
 * Depending on the part of the codebase you are working on read relevant parts of [EXPLANATION-development-guidelines.md](./docs/EXPLANATION-development-guidelines.md) for some context and common gotchas.
-* While working on an issue, run existing tests to make sure they still work (`npm test`)
+* While working on an issue, run existing tests to make sure they still work (`npm test` or `npm run test-sqlite` depending on your backend)
 * Please try adding a test, at least for backend changes (We have an [open issue to wire up frontend React testing](https://github.com/MoveOnOrg/Spoke/issues/292))
 * Before committing changes, please run `npm run lint` to standardize formatting
 

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -13,4 +13,4 @@ GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 
 ## SQLite Testing (simpler)
 
-1) Run `npm test -- --config jest.config.sqlite.js`
+1) Run `npm run test-sqlite`

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "jest",
+    "test-sqlite": "jest --config jest.config.sqlite.js",
     "test-coverage": "jest --coverage",
     "test-coverage-bothbackends": "jest --config jest.config.sqlite.js &&  jest --coverage",
     "clean": "rm -rf $OUTPUT_DIR",


### PR DESCRIPTION
To make it easier to run tests using an sqlite3 backend, instead of
manually passing in the `--config jest.config.sqlite.js` option, this
commit adds a `test-squlite` npm script.

Running `npm run test-sqlite` runs the test suites using an sqlite
backend.

The appropriate sections on testing in `CONTRIBUTING.md` and
`docs/HOWTO-run_tests.md` have been updated.