### PR TITLE
Update ActionKit documentation with instructions for retrieving ActionKit secret

### DIFF
--- a/docs/HOWTO_INTEGRATE_WITH_ACTIONKIT.md
+++ b/docs/HOWTO_INTEGRATE_WITH_ACTIONKIT.md
@@ -5,6 +5,7 @@
 - ACTION_HANDLERS should equal "actionkit-rsvp"
 - AK_BASEURL should be your base url from your ActionKit account
 - AK_SECRET should be your secret from your ActionKit account
+    + Refer to ActionKit's [Hashing documentation](https://docs.actionkit.com/docs/manual/developer/hashing.html#actionkit-s-hashing-system) for instructions on where to find your secret
 
 ## Step Two - making sure you have the correct data in your contacts list
 


### PR DESCRIPTION
[`HOWTO_INTEGRATE_WITH_ACTIONKIT.md`](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO_INTEGRATE_WITH_ACTIONKIT.md) specifies the use of `AK_SECRET` but does not provide information on where to find this value. ActionKit's documentation for this is a bit buried so add a direct link to it.