### PR TITLE
Sort question responses

### DIFF
--- a/src/server/api/question.js
+++ b/src/server/api/question.js
@@ -25,6 +25,7 @@ export const resolvers = {
       r.table('interaction_step')
         .filter({ parent_interaction_id: interactionStep.id })
         .filter({ is_deleted: false })
+        .orderBy('answer_option')
         .map({
           value: r.row('answer_option'),
           action: r.row('answer_actions'),


### PR DESCRIPTION
Texters develop muscle memory for the script which is disrupted when the response order changes. Responses to questions should have a consistent sort order.