### PR TITLE
Fix zip column bug

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -187,7 +187,7 @@ class AdminCampaignEdit extends React.Component {
             cell: contact.cell,
             firstName: contact.firstName,
             lastName: contact.lastName,
-            zip: contact.zip,
+            zip: contact.zip || '',
             external_id: contact.external_id || ''
           }
           Object.keys(contact).forEach((key) => {

--- a/src/server/models/custom-types.js
+++ b/src/server/models/custom-types.js
@@ -4,9 +4,9 @@ const r = thinky.r
 
 // In order to not end up with optional
 // strings that are half null and half
-// empty strings, we standardize on null for
-// optional strings and don't allow blank
-// strings
+// empty strings, we standardize on empty
+// strings for optional strings and don't
+// allow null strings
 
 export function requiredString() {
   return type


### PR DESCRIPTION
Like `external_id`, `zip` is an `optionalString` in `src/server/models/campaign-contact.js`. The way `optionalString` is defined requires an empty string rather than `null`.

This addresses #648 