### PR TITLE
#628: "Send First Texts" button disables properly

### DIFF
--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -67,7 +67,7 @@ export class AssignmentSummary extends Component {
           disabled={disabled}
           label={title}
           primary={primary && !disabled}
-          onTouchTap={() => this.goToTodos(contactsFilter, assignment.id)}
+          onClick={() => this.goToTodos(contactsFilter, assignment.id)}
         />)
     } else {
       return (<Badge
@@ -80,7 +80,7 @@ export class AssignmentSummary extends Component {
         <RaisedButton
           disabled={disabled}
           label={title}
-          onTouchTap={() => this.goToTodos(contactsFilter, assignment.id)}
+          onClick={() => this.goToTodos(contactsFilter, assignment.id)}
         />
       </Badge>)
     }
@@ -88,7 +88,7 @@ export class AssignmentSummary extends Component {
 
   render() {
     const { assignment, unmessagedCount, unrepliedCount, badTimezoneCount, totalMessagedCount, pastMessagesCount } = this.props
-    const { title, description, dueBy,
+    const { title, description, hasUnassignedContacts, dueBy,
             primaryColor, logoImageUrl, introHtml,
             useDynamicAssignment } = assignment.campaign
 
@@ -113,7 +113,7 @@ export class AssignmentSummary extends Component {
               title: 'Send first texts',
               count: unmessagedCount,
               primary: true,
-              disabled: false,
+              disabled: (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) ? true : false,
               contactsFilter: 'text',
               hideIfZero: !useDynamicAssignment
             })}


### PR DESCRIPTION
The "Send first messages" button will be disabled if all texters are assigned and unmessaged count is zero. Additionally, onTouchTap replaced with onClick because of Matrial UI and React updates.