### PR TITLE
Fix duplicate assignee names

### DIFF
--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -339,7 +339,7 @@ export default class CampaignTextersForm extends React.Component {
     return this.formValues().texters.map((texter, index) => {
       const messagedCount = texter.assignment.contactsCount - texter.assignment.needsMessageCount
       return (
-        <div className={css(styles.texterRow)}>
+        <div key={index} className={css(styles.texterRow)}>
           <div className={css(styles.leftSlider)}>
             <Slider
               maxValue={this.formValues().contactsCount}

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -1,5 +1,6 @@
 import type from 'prop-types'
 import React from 'react'
+import orderBy from 'lodash/orderBy'
 import Slider from './Slider'
 import AutoComplete from 'material-ui/AutoComplete'
 import IconButton from 'material-ui/IconButton'
@@ -240,16 +241,10 @@ export default class CampaignTextersForm extends React.Component {
   })
 
   formValues() {
+    const unorderedTexters = this.props.formValues.texters
     return {
       ...this.props.formValues,
-      texters: this.props.formValues.texters.sort((texter1, texter2) => {
-        if (texter1.firstName < texter2.firstName) {
-          return -1
-        } else if (texter1.firstName > texter2.firstName) {
-          return 1
-        }
-        return 0
-      })
+      texters: orderBy(unorderedTexters, ['firstName', 'lastName'], ['asc', 'asc'])
     }
   }
 
@@ -339,7 +334,7 @@ export default class CampaignTextersForm extends React.Component {
     return this.formValues().texters.map((texter, index) => {
       const messagedCount = texter.assignment.contactsCount - texter.assignment.needsMessageCount
       return (
-        <div key={index} className={css(styles.texterRow)}>
+        <div key={texter.id} className={css(styles.texterRow)}>
           <div className={css(styles.leftSlider)}>
             <Slider
               maxValue={this.formValues().contactsCount}

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -33,6 +33,7 @@ const campaignInfoFragment = `
   texters {
     id
     firstName
+    lastName
     assignment(campaignId:$campaignId) {
       contactsCount
       needsMessageCount: contactsCount(contactsFilter:{messageStatus:\"needsMessage\"})
@@ -621,6 +622,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         texters: people {
           id
           firstName
+          lastName
           displayName
         }
       }


### PR DESCRIPTION
Missing `key` prop causes React to get rows confused when calculating render diffs. These three texters should have different last names and assignment numbers:

![image](https://user-images.githubusercontent.com/2145526/42539107-edcc7090-8467-11e8-8b1d-33f146762043.png)

