### PR TITLE
Handle TZ defaults in case of no TZ info (432)

### DIFF
--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { Toolbar, ToolbarGroup, ToolbarTitle } from 'material-ui/Toolbar'
 import { getDisplayPhoneNumber } from '../lib/phone-format'
-import { getLocalTime } from '../lib/timezones'
+import { getLocalTime , getContactTimezone } from '../lib/timezones'
 import { grey100 } from 'material-ui/styles/colors'
 
 const inlineStyles = {
@@ -39,6 +39,9 @@ const ContactToolbar = function ContactToolbar(props) {
       offset = timezone.offset || offset
       hasDST = timezone.hasDST || hasDST
     }
+    const adjustedLocationTZ = getContactTimezone(location)
+    offset = adjustedLocationTZ.timezone.offset;
+    hasDST = adjustedLocationTZ.timezone.hasDST;
   }
 
   let formattedLocation = `${city}`

--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -40,8 +40,10 @@ const ContactToolbar = function ContactToolbar(props) {
       hasDST = timezone.hasDST || hasDST
     }
     const adjustedLocationTZ = getContactTimezone(location)
-    offset = adjustedLocationTZ.timezone.offset;
-    hasDST = adjustedLocationTZ.timezone.hasDST;
+    if (adjustedLocationTZ && adjustedLocationTZ.timezone) {
+      offset = adjustedLocationTZ.timezone.offset;
+      hasDST = adjustedLocationTZ.timezone.hasDST;
+    }
   }
 
   let formattedLocation = `${city}`

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -30,6 +30,8 @@ import { withRouter } from 'react-router'
 import wrapMutations from './hoc/wrap-mutations'
 import Empty from '../components/Empty'
 import CreateIcon from 'material-ui/svg-icons/content/create'
+import { getContactTimezone } from '../lib/timezones'
+
 
 const styles = StyleSheet.create({
   mobile: {
@@ -511,7 +513,11 @@ export class AssignmentTexterContact extends React.Component {
       const { hasDST, offset } = contact.location.timezone
 
       timezoneData = { hasDST, offset }
+     } else {
+        const { hasDST, offset } = getContactTimezone(location).timezone
+        timezoneData = { hasDST, offset }
     }
+
     const { textingHoursStart, textingHoursEnd, textingHoursEnforced } = campaign.organization
     const config = {
       textingHoursStart,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -32,7 +32,6 @@ import Empty from '../components/Empty'
 import CreateIcon from 'material-ui/svg-icons/content/create'
 import { getContactTimezone } from '../lib/timezones'
 
-
 const styles = StyleSheet.create({
   mobile: {
     '@media(min-width: 425px)': {
@@ -518,8 +517,7 @@ export class AssignmentTexterContact extends React.Component {
         if (location) {
           let timezone = location.timezone
           if (timezone) {
-            const { hasDST, offset } = timezone
-            timezoneData = { hasDST, offset }
+              timezoneData = timezone
           }
         }
     }

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -514,8 +514,14 @@ export class AssignmentTexterContact extends React.Component {
 
       timezoneData = { hasDST, offset }
      } else {
-        const { hasDST, offset } = getContactTimezone(location).timezone
-        timezoneData = { hasDST, offset }
+        let location = getContactTimezone(contact.location)
+        if (location) {
+          let timezone = location.timezone
+          if (timezone) {
+            const { hasDST, offset } = timezone
+            timezoneData = { hasDST, offset }
+          }
+        }
     }
 
     const { textingHoursStart, textingHoursEnd, textingHoursEnforced } = campaign.organization

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -12,6 +12,28 @@ const TIMEZONE_CONFIG = {
   }
 }
 
+export const getContactTimezone = (location) => {
+
+  if (location.timezone == null || location.timezone.offset == null) {
+    let timezoneData = null;
+    let offset;
+    let hasDST;
+
+    if (getProcessEnvTz()) {
+      offset = moment().tz(getProcessEnvTz()).format('Z');
+      isDst =  moment().isDST();
+      timezoneData = {offset, hasDST}
+    } else {
+      offset = TIMEZONE_CONFIG.missingTimeZone.offset
+      hasDST = TIMEZONE_CONFIG.missingTimeZone.hasDST
+      timezoneData = {offset, hasDST}
+    }
+    location.timezone = timezoneData
+  }
+  return location;
+}
+
+
 export const getLocalTime = (offset, hasDST) => {
   return moment().utc().utcOffset(DstHelper.isDateDst(new Date(), getProcessEnvDstReferenceTimezone()) && hasDST ? offset + 1 : offset)
 }

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -20,8 +20,8 @@ export const getContactTimezone = (location) => {
     let hasDST;
 
     if (getProcessEnvTz()) {
-      offset = moment().tz(getProcessEnvTz()).format('Z');
-      isDst =  moment().isDST();
+      offset = moment().tz(getProcessEnvTz()).format('Z')
+      hasDST =  moment().isDST()
       timezoneData = {offset, hasDST}
     } else {
       offset = TIMEZONE_CONFIG.missingTimeZone.offset


### PR DESCRIPTION
Fix for https://github.com/MoveOnOrg/Spoke/issues/432

- Introduced new helper method getContactTimezone (in /lib/timezones.js), which determines if there is timezone info available. If so, just return it. If not, try using the process.env.TZ info.  If that's not available, use the fallback timezone config.  Between these two options, the timezone info will always be populated.
- Called getContactTimezone from ContactToolbar and AssignmentTexterContact to handle possible missing timezone info
 