### PR TITLE
Lock pending messages while sending

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "redux": "^3.7.2",
     "redux-thunk": "^2.1.0",
     "request": "^2.81.0",
-    "rethink-knex-adapter": "^0.4.11",
+    "rethink-knex-adapter": "^0.4.12",
     "rollbar": "^0.6.2",
     "thinky": "^2.3.3",
     "timezonecomplete": "^5.5.0",

--- a/src/server/api/lib/fakeservice.js
+++ b/src/server/api/lib/fakeservice.js
@@ -6,12 +6,16 @@ import { log } from '../../../lib'
 // that end up just in the db appropriately and then using sendReply() graphql
 // queries for the reception (rather than a real service)
 
-async function sendMessage(message) {
+async function sendMessage(message, trx) {
+  let options = { conflict: 'update' }
+  if (trx) {
+    options.transaction = trx
+  }
   return Message.save({ ...message,
                         send_status: 'SENT',
                         service: 'fakeservice',
                         sent_at: new Date()
-                      }, { conflict: 'update' })
+                      }, options)
     .then((saveError, newMessage) => newMessage)
 }
 

--- a/src/server/api/lib/services.js
+++ b/src/server/api/lib/services.js
@@ -3,7 +3,7 @@ import twilio from './twilio'
 import fakeservice from './fakeservice'
 
 // Each service needs the following api points:
-// async sendMessage(message) -> void
+// async sendMessage(message, trx) -> void
 // To receive messages from the outside, you will probably need to implement these, as well:
 // async handleIncomingMessage(<native message format>) -> saved (new) messagePart.id
 // async convertMessagePartsToMessage(messagePartsGroupedByMessage) -> new Message() <unsaved>

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -109,12 +109,13 @@ function parseMessageText(message) {
   return params
 }
 
-async function sendMessage(message) {
+async function sendMessage(message, trx) {
   if (!twilio) {
     log.warn('cannot actually send SMS message -- twilio is not fully configured:', message.id)
     if (message.id) {
+      const options = trx ? { transaction: trx } : {}
       await Message.get(message.id)
-        .update({ send_status: 'SENT', sent_at: new Date() })
+        .update({ send_status: 'SENT', sent_at: new Date() }, options)
     }
     return 'test_message_uuid'
   }
@@ -158,18 +159,26 @@ async function sendMessage(message) {
         if (messageToSave.service_response.split(SENT_STRING).length >= MAX_SEND_ATTEMPTS + 1) {
           messageToSave.send_status = 'ERROR'
         }
-        Message.save(messageToSave, { conflict: 'update' })
+        let options = { conflict: 'update' }
+        if (trx) {
+          options.transaction = trx
+        }
+        Message.save(messageToSave, options)
         // eslint-disable-next-line no-unused-vars
         .then((_, newMessage) => {
           reject(err || (response ? new Error(JSON.stringify(response)) : new Error('Encountered unknown error')))
         })
       } else {
+        let options = { conflict: 'update' }
+        if (trx) {
+          options.transaction = trx
+        }
         Message.save({
           ...messageToSave,
           send_status: 'SENT',
           service: 'twilio',
           sent_at: new Date()
-        }, { conflict: 'update' })
+        }, options)
         .then((saveError, newMessage) => {
           resolve(newMessage)
         })

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -606,7 +606,7 @@ export async function sendMessages(queryFunc, defaultStatus) {
           const service = serviceMap[message.service]
           log.info(`Sending (${message.service}): ${message.user_number} -> ${message.contact_number}\nMessage: ${message.text}`)
           // TODO: pass transaction to service.sendMessage
-          await service.sendMessage(message)
+          await service.sendMessage(message, trx)
           pastMessages.push(message.id)
           pastMessages = pastMessages.slice(-100) // keep the last 100
         }

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -592,7 +592,8 @@ export async function sendMessages(queryFunc, defaultStatus) {
     if (queryFunc) {
       messageQuery = queryFunc(messageQuery)
     }
-    await messageQuery.orderBy('created_at')
+
+    messageQuery.orderBy('created_at')
       .then((messages) => {
         for (let index = 0; index < messages.length; index++) {
           let message = messages[index]

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -594,8 +594,8 @@ export async function sendMessages(queryFunc, defaultStatus) {
         messageQuery = queryFunc(messageQuery)
       }
 
-      const messages = await messageQuery.orderBy('created_at')
       try {
+        const messages = await messageQuery.orderBy('created_at')
         for (let index = 0; index < messages.length; index++) {
           let message = messages[index]
           if (pastMessages.indexOf(message.id) !== -1) {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -614,7 +614,6 @@ export async function sendMessages(queryFunc, defaultStatus) {
           message.service = message.service || process.env.DEFAULT_SERVICE
           const service = serviceMap[message.service]
           log.info(`Sending (${message.service}): ${message.user_number} -> ${message.contact_number}\nMessage: ${message.text}`)
-          // TODO: pass transaction to service.sendMessage
           await service.sendMessage(message, trx)
           pastMessages.push(message.id)
           pastMessages = pastMessages.slice(-100) // keep the last 100

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -584,7 +584,7 @@ let pastMessages = []
 
 export async function sendMessages(queryFunc, defaultStatus) {
   try {
-    await knex.transaction(trx => {
+    await knex.transaction(async trx => {
       let messageQuery = r.knex('message')
         .transacting(trx)
         .forUpdate()


### PR DESCRIPTION
This is to address concurrency problems where multiple workers each end up sending all `PENDING`/`QUEUED` messages.