### PR TITLE
Attribute messages to the texter who hits send

### DIFF
--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -129,7 +129,8 @@ const migrations = [
     date: '2018-07-16',
     migrate: async function() {
       await r.knex.schema.alterTable('message', (table) => {
-        table.integer('user_id').unsigned()
+        table.integer('user_id').unsigned().nullable().default(null)
+          .index().references('id').inTable('user')
       })
       console.log('added user_id column to message table')
     }

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -124,7 +124,17 @@ const migrations = [
       })
       console.log('added log table')
     }
-  }
+  },
+  { auto: true, // 11
+    date: '2018-07-14',
+    // eslint-disable-next-line
+    migrate: async function() {
+      await r.knex.schema.alterTable('message', (table) => {
+        table.integer('user_id').unsigned().index().references('id').inTable('user')
+      })
+      console.log('added user_id column to message table')
+    }
+   }
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically
       date: '2017-08-23',

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -124,17 +124,7 @@ const migrations = [
       })
       console.log('added log table')
     }
-  },
-  { auto: true, // 11
-    date: '2018-07-14',
-    // eslint-disable-next-line
-    migrate: async function() {
-      await r.knex.schema.alterTable('message', (table) => {
-        table.integer('user_id').unsigned().index().references('id').inTable('user')
-      })
-      console.log('added user_id column to message table')
-    }
-   }
+  }
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically
       date: '2017-08-23',

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -124,6 +124,15 @@ const migrations = [
       })
       console.log('added log table')
     }
+  },
+  { auto: true, // 11
+    date: '2018-07-16',
+    migrate: async function() {
+      await r.knex.schema.alterTable('message', (table) => {
+        table.integer('user_id').unsigned()
+      })
+      console.log('added user_id column to message table')
+    }
   }
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1083,6 +1083,7 @@ const rootMutations = {
       const messageInstance = new Message({
         text: replaceCurlyApostrophes(text),
         contact_number: contactNumber,
+        user_id: campaignContactId,
         user_number: '',
         assignment_id: message.assignmentId,
         send_status: JOBS_SAME_PROCESS ? 'SENDING' : 'QUEUED',

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1023,7 +1023,7 @@ const rootMutations = {
 
       return []
     },
-    sendMessage: async (_, { message, campaignContactId }, { loaders }) => {
+    sendMessage: async (_, { message, campaignContactId }, { user, loaders }) => {
       const contact = await loaders.campaignContact.load(campaignContactId)
       const campaign = await loaders.campaign.load(contact.campaign_id)
       if (contact.assignment_id !== parseInt(message.assignmentId) || campaign.is_archived) {
@@ -1083,7 +1083,7 @@ const rootMutations = {
       const messageInstance = new Message({
         text: replaceCurlyApostrophes(text),
         contact_number: contactNumber,
-        user_id: campaignContactId,
+        user_id: user.id,
         user_number: '',
         assignment_id: message.assignmentId,
         send_status: JOBS_SAME_PROCESS ? 'SENDING' : 'QUEUED',

--- a/src/server/models/message.js
+++ b/src/server/models/message.js
@@ -2,10 +2,14 @@ import thinky from './thinky'
 const type = thinky.type
 import { requiredString, optionalString, timestamp } from './custom-types'
 
+import User from './user'
 import Assignment from './assignment'
 
 const Message = thinky.createModel('message', type.object().schema({
   id: type.string(),
+  // Assignments may change, so attribute the message to the specific
+  // texter account that sent it
+  user_id: requiredString(),
   // theoretically the phone number
   // userNumber should stay constant for a
   // texter, but this is not guaranteed
@@ -28,9 +32,10 @@ const Message = thinky.createModel('message', type.object().schema({
   sent_at: timestamp(),
   service_response_at: timestamp()
 }, {
-  dependencies: [Assignment]
+  dependencies: [User, Assignment]
 }).allowExtra(false))
 
+Message.ensureIndex('user_id')
 Message.ensureIndex('assignment_id')
 Message.ensureIndex('send_status')
 Message.ensureIndex('user_number')

--- a/src/server/models/message.js
+++ b/src/server/models/message.js
@@ -2,13 +2,14 @@ import thinky from './thinky'
 const type = thinky.type
 import { requiredString, optionalString, timestamp } from './custom-types'
 
+import User from './user'
 import Assignment from './assignment'
 
 const Message = thinky.createModel('message', type.object().schema({
   id: type.string(),
   // Assignments may change, so attribute the message to the specific
   // texter account that sent it
-  user_id: optionalString().stopReference(),
+  user_id: type.string().allowNull(true),
   // theoretically the phone number
   // userNumber should stay constant for a
   // texter, but this is not guaranteed
@@ -31,9 +32,10 @@ const Message = thinky.createModel('message', type.object().schema({
   sent_at: timestamp(),
   service_response_at: timestamp()
 }, {
-  dependencies: [Assignment]
+  dependencies: [User, Assignment]
 }).allowExtra(false))
 
+Message.ensureIndex('user_id')
 Message.ensureIndex('assignment_id')
 Message.ensureIndex('send_status')
 Message.ensureIndex('user_number')

--- a/src/server/models/message.js
+++ b/src/server/models/message.js
@@ -2,14 +2,13 @@ import thinky from './thinky'
 const type = thinky.type
 import { requiredString, optionalString, timestamp } from './custom-types'
 
-import User from './user'
 import Assignment from './assignment'
 
 const Message = thinky.createModel('message', type.object().schema({
   id: type.string(),
   // Assignments may change, so attribute the message to the specific
   // texter account that sent it
-  user_id: requiredString(),
+  user_id: optionalString().stopReference(),
   // theoretically the phone number
   // userNumber should stay constant for a
   // texter, but this is not guaranteed
@@ -32,10 +31,9 @@ const Message = thinky.createModel('message', type.object().schema({
   sent_at: timestamp(),
   service_response_at: timestamp()
 }, {
-  dependencies: [User, Assignment]
+  dependencies: [Assignment]
 }).allowExtra(false))
 
-Message.ensureIndex('user_id')
 Message.ensureIndex('assignment_id')
 Message.ensureIndex('send_status')
 Message.ensureIndex('user_number')


### PR DESCRIPTION
Now that we have introduced campaign contact re-assignment, the `user_id` of the assignment is no longer a valid way to determine which user actually hit send. This is important for quality control, especially in largely volunteer-driven campaigns where bad actors may sign up to volunteer with little to no vetting.