### PR TITLE
Backwards compatibility for roles query

### DIFF
--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -7,3 +7,6 @@ export const hasRoleAtLeast = (hasRole, wantsRole) => (ROLE_HIERARCHY.indexOf(ha
 export const getHighestRole = (roles) => roles.sort(isRoleGreater)[roles.length - 1]
 
 export const hasRole = (role, roles) => hasRoleAtLeast(getHighestRole(roles), role)
+
+// Return array of roles at least as high as the role argument
+export const rolesAtLeast = (role) => ROLE_HIERARCHY.slice(ROLE_HIERARCHY.indexOf(role), ROLE_HIERARCHY.length)

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -34,13 +34,15 @@ export const resolvers = {
       if (!user || !user.id) {
         return []
       }
-      let orgs = r.knex('user_organization')
-        .where({ user_id: user.id })
+      let orgs = r.knex.select('organization.*')
+        .from('organization')
+        .join('user_organization', 'organization.id', 'user_organization.organization_id')
+        .where('user_organization.user_id', user.id)
       if (role) {
         const matchingRoles = rolesAtLeast(role)
-        orgs = orgs.whereIn('role', matchingRoles)
+        orgs = orgs.whereIn('user_organization.role', matchingRoles)
       }
-      return orgs.rightJoin('organization', 'user_organization.organization_id', 'organization.id').distinct()
+      return orgs.distinct()
     },
     roles: async(user, { organizationId }) => (
       r.table('user_organization')


### PR DESCRIPTION
As new roles are introduced, the [initial set of roles](https://github.com/MoveOnOrg/Spoke/blob/main/src/server/api/schema.js#L847-L853) created for a user/organization may become out of date. This currently requires explicit calls to the `editOrganizationRoles` mutation to correct the set of roles. Instead, check for all roles as high or higher than the requested role.

Specifically, this was causing problems when visiting the site index. Admins were getting a message that they didn't belong to any organizations and had to manually fix the URL.

Also includes query refactor to use knex.