### PR TITLE
[WIP] Convert SQLite's unix timestamp to date/time format

### DIFF
--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -1,3 +1,4 @@
+import moment from 'moment'
 import { mapFieldsToModel } from './lib/utils'
 import { r, Organization } from '../models'
 import { accessRequired } from './errors'
@@ -19,7 +20,15 @@ export const resolvers = {
         campaignsFilter
       )
       query = query.orderBy('due_by', 'desc')
-      return query
+      let results = await query
+      results = results.map(result => {
+        // Convert unix timestamp to date/time format
+        if (!isNaN(result.due_by)) {
+          const unixTimestamp = result.due_by
+          result.due_by = moment(unixTimestamp).utc().format('YYYY-MM-DD HH:mm:ss')
+        }
+      })
+      return results
     },
     uuid: async (organization, _, { user }) => {
       await accessRequired(user, organization.id, 'SUPERVOLUNTEER')

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -1,4 +1,3 @@
-import moment from 'moment'
 import { mapFieldsToModel } from './lib/utils'
 import { r, Organization } from '../models'
 import { accessRequired } from './errors'
@@ -25,8 +24,9 @@ export const resolvers = {
         // Convert unix timestamp to date/time format
         if (!isNaN(result.due_by)) {
           const unixTimestamp = result.due_by
-          result.due_by = moment(unixTimestamp).utc().format('YYYY-MM-DD HH:mm:ss')
+          result.due_by = new Date(unixTimestamp)
         }
+        return result
       })
       return results
     },


### PR DESCRIPTION
SQLite bug due to differences in how `date` vs `timestamp` are stored in Postgres vs SQLite:
```js
// https://github.com/MoveOnOrg/Spoke/blob/stage-main/src/server/models/campaign.js#L15-L19

  due_by: type
    .date()
    .required()
    .default(null),
  created_at: timestamp(),
```

<details open>
<summary>Logging the `campaigns` resolver for an organization returns:</summary>

```
[ { id: 2,
    organization_id: 2,
    title: 'Date Format Errors',
    description: 'Does this error with SQLite?',
    is_started: 0,
    due_by: 1532995200000,
    created_at: '2018-07-19 15:36:46',
    is_archived: 0,
    use_dynamic_assignment: null,
    logo_image_url: '',
    intro_html: null,
    primary_color: null } ]
TypeError: Field error: value is not an instance of Date
```
</details>

<details open>
<summary>Whereas Postgres returns:</summary>

```
anonymous {
  id: 79,
  organization_id: 1,
  title: '[bchrobot test] Custom Fields',
  description: 'There are custom fields',
  is_started: false,
  due_by: 2018-06-30T00:00:00.000Z,
  created_at: 2018-06-25T16:35:30.139Z,
  is_archived: false,
  use_dynamic_assignment: null,
  logo_image_url: '',
  intro_html: null,
  primary_color: null } ]
```
</details>