### PR TITLE
Allow users to, at upload time, exclude contacts from existing campaigns

### DIFF
--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -49,5 +49,6 @@ export const schema = `
     textingHoursStart: Int
     textingHoursEnd: Int
     timezone: String
+    createdAt: Date
   }
 `

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -87,6 +87,7 @@ const rootSchema = `
     introHtml: String
     useDynamicAssignment: Boolean
     contacts: [CampaignContactInput]
+    excludeCampaignIds: [Int]
     contactSql: String
     organizationId: String
     texters: [TexterInput]

--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -145,10 +145,10 @@ export default class CampaignContactsForm extends React.Component {
 
     return (
       <div>
-        <p>You can also exclude contacts from existing Spoke campaigns:</p>
+        <p>You can also filter out contacts from this upload that are already uploaded to an existing Spoke campaigns (regardless of whether they have been texted yet in that campaign).</p>
         <SelectField
           multiple
-          hintText='Other campaigns'
+          hintText='Existing campaigns'
           value={selectedCampaignIds}
           onChange={this.handleCampaignExclusionChange}
         >

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -297,7 +297,7 @@ class AdminCampaignEdit extends React.Component {
     }, {
       title: 'Contacts',
       content: CampaignContactsForm,
-      keys: ['contacts', 'contactsCount', 'customFields', 'contactSql'],
+      keys: ['contacts', 'contactsCount', 'customFields', 'contactSql', 'excludeCampaignIds'],
       checkCompleted: () => this.state.campaignFormValues.contactsCount > 0,
       checkSaved: () => (
         // Must be false for save to be tried
@@ -314,7 +314,8 @@ class AdminCampaignEdit extends React.Component {
       extraProps: {
         optOuts: [], // this.props.organizationData.organization.optOuts, // <= doesn't scale
         datawarehouseAvailable: this.props.campaignData.campaign.datawarehouseAvailable,
-        jobResultMessage: ((this.props.pendingJobsData.campaign.pendingJobs.filter((job) => (/contacts/.test(job.jobType)))[0] || {}).resultMessage || '')
+        jobResultMessage: ((this.props.pendingJobsData.campaign.pendingJobs.filter((job) => (/contacts/.test(job.jobType)))[0] || {}).resultMessage || ''),
+        otherCampaigns: this.props.organizationData.organization.campaigns.filter(campaign => campaign.id != this.props.params.campaignId)
       }
     }, {
       title: 'Texters',
@@ -672,6 +673,11 @@ const mapQueriesToProps = ({ ownProps }) => ({
           firstName
           lastName
           displayName
+        }
+        campaigns {
+          id
+          title
+          createdAt
         }
       }
     }`,

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -91,7 +91,8 @@ export const resolvers = {
       'textingHoursEnforced',
       'textingHoursStart',
       'textingHoursEnd',
-      'timezone'
+      'timezone',
+      'createdAt'
     ], Campaign),
     dueBy: (campaign) => (
       (campaign.due_by instanceof Date || !campaign.due_by)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -137,7 +137,11 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
       modelData.campaign_id = id
       return modelData
     })
-    const compressedString = await gzip(JSON.stringify(contactsToSave))
+    const jobPayload = {
+      excludeCampaignIds: campaign.excludeCampaignIds || [],
+      contacts: contactsToSave
+    }
+    const compressedString = await gzip(JSON.stringify(jobPayload))
     let job = await JobRequest.save({
       queue_name: `${id}:edit_campaign`,
       job_type: 'upload_contacts',


### PR DESCRIPTION
At upload time, allow users to exclude contacts from existing campaigns. This exclusion is done server-side using the same mechanism as for filtering opt-outs.

<img width="1123" alt="screen shot 2018-07-20 at 3 58 53 pm" src="https://user-images.githubusercontent.com/2145526/43022706-26c6d874-8c36-11e8-9316-fcf83d615b6d.png">
