### PR TITLE
End to End Tests - Further Modification of the Travis CI script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
 - chmod +x ./travis-run-e2e-tests
 script:
 - npm run test-coverage
+- CC_TEST_RESULT=$?
 - ./travis-run-e2e-tests
 after_script:
-- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
+- ./cc-test-reporter after-build --exit-code $CC_TEST_RESULT

--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "regenerator-runtime": "^0.10.5",
     "selenium-webdriver": "^3.6.0",
     "sqlite3": "^3.1.9",
+    "wait-on": "^2.1.0",
     "webpack-dev-server": "^2.9.4"
   }
 }

--- a/travis-run-e2e-tests
+++ b/travis-run-e2e-tests
@@ -1,9 +1,12 @@
 #!/bin/bash
-# Run End to End tests on non-pull requests
+set -ev
+# Only run on non-pull requests
 # https://docs.travis-ci.com/user/pull-requests/#Pull-Requests-and-Security-Restrictions
-if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+  # Start dev server
   npm run dev-nowrap &
-  sleep 120
-  # TODO: Grep stdout or something to determine that the server is active. Or do this in the test setup.
+  # Wait for server availability https://github.com/jeffbski/wait-on#readme
+  wait-on -d 30000 -i 1000 -w 2000 http-get://localhost:3000
+  # Run end to end tests
   npm run test-e2e --saucelabs
 fi


### PR DESCRIPTION
# Summary 

Followup to #611 

This PR addresses an outstanding TODO in the script to launch the end to end tests. Instead of using a simple sleep, the tests will wait until a GET request to the server responds with a 2xx code.

Also includes a change to capture _only_ the test coverage result to pass into the "after-build" step

# Development Notes:

This PR introduces an additional dependency:
https://www.npmjs.com/package/wait-on

The after-build step of the code coverage report is still failing because the token isn't set as a Travis Environment Variable.
https://docs.codeclimate.com/v1.0/docs/finding-your-test-coverage-token