### PR TITLE
Fix for End to End tests

### DIFF
--- a/__test__/e2e/page-functions/campaigns.js
+++ b/__test__/e2e/page-functions/campaigns.js
@@ -56,6 +56,7 @@ export const campaigns = {
         expect(await wait.andGetValue(driver, pom.campaigns.form.texters.texterAssignmentByIndex(1)) > 0).toBeTruthy()
         // Assign (All to Texter)
         await wait.andClick(driver, pom.campaigns.form.texters.autoSplit, { elementIsVisible: false })
+        await wait.andType(driver, pom.campaigns.form.texters.texterAssignmentByIndex(0), '0')
         await wait.andType(driver, pom.campaigns.form.texters.texterAssignmentByIndex(1), campaign.texters.contactLength)
         // Validate Assignment
         expect(await wait.andGetValue(driver, pom.campaigns.form.texters.texterAssignmentByIndex(0))).toBe('0')


### PR DESCRIPTION
## Summary
This fix sets the admin assignments to zero before assigning all contacts to the texter.

## Root Cause
The logic for the inputs for assigning contacts to texters changed slightly. Now you aren't allowed to over-assign texters beyond the total number of contacts. Previously, if you did so the contacts would be unassigned from other texters.

## Run
`npm run test-e2e`