### PR TITLE
Switching to lodash

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -4,7 +4,7 @@ import Paper from 'material-ui/Paper'
 import { List, ListItem } from 'material-ui/List'
 import Divider from 'material-ui/Divider'
 import { withRouter } from 'react-router'
-import camelCase from 'camelcase'
+import _ from 'lodash'
 import { dataTest } from '../lib/attributes'
 
 const Navigation = function Navigation(props) {
@@ -21,7 +21,7 @@ const Navigation = function Navigation(props) {
       <List>
         {sections.map((section) => (
           <ListItem
-            {...dataTest(camelCase(`nav ${section.path}`))}
+            {...dataTest(_.camelCase(`nav ${section.path}`))}
             key={section.name}
             primaryText={section.name}
             onTouchTap={() => props.router.push(section.url)}


### PR DESCRIPTION
we can move to something different (off camelCasing convention), but this should help with heroku deployment errors