### PR TITLE
fix ambiguous user_id error

### DIFF
--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -47,7 +47,7 @@ export const resolvers = {
     ),
     todos: async (user, { organizationId }) =>
       r.table('assignment')
-        .getAll(user.id, { index: 'user_id' })
+        .getAll(user.id, { index: 'assignment.user_id' })
         .eqJoin('campaign_id', r.table('campaign'))
         .filter({ 'is_started': true,
                  'organization_id': organizationId,


### PR DESCRIPTION
@schuyler1d  @shakalee14   We probably want to merge this soon, because it fixes an error that exists on main.

This is a fix for the following error encountered on branch main when opening texted view.

In the debugger:

`select "assignment"."id", "assignment"."user_id", "assignment"."campaign_id", "assignment"."created_at", "assignment"."max_contacts" from "assignment" inner join "campaign" on "assignment"."campaign_id" = "campaign"."id" where "user_id" = $1 and "is_started" = $2 and "organization_id" = $3 and "is_archived" = $4 - column reference "user_id" is ambiguous`

In the log:

```
error: column reference "user_id" is ambiguous
    at Connection.parseE (/Users/larryperson/personal_code/Spoke/node_modules/pg/lib/connection.js:567:11)
    at Connection.parseMessage (/Users/larryperson/personal_code/Spoke/node_modules/pg/lib/connection.js:391:17)
    at Socket.<anonymous> (/Users/larryperson/personal_code/Spoke/node_modules/pg/lib/connection.js:129:22)
    at emitOne (events.js:96:13)
    at Socket.emit (events.js:188:7)
    at readableAddChunk (_stream_readable.js:176:18)
    at Socket.Readable.push (_stream_readable.js:134:10)
    at TCP.onread (net.js:547:20)
From previous event:
    at Client_PG._query (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/dialects/postgres/index.js:260:12)
    at Client_PG.query (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/client.js:202:17)
    at Runner.<anonymous> (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/runner.js:146:36)
From previous event:
    at /Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/runner.js:48:21
From previous event:
    at Runner.run (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/runner.js:34:31)
    at Builder.Target.then (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/knex/lib/interface.js:20:43)
    at Object.then (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/query.js:158:29)
    at Object._send (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/query.js:557:22)
    at /Users/larryperson/personal_code/Spoke/node_modules/rethinkdbdash/lib/term.js:202:22
    at tryCatcher (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromiseAtPostResolution (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/promise.js:245:10)
    at Async._drainQueue (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/async.js:128:12)
    at Async._drainQueues (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues (/Users/larryperson/personal_code/Spoke/node_modules/rethink-knex-adapter/node_modules/bluebird/js/main/async.js:15:14)
    at runCallback (timers.js:672:20)
    at tryOnImmediate (timers.js:645:5)
    at processImmediate [as _immediateCallback] (timers.js:617:5)
```
