### PR TITLE
decouple contact loading (for #813 )

### DIFF
--- a/__test__/containers/AssignmentTexterContact.test.js
+++ b/__test__/containers/AssignmentTexterContact.test.js
@@ -60,27 +60,16 @@ const propsWithEnforcedTextingHoursCampaign = {
     campaign: campaign,
     contacts: [
       {
-        id: 19,
-        customFields: "{}"
-      },
-      {
-        id: 20,
-        customFields: "{}"
-      }
-    ],
-    allContacts: [
-      {
         id: 19
       },
       {
         id: 20
       }
     ],
+    allContactsCount: 2,
   },
   refreshData: jest.fn(),
-  data: {
-    loading: false,
-    contact: {
+  contact: {
       id: 19,
       assignmentId: 9,
       firstName: "larry",
@@ -101,7 +90,6 @@ const propsWithEnforcedTextingHoursCampaign = {
       },
       messageStatus: "needsMessage",
       messages: []
-    }
   }
 }
 
@@ -121,7 +109,7 @@ describe('when contact is not within texting hours...', () => {
           campaign={campaign}
           assignment={propsWithEnforcedTextingHoursCampaign.assignment}
           refreshData={propsWithEnforcedTextingHoursCampaign.refreshData}
-          data={propsWithEnforcedTextingHoursCampaign.data}
+          contact={propsWithEnforcedTextingHoursCampaign.contact}
         />
       </MuiThemeProvider>
     )
@@ -144,7 +132,7 @@ describe('when contact is within texting hours...', () => {
           campaign={campaign}
           assignment={propsWithEnforcedTextingHoursCampaign.assignment}
           refreshData={propsWithEnforcedTextingHoursCampaign.refreshData}
-          data={propsWithEnforcedTextingHoursCampaign.data}
+          contact={propsWithEnforcedTextingHoursCampaign.contact}
         />
       </MuiThemeProvider>
     )

--- a/docs/EXPLANATION-development-guidelines.md
+++ b/docs/EXPLANATION-development-guidelines.md
@@ -124,6 +124,19 @@ we want to add a value to campaign info for that edit page. We might need to edi
   see called in files like `src/server/api/campaign.js`
 * In `campaign.js` note that you will need to update `type Campaign` above, and possibly lower down in `Campaign: { ...mapFieldsToModel([...` (but only if it's a new field/column on the campaign table.
 
+### Security and Access-control
+
+* Roles are assigned per-organization. Users can be assigned a cross-organizational property called 'superadmin' which is limited for
+  actions that could undermine the security of the system or access system-level data.
+* Security for top-level graphQL queries are in rootResolvers.RootQuery object in [server/api/schema.js](https://github.com/MoveOnOrg/Spoke/blob/dec93521d54ea46476d2a5c7eb9deeedbd69d53f/src/server/api/schema.js#L1122)
+  * These correspond to e.g. getContact or getOrganization, etc
+* Mutations and custom queries are inside the method
+* Helper functions are in [server/api/errors.js](https://github.com/MoveOnOrg/Spoke/blob/main/src/server/api/errors.js) which should/will be optimized to use cached info, etc.  Each of them will throw an error and therefore cancel the request if the user doesn't have the appropriate access.
+  * `authRequired(user)` establishes that the user is not anonymous
+  * `accessRequired(user, orgId, role, allowSuperadmin = false)` will require the user to have a certain role or higher.  Pass in `true` to allowSuperadmin if superadmins should be allowed.  Generally they should be allowed to do things, but might as well be explicit.
+  * `assignmentRequired(user, assignmentId)` makes sure that the user has the assignment in question
+  * `superAdminRequired(user)` requires a super-admin user
+
 
 ## Asynchronous tasks (workers)
 

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -196,6 +196,7 @@ const rootSchema = `
     archiveCampaign(id:String!): Campaign,
     unarchiveCampaign(id:String!): Campaign,
     sendReply(id: String!, message: String!): CampaignContact
+    getAssignmentContacts(assignmentId: String!, contactIds: [String], findNew: Boolean): [CampaignContact],
     findNewCampaignContact(assignmentId: String!, numberContacts: Int!): FoundContact,
     assignUserToCampaign(organizationUuid: String!, campaignId: String!): Campaign
     userAgreeTerms(userId: String!): User

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -42,13 +42,6 @@ class AssignmentTexter extends React.Component {
 
   componentWillMount() {
     this.updateCurrentContactIndex(0)
-    const self = this
-    this.refreshInterval = setInterval(() => self.props.refreshData(), 20000)
-  }
-  componentWillUnmount() {
-    if (this.refreshInterval) {
-      clearInterval(this.refreshInterval)
-    }
   }
 
   componentWillUpdate(nextProps, nextState) {

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -180,7 +180,7 @@ export class AssignmentTexterContact extends React.Component {
     super(props)
 
     const { assignment, campaign } = this.props
-    const { contact } = this.props.data
+    const { contact } = this.props
     const questionResponses = this.getInitialQuestionResponses(contact.questionResponseValues)
     const availableSteps = this.getAvailableInteractionSteps(questionResponses)
 
@@ -223,7 +223,7 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   componentDidMount() {
-    const { contact } = this.props.data
+    const { contact } = this.props
     if (contact.optOut) {
       this.skipContact()
     } else if (!this.isContactBetweenTextingHours(contact)) {
@@ -290,8 +290,7 @@ export class AssignmentTexterContact extends React.Component {
     return questionResponses
   }
   getMessageTextFromScript(script) {
-    const { data, campaign, texter } = this.props
-    const { contact } = data
+    const { campaign, contact, texter } = this.props
 
     return script ? applyScript({
       contact,
@@ -302,7 +301,7 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   getStartingMessageText() {
-    const { contact } = this.props.data
+    const { contact } = this.props
     const { messages } = contact
     return messages.length > 0 ? '' : this.getMessageTextFromScript(contact.currentInteractionStepScript)
   }
@@ -327,7 +326,7 @@ export class AssignmentTexterContact extends React.Component {
 
   createMessageToContact(text) {
     const { texter, assignment } = this.props
-    const { contact } = this.props.data
+    const { contact } = this.props
 
     return {
       contactNumber: contact.cell,
@@ -376,7 +375,7 @@ export class AssignmentTexterContact extends React.Component {
 
   handleMessageFormSubmit = async ({ messageText }) => {
     try {
-      const { contact } = this.props.data
+      const { contact } = this.props
       const message = this.createMessageToContact(messageText)
       if (this.state.disabled) {
         return // stops from multi-send
@@ -392,7 +391,7 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   handleSubmitSurveys = async () => {
-    const { contact } = this.props.data
+    const { contact } = this.props
 
     const deletionIds = []
     const questionResponseObjects = []
@@ -429,13 +428,13 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   handleEditMessageStatus = async (messageStatus) => {
-    const { contact } = this.props.data
+    const { contact } = this.props
     await this.props.mutations.editCampaignContactMessageStatus(messageStatus, contact.id)
   }
 
   handleOptOut = async () => {
     const optOutMessageText = this.state.optOutMessageText
-    const { contact } = this.props.data
+    const { contact } = this.props
     const { assignment } = this.props
     const message = this.createMessageToContact(optOutMessageText)
     if (this.state.disabled) {
@@ -497,7 +496,7 @@ export class AssignmentTexterContact extends React.Component {
 
   handleClickSendMessageButton = () => {
     this.refs.form.submit()
-    if (this.props.data.contact.messageStatus === 'needsMessage') {
+    if (this.props.contact.messageStatus === 'needsMessage') {
       this.setState({ justSentNew: true })
     }
   }
@@ -550,7 +549,7 @@ export class AssignmentTexterContact extends React.Component {
   handleMessageFormChange = ({ messageText }) => this.setState({ messageText })
 
   renderMiddleScrollingSection() {
-    const { contact } = this.props.data
+    const { contact } = this.props
     return (
       <MessageList
         contact={contact}
@@ -560,7 +559,7 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   renderSurveySection() {
-    const { contact } = this.props.data
+    const { contact } = this.props
     const { messages } = contact
 
     const { questionResponses } = this.state
@@ -603,9 +602,8 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   renderActionToolbar() {
-    const { data, campaign, assignment, navigationToolbarChildren, onFinishContact } = this.props
+    const { contact, campaign, assignment, navigationToolbarChildren, onFinishContact } = this.props
     const { justSentNew } = this.state
-    const { contact } = data
     const { messageStatus } = contact
     const size = document.documentElement.clientWidth
 
@@ -707,7 +705,7 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   renderTopFixedSection() {
-    const { contact } = this.props.data
+    const { contact } = this.props
     return (
       <ContactToolbar
         campaignContact={contact}
@@ -789,7 +787,7 @@ export class AssignmentTexterContact extends React.Component {
 
   renderCorrectSendButton() {
     const { campaign } = this.props
-    const { contact } = this.props.data
+    const { contact } = this.props
     if (contact.messageStatus === 'messaged' || contact.messageStatus === 'convo' || contact.messageStatus === 'needsResponse') {
       return (
         <SendButtonArrow
@@ -850,7 +848,7 @@ export class AssignmentTexterContact extends React.Component {
           </div>
         ) : ''
         }
-        <div className={css(styles.container)} style={this.props.data.contact.messageStatus === 'needsResponse' ? { backgroundColor: 'rgba(83, 180, 119, 0.25)' } : {}}>
+        <div className={css(styles.container)} style={this.props.contact.messageStatus === 'needsResponse' ? { backgroundColor: 'rgba(83, 180, 119, 0.25)' } : {}}>
           <div className={css(styles.topFixedSection)}>
             {this.renderTopFixedSection()}
           </div>
@@ -884,56 +882,10 @@ AssignmentTexterContact.propTypes = {
   navigationToolbarChildren: PropTypes.array,
   onFinishContact: PropTypes.func,
   router: PropTypes.object,
-  data: PropTypes.object,
   mutations: PropTypes.object,
   onExitTexter: PropTypes.func,
   onRefreshAssignmentContacts: PropTypes.func
 }
-
-const mapQueriesToProps = ({ ownProps }) => ({
-  data: {
-    // These fields are needed for possibly filling in script values
-    query: gql`query getContact($campaignContactId: String!) {
-      contact(id: $campaignContactId) {
-        id
-        assignmentId
-        firstName
-        lastName
-        cell
-        zip
-        customFields
-        optOut {
-          id
-          createdAt
-        }
-        currentInteractionStepScript
-        questionResponseValues {
-          interactionStepId
-          value
-        }
-        location {
-          city
-          state
-          timezone {
-            offset
-            hasDST
-          }
-        }
-        messageStatus
-        messages {
-          id
-          createdAt
-          text
-          isFromContact
-        }
-      }
-    }`,
-    variables: {
-      campaignContactId: ownProps.campaignContactId
-    },
-    forceFetch: true
-  }
-})
 
 const mapMutationsToProps = () => ({
   createOptOut: (optOut, campaignContactId) => ({
@@ -1029,6 +981,5 @@ const mapMutationsToProps = () => ({
 
 export default loadData(wrapMutations(
   withRouter(AssignmentTexterContact)), {
-    mapQueriesToProps,
     mapMutationsToProps
   })

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -170,7 +170,8 @@ const mapQueriesToProps = ({ ownProps }) => ({
       },
       assignmentId: ownProps.params.assignmentId
     },
-    forceFetch: true
+    forceFetch: true,
+    pollInterval: 20000
   }
 })
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -71,7 +71,6 @@ export const resolvers = {
       'id',
       'title',
       'description',
-      'dueBy',
       'isStarted',
       'isArchived',
       'useDynamicAssignment',
@@ -79,6 +78,11 @@ export const resolvers = {
       'primaryColor',
       'logoImageUrl'
     ], Campaign),
+    dueBy: (campaign) => (
+      (typeof campaign.due_by === 'number')
+      ? new Date(campaign.due_by)
+      : campaign.due_by
+    ),
     organization: async (campaign, _, { loaders }) => (
       loaders.organization.load(campaign.organization_id)
     ),

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -700,7 +700,21 @@ const rootMutations = {
       contact.message_status = messageStatus
       return await contact.save()
     },
-
+    getAssignmentContacts: async (_, { assignmentId, contactIds, findNew }, { loaders, user }) => {
+      assignmentRequired(user, assignmentId)
+      const contacts = contactIds.map(async (contactId) => {
+        const contact = await loaders.campaignContact.load(contactId)
+        if (contact && contact.assignment_id === Number(assignmentId)) {
+          return contact
+        }
+        return null
+      })
+      if (findNew) {
+        // maybe TODO: we could automatically add dynamic assignments in the same api call
+        // findNewCampaignContact()
+      }
+      return contacts
+    },
     findNewCampaignContact: async (_, { assignmentId, numberContacts }, { loaders, user }) => {
       /* This attempts to find a new contact for the assignment, in the case that useDynamicAssigment == true */
       const assignment = await Assignment.get(assignmentId)

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -23,8 +23,16 @@ import Log from './log'
 import thinky from './thinky'
 import datawarehouse from './datawarehouse'
 
-function createLoader(model, idKey = 'id') {
+const r = thinky.r
+
+function createLoader(model, idKey = 'id', cacheFunction) {
   return new DataLoader(async (keys) => {
+    if (cacheFunction && r.redis) {
+      const cachedData = await cacheFunction(keys)
+      if (cachedData) {
+        return cachedData
+      }
+    }
     const docs = await model.getAll(...keys, { index: idKey })
     return keys.map((key) => (
       docs.find((doc) => doc[idKey].toString() === key.toString())
@@ -52,8 +60,6 @@ const createLoaders = () => ({
   userCell: createLoader(UserCell),
   userOrganization: createLoader(UserOrganization)
 })
-
-const r = thinky.r
 
 export {
   createLoaders,


### PR DESCRIPTION
I believe this should complete #813 

In passing, we also fix the root cause of #452 because we need contacts and index in the TexterTodo/AssignmentTexter contexts to be reliable and not change every contact update.

This PR does three things:
* Move the api call to get contact data up to TexterTodo (and executed by AssignmentTexter) away from AssignmentTexterContact
* Instead of just gettting one contact at a time, we get 10 contacts at a time and try to load new contacts 5 contacts ahead of when we will run out of cached local data
* Before on each contact shift we refreshData'd all the assignment info, and now we will update that every 20 seconds.
