### PR TITLE
migration is not triggered when we are not creating the db

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -45,6 +45,9 @@ if (!process.env.SUPPRESS_DATABASE_AUTOCREATE) {
     if (didCreate && !process.env.SUPPRESS_SEED_CALLS) {
       seedZipCodes()
     }
+    if (!didCreate && !process.env.SUPPRESS_MIGRATIONS) {
+      runMigrations()
+    }
   })
 } else if (!process.env.SUPPRESS_MIGRATIONS) {
   runMigrations()


### PR DESCRIPTION
https://github.com/MoveOnOrg/Spoke/pull/819 introduced a bug and does not run migrations unless we are suppressing db creation completely