### PR TITLE
force display on graphQL errors

### DIFF
--- a/src/network/errors.js
+++ b/src/network/errors.js
@@ -14,7 +14,9 @@ export function graphQLErrorParser(response) {
     try {
       parsedError = JSON.parse(error.message)
     } catch (ex) {
-      parsedError = null
+      // Even if we can't parse an error messge into JSON, still render it as a string 
+      // so that we still display some error message instead of no error message at all.
+      parsedError = {status: 500, message: error.message}
     }
     if (parsedError) {
       return {


### PR DESCRIPTION
It was driving me nuts that graphQL syntax errors were getting silently eaten- this is particularly hard to debug. Looks like this is because the ApolloClient default error parser was assuming most errors to come in the form of parse-able JSON. When this isn't the case, instead of displaying generic error message on error parsing exception, still display the raw message as a string