### PR TITLE
741 default instance-wide optout message

### DIFF
--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -11,6 +11,7 @@ export const schema = `
     people(role: String): [User]
     optOuts: [OptOut]
     threeClickEnabled: Boolean
+    optOutMessage: String
     textingHoursEnforced: Boolean
     textingHoursStart: Int
     textingHoursEnd: Int

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -186,6 +186,7 @@ const rootSchema = `
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
+    updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -213,7 +213,7 @@ export class AssignmentTexterContact extends React.Component {
       snackbarError,
       snackbarActionTitle,
       snackbarOnTouchTap,
-      optOutMessageText: window.OPT_OUT_MESSAGE,
+      optOutMessageText: campaign.organization.optOutMessage,
       responsePopoverOpen: false,
       messageText: this.getStartingMessageText(),
       optOutDialogOpen: false,

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -124,23 +124,29 @@ class Settings extends React.Component {
           <CardHeader
             title='Settings'
           />
-          <GSForm
-            schema={formSchema}
-            onSubmit={this.props.mutations.updateOptOutMessage}
-            defaultValue={{ optOutMessage }}
-          >
+          <CardText>
+            <div className={css(styles.section)}>
 
-            <Form.Field 
-              label='Default Opt-Out Message' 
-              name='optOutMessage'  
-            />
+            <GSForm
+              schema={formSchema}
+              onSubmit={this.props.mutations.updateOptOutMessage}
+              defaultValue={{ optOutMessage }}
+            >
 
-            <Form.Button
-              type='submit'
-              label={this.props.saveLabel || 'Save Opt-Out Message'}
-            />
+              <Form.Field 
+                label='Default Opt-Out Message' 
+                name='optOutMessage'  
+              />
 
-          </GSForm>
+              <Form.Button
+                type='submit'
+                label={this.props.saveLabel || 'Save Opt-Out Message'}
+              />
+
+            </GSForm>
+            </div>
+          </CardText>
+
           <CardText>
             <div className={css(styles.section)}>
               <span className={css(styles.sectionLabel)}>

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import TextField from 'material-ui/TextField'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
 import wrapMutations from './hoc/wrap-mutations'
@@ -136,6 +135,7 @@ class Settings extends React.Component {
               <Form.Field 
                 label='Default Opt-Out Message' 
                 name='optOutMessage'  
+                fullWidth
               />
 
               <Form.Button

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -1,5 +1,6 @@
 import PropTypes from 'prop-types'
 import React from 'react'
+import TextField from 'material-ui/TextField'
 import loadData from './hoc/load-data'
 import gql from 'graphql-tag'
 import wrapMutations from './hoc/wrap-mutations'
@@ -54,11 +55,9 @@ class Settings extends React.Component {
 
   handleCloseTextingHoursDialog = () => this.setState({ textingHoursDialogOpen: false })
 
-
   renderTextingHoursForm() {
     const { organization } = this.props.data
     const { textingHoursStart, textingHoursEnd } = organization
-
     const formSchema = yup.object({
       textingHoursStart: yup.number().required(),
       textingHoursEnd: yup.number().required()
@@ -114,12 +113,34 @@ class Settings extends React.Component {
 
   render() {
     const { organization } = this.props.data
+    const {optOutMessage } = organization
+    const formSchema = yup.object({
+      optOutMessage: yup.string().required()
+    })
+
     return (
       <div>
         <Card>
           <CardHeader
             title='Settings'
           />
+          <GSForm
+            schema={formSchema}
+            onSubmit={this.props.mutations.updateOptOutMessage}
+            defaultValue={{ optOutMessage }}
+          >
+
+            <Form.Field 
+              label='Default Opt-Out Message' 
+              name='optOutMessage'  
+            />
+
+            <Form.Button
+              type='submit'
+              label={this.props.saveLabel || 'Save Opt-Out Message'}
+            />
+
+          </GSForm>
           <CardText>
             <div className={css(styles.section)}>
               <span className={css(styles.sectionLabel)}>
@@ -199,7 +220,21 @@ const mapMutationsToProps = ({ ownProps }) => ({
       organizationId: ownProps.params.organizationId,
       textingHoursEnforced
     }
+  }),
+  updateOptOutMessage: ({optOutMessage}) => ({
+    mutation: gql`
+      mutation updateOptOutMessage($optOutMessage: String!, $organizationId: String!) {
+        updateOptOutMessage(optOutMessage: $optOutMessage, organizationId: $organizationId) {
+          id
+          optOutMessage
+        }
+      }`,
+    variables: {
+      organizationId: ownProps.params.organizationId,
+      optOutMessage
+    }
   })
+
 })
 
 const mapQueriesToProps = ({ ownProps }) => ({
@@ -211,6 +246,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         textingHoursEnforced
         textingHoursStart
         textingHoursEnd
+        optOutMessage
       }
     }`,
     variables: {

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -95,6 +95,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             textingHoursStart
             textingHoursEnd
             threeClickEnabled
+            optOutMessage
           }
           customFields
           interactionSteps {

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -38,6 +38,7 @@ export const resolvers = {
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,
+    optOutMessage: (organization) => (organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE),
     textingHoursStart: (organization) => organization.texting_hours_start,
     textingHoursEnd: (organization) => organization.texting_hours_end
   }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -38,7 +38,7 @@ export const resolvers = {
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,
-    optOutMessage: (organization) => (organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE),
+    optOutMessage: (organization) => (organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE) || 'I\'m opting you out of texts immediately. Have a great day.',
     textingHoursStart: (organization) => organization.texting_hours_start,
     textingHoursEnd: (organization) => organization.texting_hours_end
   }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -501,7 +501,7 @@ const rootMutations = {
       await accessRequired(user, organizationId, 'OWNER')
 
       const organization = await Organization.get(organizationId)
-      const featuresJSON = JSON.parse(organization.features)
+      const featuresJSON = JSON.parse(organization.features || '{}')
       featuresJSON.opt_out_message = optOutMessage
       organization.features = JSON.stringify(featuresJSON)
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -496,6 +496,22 @@ const rootMutations = {
 
       return await Organization.get(organizationId)
     },
+    updateOptOutMessage: async (
+      _,
+      { organizationId, optOutMessage },
+      { user }
+    ) => {
+      await accessRequired(user, organizationId, 'OWNER')
+
+      const organization = await Organization.get(organizationId)
+      const featuresJSON = JSON.parse(organization.features)
+      featuresJSON.opt_out_message = optOutMessage
+      organization.features = JSON.stringify(featuresJSON)
+
+      await organization.save()
+
+      return await Organization.get(organizationId)
+    },
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !process.env.SUPPRESS_SELF_INVITE) {
         const inviteInstance = new Invite({

--- a/src/server/middleware/render-index.js
+++ b/src/server/middleware/render-index.js
@@ -69,7 +69,6 @@ export default function renderIndex(html, css, assetMap, store) {
       window.BASE_URL="${process.env.BASE_URL || ''}"
       window.NOT_IN_USA=${process.env.NOT_IN_USA || 0}
       window.ALLOW_SEND_ALL=${process.env.ALLOW_SEND_ALL || 0}
-      window.OPT_OUT_MESSAGE="${process.env.OPT_OUT_MESSAGE || 'I\'m opting you out of texts immediately. Have a great day.'}"
       window.BULK_SEND_CHUNK_SIZE=${process.env.BULK_SEND_CHUNK_SIZE || 0}
       window.MAX_MESSAGE_LENGTH=${process.env.MAX_MESSAGE_LENGTH || 99999}
       window.TERMS_REQUIRE="${process.env.TERMS_REQUIRE || ''}"


### PR DESCRIPTION
Added a new place to edit org-specific optout message in org settings, and if set, it'll override both the env var instance-wide setting OPT_OUT_MESSAGE and also the hard coded default  "I'm opting you out of texts immediately. Have a great day." Test this by going into your name (in top right) -> your org -> settings and then editing the "Default opt-out message" setting. #741 