### PR TITLE
828 fix max contacts

### DIFF
--- a/docs/REFERENCE-environment_variables.md
+++ b/docs/REFERENCE-environment_variables.md
@@ -38,7 +38,7 @@ MAILGUN_SMTP_PASSWORD             | 'Default Password' in Mailgun. _Required for
 MAILGUN_SMTP_PORT                 | _Default_: 587. Do not modify. _Required for Mailgun usage._
 MAILGUN_SMTP_SERVER               | _Default_: smtp.mailgun.org. Do not modify. _Required for Mailgun usage._
 MAX_CONTACTS                      | If set each campaign can only have a maximum of the value (an integer). This is good for staging/QA/evaluation instances.  _Default_: false (i.e. there is no maximum)
-MAX_CONTACTS_PER_TEXTER           | Maximum contacts that a texter can receive. This is particularly useful for dynamic assignment. If it's zero, then there is no maximum. _Default_: 0
+MAX_CONTACTS_PER_TEXTER           | Maximum contacts that a texter can receive. This is particularly useful for dynamic assignment. Leave it blank (which is the default value) for no maximum.
 MAX_MESSAGE_LENGTH                | The maximum size for a message that a texter can send. When you send a SMS message over 160 characters the message will be split, so you might want to set this as 160 or less if you have a high SMS-only target demographic. _Default_: 99999
 NEXMO_API_KEY                     | Nexmo API key. Required if using Nexmo.
 NEXMO_API_SECRET                  | Nexmo API secret. Required if using Nexmo.

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "redux": "^3.7.2",
     "redux-thunk": "^2.1.0",
     "request": "^2.81.0",
-    "rethink-knex-adapter": "^0.4.14",
+    "rethink-knex-adapter": "^0.4.15",
     "rollbar": "^0.6.2",
     "thinky": "^2.3.3",
     "timezonecomplete": "^5.5.0",

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -91,7 +91,8 @@ export class AssignmentSummary extends Component {
     const { title, description, hasUnassignedContacts, dueBy,
             primaryColor, logoImageUrl, introHtml,
             useDynamicAssignment } = assignment.campaign
-
+    const maxContacts = assignment.maxContacts
+    const disabled = (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) || (useDynamicAssignment && maxContacts === 0)
     return (
       <div className={css(styles.container)}>
         <Card
@@ -113,7 +114,7 @@ export class AssignmentSummary extends Component {
               title: 'Send first texts',
               count: unmessagedCount,
               primary: true,
-              disabled: (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) ? true : false,
+              disabled: (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) || (useDynamicAssignment && maxContacts === 0),
               contactsFilter: 'text',
               hideIfZero: !useDynamicAssignment
             })}

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -92,7 +92,6 @@ export class AssignmentSummary extends Component {
             primaryColor, logoImageUrl, introHtml,
             useDynamicAssignment } = assignment.campaign
     const maxContacts = assignment.maxContacts
-    const disabled = (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) || (useDynamicAssignment && maxContacts === 0)
     return (
       <div className={css(styles.container)}>
         <Card

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -95,6 +95,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             primaryColor
             logoImageUrl
           }
+          maxContacts
           unmessagedCount: contactsCount(contactsFilter: $needsMessageFilter)
           unrepliedCount: contactsCount(contactsFilter: $needsResponseFilter)
           badTimezoneCount: contactsCount(contactsFilter: $badTimezoneFilter)

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -707,7 +707,7 @@ const rootMutations = {
         })
       }
       const campaign = await Campaign.get(assignment.campaign_id)
-      if (!campaign.use_dynamic_assignment) {
+      if (!campaign.use_dynamic_assignment || assignment.max_contacts === 0) {
         return { found: false }
       }
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -172,23 +172,6 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
         assignTexters(job)
       }
     }
-
-    // assign the maxContacts
-    // TODO: move this inside the job
-    campaign.texters.forEach(async texter => {
-      let maxContacts = null
-      if (texter.maxContacts || parseInt(texter.maxContacts, 10) === 0) {
-        maxContacts = parseInt(texter.maxContacts)
-      }
-      const dog = r
-        .knex('campaign')
-        .where({ id })
-        .select('useDynamicAssignment')
-      await r
-        .knex('assignment')
-        .where({ user_id: texter.id, campaign_id: id })
-        .update({ max_contacts: maxContacts })
-    })
   }
 
   if (campaign.hasOwnProperty('interactionSteps')) {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -174,7 +174,12 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     }
 
     // assign the maxContacts
+    // TODO: move this inside the job
     campaign.texters.forEach(async texter => {
+      let maxContacts = null
+      if (texter.maxContacts || parseInt(texter.maxContacts, 10) === 0) {
+        maxContacts = parseInt(texter.maxContacts)
+      }
       const dog = r
         .knex('campaign')
         .where({ id })
@@ -182,7 +187,7 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
       await r
         .knex('assignment')
         .where({ user_id: texter.id, campaign_id: id })
-        .update({ max_contacts: texter.maxContacts ? texter.maxContacts : null })
+        .update({ max_contacts: maxContacts })
     })
   }
 

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -487,8 +487,7 @@ export async function assignTexters(job) {
         }
       } 
       return assignment
-    }
-    else { // new texter
+    } else { // new texter
       return assignment
     }
   }).filter((ele) => ele !== null)

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -440,7 +440,6 @@ export async function assignTexters(job) {
   TODO: what happens when we switch modes? Do we allow it?
   */ 
   const payload = JSON.parse(job.payload)
-  console.log(payload)
   const cid = job.campaign_id
   const campaign = (await r.knex('campaign').where({ id: cid }))[0]
   const texters = payload.texters
@@ -460,7 +459,6 @@ export async function assignTexters(job) {
   const unchangedTexters = {} // max_contacts and needsMessageCount unchanged
   const demotedTexters = {} // needsMessageCount reduced
   const dynamic = campaign.use_dynamic_assignment
-
   // detect changed assignments
   currentAssignments.map((assignment) => {
     const texter = texters.filter((ele) => parseInt(ele.id, 10) === assignment.user_id)[0]
@@ -494,7 +492,7 @@ export async function assignTexters(job) {
       return assignment
     }
   }).filter((ele) => ele !== null)
-  console.log("unchangedTexters", unchangedTexters)
+
   for (const assignId in demotedTexters) {
     // Here we unassign ALL the demotedTexters contacts (not just the demotion count)
     // because they will get reapportioned below

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -465,13 +465,10 @@ export async function assignTexters(job) {
   currentAssignments.map((assignment) => {
     const texter = texters.filter((ele) => parseInt(ele.id, 10) === assignment.user_id)[0]
     const unchangedMaxContacts = 
-      parseInt(texter.maxContacts || 0, 10) === assignment.max_contacts || // integer = integer
+      parseInt(texter.maxContacts, 10) === assignment.max_contacts || // integer = integer
       texter.maxContacts === assignment.max_contacts // null = null 
     const unchangedNeedsMessageCount = 
       texter.needsMessageCount === parseInt(assignment.needs_message_count, 10)
-    console.log("texter.id", texter.id)
-    console.log("unchangedMaxContacts", unchangedMaxContacts)
-    console.log("unchangedNeedsMessageCount", unchangedNeedsMessageCount)
     if (texter) {
       if ((!dynamic && unchangedNeedsMessageCount) || (dynamic && unchangedMaxContacts)) {
         unchangedTexters[assignment.user_id] = true
@@ -548,7 +545,6 @@ export async function assignTexters(job) {
     availableContacts = availableContacts - contactsToAssign
     const existingAssignment = currentAssignments.find((ele) => ele.user_id === texterId)
     let assignment = null
-
     if (existingAssignment) {
       if (!dynamic) {
         assignment = new Assignment({ id: existingAssignment.id,


### PR DESCRIPTION
We can now set max contacts to 0 to stop texters in dynamic assignment mode from sending any more texts in that campaign. Before, we weren't distinguishing between 0 and null, so both meant no limit on contacts assigned to a given texter. This PR addresses #828 and the connected issue #629.

Note that we had to fix rethink-knex and bump it up a version, so ppl will have to update the node module to see changes working.