### PR TITLE
Campaign page related fixes

### DIFF
--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -18,7 +18,7 @@ class AdminCampaignList extends React.Component {
     isCreating: false,
     campaignsFilter: {
       isArchived: false,
-      listSize: 25
+      listSize: 50
     }
   }
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -5,8 +5,6 @@ import { currentEditors } from '../models/cacheable_queries'
 
 export function buildCampaignQuery(queryParam, organizationId, campaignsFilter, addFromClause = true) {
   let query = queryParam
-  const resultSize = (campaignsFilter.listSize ? campaignsFilter.listSize : 0)
-  const pageSize = (campaignsFilter.pageSize ? campaignsFilter.pageSize : 0)
 
   if (addFromClause) {
     query = query.from('campaign')
@@ -15,6 +13,9 @@ export function buildCampaignQuery(queryParam, organizationId, campaignsFilter, 
   query = query.where('organization_id', organizationId)
 
   if (campaignsFilter) {
+    const resultSize = (campaignsFilter.listSize ? campaignsFilter.listSize : 0)
+    const pageSize = (campaignsFilter.pageSize ? campaignsFilter.pageSize : 0)
+    
     if ('isArchived' in campaignsFilter) {
       query = query.where({ is_archived: campaignsFilter.isArchived })
     }


### PR DESCRIPTION
This PR fixes 2 things: 
1) A bug introduced by https://github.com/MoveOnOrg/Spoke/pull/816 which breaks the ability to view the message review panel because of this error : `"Cannot read property 'listSize' of undefined"`
2) A request to change the default page size to be 50 (vs 25) by @erikkirkstein 