### PR TITLE
858 Stop Texting Toggle For Organization

### DIFF
--- a/src/api/campaign-contact.js
+++ b/src/api/campaign-contact.js
@@ -34,6 +34,6 @@ export const schema = `
     interactionSteps: [InteractionStep]
     messageStatus: String
     assignmentId: String
-    resultStatus: String
+    textingTurnedOff: String
   }
 `

--- a/src/api/campaign-contact.js
+++ b/src/api/campaign-contact.js
@@ -34,6 +34,5 @@ export const schema = `
     interactionSteps: [InteractionStep]
     messageStatus: String
     assignmentId: String
-    textingTurnedOff: String
   }
 `

--- a/src/api/campaign-contact.js
+++ b/src/api/campaign-contact.js
@@ -34,6 +34,6 @@ export const schema = `
     interactionSteps: [InteractionStep]
     messageStatus: String
     assignmentId: String
+    resultStatus: String
   }
 `
-

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -12,9 +12,9 @@ export const schema = `
     optOuts: [OptOut]
     threeClickEnabled: Boolean
     optOutMessage: String
+    turnTextingOff: Boolean
     textingHoursEnforced: Boolean
     textingHoursStart: Int
     textingHoursEnd: Int
   }
 `
-

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -12,7 +12,7 @@ export const schema = `
     optOuts: [OptOut]
     threeClickEnabled: Boolean
     optOutMessage: String
-    turnTextingOff: Boolean
+    textingTurnedOff: Boolean
     textingHoursEnforced: Boolean
     textingHoursStart: Int
     textingHoursEnd: Int

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -193,7 +193,7 @@ const rootSchema = `
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
-    turnTextingOff( organizationId: String!, turnTextingOff: Boolean!): Organization
+    textingTurnedOff( organizationId: String!, textingTurnedOff: Boolean!): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -127,7 +127,7 @@ const rootSchema = `
     message: MessageInput!
     campaignContactId: String!
   }
-  
+
   input OffsetLimitCursor {
     offset: Int!
     limit: Int!
@@ -153,7 +153,7 @@ const rootSchema = `
   type FoundContact {
     found: Boolean
   }
-  
+
   type PageInfo {
     limit: Int!
     offset: Int!
@@ -193,7 +193,7 @@ const rootSchema = `
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
-    textingTurnedOff( organizationId: String!, textingTurnedOff: Boolean!): Organization
+    turnTextingOff( organizationId: String!, turnTextingOff: Boolean!): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,
@@ -236,4 +236,3 @@ export const schema = [
   inviteSchema,
   conversationSchema
 ]
-

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -193,6 +193,7 @@ const rootSchema = `
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
+    textingTurnedOff( organizationId: String!, textingTurnedOff: Boolean!): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -971,6 +971,7 @@ const mapMutationsToProps = () => ({
             text
             isFromContact
           }
+          resultStatus
         }
       }
     `,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -971,7 +971,7 @@ const mapMutationsToProps = () => ({
             text
             isFromContact
           }
-          resultStatus
+          textingTurnedOff
         }
       }
     `,

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -185,6 +185,8 @@ export class AssignmentTexterContact extends React.Component {
     const questionResponses = this.getInitialQuestionResponses(contact.questionResponseValues)
     const availableSteps = this.getAvailableInteractionSteps(questionResponses)
 
+    const textingTurnedOff = this.props.campaign.organization.textingTurnedOff
+
     let disabled = false
     let disabledText = 'Sending...'
     let snackbarOnTouchTap = null
@@ -203,6 +205,12 @@ export class AssignmentTexterContact extends React.Component {
     } else if (!this.isContactBetweenTextingHours(contact)) {
       disabledText = "Refreshing because it's now out of texting hours for some of your contacts"
       disabled = true
+    } else if (textingTurnedOff) {
+      disabledText = 'Texting is turned off for this organization'
+      disabled = true
+      snackbarError = 'Texting is turned off for this organization'
+      snackbarOnTouchTap = this.goBackToTodos
+      snackbarActionTitle = 'Back to Todos'
     }
 
     this.state = {
@@ -851,8 +859,6 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   render() {
-    const textingTurnedOff = this.props.campaign.organization.textingTurnedOff
-    console.log('texting turned off:', this.props.campaign.organization.textingTurnedOff);
     return (
       <div>
         {this.state.disabled ? (

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -851,6 +851,8 @@ export class AssignmentTexterContact extends React.Component {
   }
 
   render() {
+    const textingTurnedOff = this.props.campaign.organization.textingTurnedOff
+    console.log('texting turned off:', this.props.campaign.organization.textingTurnedOff);
     return (
       <div>
         {this.state.disabled ? (

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -127,12 +127,11 @@ class Settings extends React.Component {
             <div className={css(styles.section)}>
             <div className={css(styles.section)}>
               <Toggle
-                toggled={organization.textingTurnedOff}
-                label='Turn Texting Off For All Campaigns?'
-                onToggle={async (event, isToggled) => await this.props.mutations.textingTurnedOff(isToggled)}
+                toggled={organization.turnTextingOff}
+                label={(organization.turnTextingOff ? 'Texting for All Campaigns On' : 'Texting for All Campaigns Off')}
+                onToggle={async (event, isToggled) => await this.props.mutations.turnTextingOff(isToggled)}
               />
             </div>
-            .. add red button
             <GSForm
               schema={formSchema}
               onSubmit={this.props.mutations.updateOptOutMessage}
@@ -247,17 +246,17 @@ const mapMutationsToProps = ({ ownProps }) => ({
       optOutMessage
     }
   }),
-  textingTurnedOff: (textingTurnedOff) => ({
+  turnTextingOff: (turnTextingOff) => ({
     mutation: gql`
-      mutation textingTurnedOff($textingTurnedOff: Boolean!, $organizationId: String!) {
-        textingTurnedOff(textingTurnedOff: $textingTurnedOff, organizationId: $organizationId) {
+      mutation turnTextingOff($turnTextingOff: Boolean!, $organizationId: String!) {
+        turnTextingOff(turnTextingOff: $turnTextingOff, organizationId: $organizationId) {
           id
-          textingTurnedOff
+          turnTextingOff
         }
       }`,
     variables: {
       organizationId: ownProps.params.organizationId,
-      textingTurnedOff
+      turnTextingOff
     }
   }),
 
@@ -273,6 +272,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         textingHoursStart
         textingHoursEnd
         optOutMessage
+        turnTextingOff
       }
     }`,
     variables: {

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -132,7 +132,7 @@ class Settings extends React.Component {
                 onToggle={async (event, isToggled) => await this.props.mutations.textingTurnedOff(isToggled)}
               />
             </div>
-
+            .. add red button
             <GSForm
               schema={formSchema}
               onSubmit={this.props.mutations.updateOptOutMessage}

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -127,9 +127,9 @@ class Settings extends React.Component {
             <div className={css(styles.section)}>
             <div className={css(styles.section)}>
               <Toggle
-                toggled={organization.turnTextingOff}
-                label={(organization.turnTextingOff ? 'TEXTING TURNED OFF FOR ALL CAMPAIGNS' : 'TEXTING TURNED ON FOR ALL CAMPAIGNS')}
-                onToggle={async (event, isToggled) => await this.props.mutations.turnTextingOff(isToggled)}
+                toggled={organization.textingTurnedOff}
+                label={(organization.textingTurnedOff ? 'TEXTING TURNED OFF FOR ALL CAMPAIGNS' : 'TEXTING TURNED ON FOR ALL CAMPAIGNS')}
+                onToggle={async (event, isToggled) => await this.props.mutations.textingTurnedOff(isToggled)}
               />
             </div>
             <GSForm
@@ -246,17 +246,17 @@ const mapMutationsToProps = ({ ownProps }) => ({
       optOutMessage
     }
   }),
-  turnTextingOff: (turnTextingOff) => ({
+  textingTurnedOff: (textingTurnedOff) => ({
     mutation: gql`
-      mutation turnTextingOff($turnTextingOff: Boolean!, $organizationId: String!) {
-        turnTextingOff(turnTextingOff: $turnTextingOff, organizationId: $organizationId) {
+      mutation textingTurnedOff($textingTurnedOff: Boolean!, $organizationId: String!) {
+        textingTurnedOff(textingTurnedOff: $textingTurnedOff, organizationId: $organizationId) {
           id
-          turnTextingOff
+          textingTurnedOff
         }
       }`,
     variables: {
       organizationId: ownProps.params.organizationId,
-      turnTextingOff
+      textingTurnedOff
     }
   }),
 
@@ -272,7 +272,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
         textingHoursStart
         textingHoursEnd
         optOutMessage
-        turnTextingOff
+        textingTurnedOff
       }
     }`,
     variables: {

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -128,7 +128,7 @@ class Settings extends React.Component {
             <div className={css(styles.section)}>
               <Toggle
                 toggled={organization.turnTextingOff}
-                label={(organization.turnTextingOff ? 'Texting for All Campaigns On' : 'Texting for All Campaigns Off')}
+                label={(organization.turnTextingOff ? 'TEXTING TURNED OFF FOR ALL CAMPAIGNS' : 'TEXTING TURNED ON FOR ALL CAMPAIGNS')}
                 onToggle={async (event, isToggled) => await this.props.mutations.turnTextingOff(isToggled)}
               />
             </div>

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -112,7 +112,7 @@ class Settings extends React.Component {
 
   render() {
     const { organization } = this.props.data
-    const {optOutMessage } = organization
+    const { optOutMessage } = organization
     const formSchema = yup.object({
       optOutMessage: yup.string().required()
     })
@@ -125,6 +125,13 @@ class Settings extends React.Component {
           />
           <CardText>
             <div className={css(styles.section)}>
+            <div className={css(styles.section)}>
+              <Toggle
+                toggled={organization.textingTurnedOff}
+                label='Turn Texting Off For All Campaigns?'
+                onToggle={async (event, isToggled) => await this.props.mutations.textingTurnedOff(isToggled)}
+              />
+            </div>
 
             <GSForm
               schema={formSchema}
@@ -132,9 +139,9 @@ class Settings extends React.Component {
               defaultValue={{ optOutMessage }}
             >
 
-              <Form.Field 
-                label='Default Opt-Out Message' 
-                name='optOutMessage'  
+              <Form.Field
+                label='Default Opt-Out Message'
+                name='optOutMessage'
                 fullWidth
               />
 
@@ -239,7 +246,20 @@ const mapMutationsToProps = ({ ownProps }) => ({
       organizationId: ownProps.params.organizationId,
       optOutMessage
     }
-  })
+  }),
+  textingTurnedOff: (textingTurnedOff) => ({
+    mutation: gql`
+      mutation textingTurnedOff($textingTurnedOff: Boolean!, $organizationId: String!) {
+        textingTurnedOff(textingTurnedOff: $textingTurnedOff, organizationId: $organizationId) {
+          id
+          textingTurnedOff
+        }
+      }`,
+    variables: {
+      organizationId: ownProps.params.organizationId,
+      textingTurnedOff
+    }
+  }),
 
 })
 

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -125,13 +125,15 @@ class Settings extends React.Component {
           />
           <CardText>
             <div className={css(styles.section)}>
-            <div className={css(styles.section)}>
               <Toggle
                 toggled={organization.textingTurnedOff}
                 label={(organization.textingTurnedOff ? 'TEXTING TURNED OFF FOR ALL CAMPAIGNS' : 'TEXTING TURNED ON FOR ALL CAMPAIGNS')}
                 onToggle={async (event, isToggled) => await this.props.mutations.textingTurnedOff(isToggled)}
               />
             </div>
+          </CardText>
+          <CardText>
+            <div className={css(styles.section)}>
             <GSForm
               schema={formSchema}
               onSubmit={this.props.mutations.updateOptOutMessage}

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -83,6 +83,7 @@ class TexterTodo extends React.Component {
     const { assignment } = this.props.data
     const contacts = assignment.contacts
     const allContactsCount = assignment.allContactsCount
+    console.log('props in texter todo:', this.props);
     return (
       <AssignmentTexter
         assignment={assignment}
@@ -141,7 +142,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             textingHoursEnd
             threeClickEnabled
             optOutMessage
-            turnTextingOff
+            textingTurnedOff
           }
           customFields
           interactionSteps {

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -83,7 +83,6 @@ class TexterTodo extends React.Component {
     const { assignment } = this.props.data
     const contacts = assignment.contacts
     const allContactsCount = assignment.allContactsCount
-    console.log('props in texter todo:', this.props);
     return (
       <AssignmentTexter
         assignment={assignment}

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -141,7 +141,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             textingHoursEnd
             threeClickEnabled
             optOutMessage
-            
+            turnTextingOff
           }
           customFields
           interactionSteps {

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -141,6 +141,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             textingHoursEnd
             threeClickEnabled
             optOutMessage
+            
           }
           customFields
           interactionSteps {

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React from 'react'
 import Check from 'material-ui/svg-icons/action/check-circle'
+import Lock from 'material-ui/svg-icons/action/lock'
 import Empty from '../components/Empty'
 import AssignmentSummary from '../components/AssignmentSummary'
 import loadData from './hoc/load-data'
@@ -69,8 +70,8 @@ class TexterTodoList extends React.Component {
 
     const textingOff = (
       <Empty
-        title='Texting is Currently Disabled For This Organization.'
-        icon={<Check />}
+        title='Texting is Currently Turned Off For This Organization.'
+        icon={<Lock />}
       />
     )
 

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -49,11 +49,17 @@ class TexterTodoList extends React.Component {
     }
   }
 
+  textingTurnedOffForOrganization(todos){
+    const orgDataForFirstTodo = todos[0].campaign.organization
+    return (todos[0].campaign.organization && orgDataForFirstTodo.textingTurnedOff ? true : false)
+  }
+
   render() {
     this.termsAgreed()
     const todos = this.props.data.currentUser.todos
     const renderedTodos = this.renderTodoList(todos)
-
+    const textingTurnedOff = this.textingTurnedOffForOrganization(todos)
+    
     const empty = (
       <Empty
         title='You have nothing to do!'
@@ -63,7 +69,7 @@ class TexterTodoList extends React.Component {
 
     return (
       <div>
-        {renderedTodos.length === 0 ?
+        {renderedTodos.length === 0  || textingTurnedOff ?
           empty : renderedTodos
         }
       </div>
@@ -95,7 +101,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             primaryColor
             logoImageUrl
             organization {
-              turnTextingOff
+              textingTurnedOff
             }
           }
           maxContacts

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -67,11 +67,26 @@ class TexterTodoList extends React.Component {
       />
     )
 
+    const textingOff = (
+      <Empty
+        title='Texting is Currently Disabled For This Organization.'
+        icon={<Check />}
+      />
+    )
+
+    const renderTexterTodosScreen = () => {
+      if(renderedTodos.length === 0) {
+        return empty
+      } else if (textingTurnedOff) {
+        return textingOff
+      } else {
+        return renderedTodos
+      }
+    }
+
     return (
       <div>
-        {renderedTodos.length === 0  || textingTurnedOff ?
-          empty : renderedTodos
-        }
+        {renderTexterTodosScreen()}
       </div>
     )
   }

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -94,6 +94,9 @@ const mapQueriesToProps = ({ ownProps }) => ({
             introHtml
             primaryColor
             logoImageUrl
+            organization {
+              turnTextingOff
+            }
           }
           maxContacts
           unmessagedCount: contactsCount(contactsFilter: $needsMessageFilter)

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -167,6 +167,7 @@ export const resolvers = {
       }
       // fake ID so we don't need to look up existance
       return (isOptedOut ? { id: 'optout' } : null)
-    }
+    },
+    resultStatus: campaignContact => campaignContact.resultStatus || null
   }
 }

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -168,6 +168,6 @@ export const resolvers = {
       // fake ID so we don't need to look up existance
       return (isOptedOut ? { id: 'optout' } : null)
     },
-    resultStatus: campaignContact => campaignContact.resultStatus || null
+    textingTurnedOff: campaignContact => campaignContact.textingTurnedOff || null
   }
 }

--- a/src/server/api/campaign-contact.js
+++ b/src/server/api/campaign-contact.js
@@ -167,7 +167,6 @@ export const resolvers = {
       }
       // fake ID so we don't need to look up existance
       return (isOptedOut ? { id: 'optout' } : null)
-    },
-    textingTurnedOff: campaignContact => campaignContact.textingTurnedOff || null
+    }
   }
 }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -38,7 +38,7 @@ export const resolvers = {
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,
-    turnTextingOff: (organization) => (organization.features && organization.features.indexOf('texting_turned_off') !== -1 ? JSON.parse(organization.features).texting_turned_off : false), 
+    textingTurnedOff: (organization) => (organization.features && organization.features.indexOf('texting_turned_off') !== -1 ? JSON.parse(organization.features).texting_turned_off : false), 
     optOutMessage: (organization) => (organization.features && organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE) || 'I\'m opting you out of texts immediately. Have a great day.',
     textingHoursStart: (organization) => organization.texting_hours_start,
     textingHoursEnd: (organization) => organization.texting_hours_end

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -38,6 +38,7 @@ export const resolvers = {
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,
+    turnTextingOff: (organization) => (organization.features && organization.features.indexOf('texting_turned_off') !== -1 ? JSON.parse(organization.features).texting_turned_off : false), 
     optOutMessage: (organization) => (organization.features && organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE) || 'I\'m opting you out of texts immediately. Have a great day.',
     textingHoursStart: (organization) => organization.texting_hours_start,
     textingHoursEnd: (organization) => organization.texting_hours_end

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -527,7 +527,7 @@ const rootMutations = {
 
       const organization = await Organization.get(organizationId)
       const featuresJSON = JSON.parse(organization.features || '{}')
-      featuresJSON.texting_turned_off =
+      featuresJSON.texting_turned_off = turnTextingOff
       organization.features = JSON.stringify(featuresJSON)
 
       await organization.save()

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -518,22 +518,22 @@ const rootMutations = {
 
       return await Organization.get(organizationId)
     },
-    textingTurnedOff: async (
+    turnTextingOff: async (
       _,
-      { organizationId, textingTurnedOff },
+      { organizationId, turnTextingOff },
       { user }
     ) => {
       await accessRequired(user, organizationId, 'OWNER')
 
       const organization = await Organization.get(organizationId)
       const featuresJSON = JSON.parse(organization.features || '{}')
-      featuresJSON.texting_turned_off = textingTurnedOff
+      featuresJSON.texting_turned_off =
       organization.features = JSON.stringify(featuresJSON)
 
       await organization.save()
       await organizationCache.clear(organizationId)
 
-      return await Organization.get(organizationId)  
+      return await Organization.get(organizationId)
     },
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !process.env.SUPPRESS_SELF_INVITE) {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -518,16 +518,16 @@ const rootMutations = {
 
       return await Organization.get(organizationId)
     },
-    turnTextingOff: async (
+    textingTurnedOff: async (
       _,
-      { organizationId, turnTextingOff },
+      { organizationId, textingTurnedOff },
       { user }
     ) => {
       await accessRequired(user, organizationId, 'OWNER')
 
       const organization = await Organization.get(organizationId)
       const featuresJSON = JSON.parse(organization.features || '{}')
-      featuresJSON.texting_turned_off = turnTextingOff
+      featuresJSON.texting_turned_off = textingTurnedOff
       organization.features = JSON.stringify(featuresJSON)
 
       await organization.save()

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -518,6 +518,23 @@ const rootMutations = {
 
       return await Organization.get(organizationId)
     },
+    textingTurnedOff: async (
+      _,
+      { organizationId, textingTurnedOff },
+      { user }
+    ) => {
+      await accessRequired(user, organizationId, 'OWNER')
+
+      const organization = await Organization.get(organizationId)
+      const featuresJSON = JSON.parse(organization.features || '{}')
+      featuresJSON.texting_turned_off = textingTurnedOff
+      organization.features = JSON.stringify(featuresJSON)
+
+      await organization.save()
+      await organizationCache.clear(organizationId)
+
+      return await Organization.get(organizationId)  
+    },
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !process.env.SUPPRESS_SELF_INVITE) {
         const inviteInstance = new Invite({

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -521,7 +521,7 @@ const rootMutations = {
     textingTurnedOff: async (
       _,
       { organizationId, textingTurnedOff },
-      { user }
+      { user, loaders }
     ) => {
       await accessRequired(user, organizationId, 'OWNER')
 
@@ -533,7 +533,7 @@ const rootMutations = {
       await organization.save()
       await organizationCache.clear(organizationId)
 
-      return await Organization.get(organizationId)
+      return await loaders.organization.load(organizationId)
     },
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !process.env.SUPPRESS_SELF_INVITE) {


### PR DESCRIPTION
Fixes #858 
- Adds toggle in organizational settings available to owner to turn off all texting for organization

**Owner Admin Settings:**
<img width="1037" alt="screen shot 2018-09-21 at 9 09 49 am" src="https://user-images.githubusercontent.com/16676323/45883187-5b4b7180-bd7e-11e8-9664-f690ddd9a3c8.png">


**Texter Todo List:**
<img width="1307" alt="screen shot 2018-09-21 at 9 09 54 am" src="https://user-images.githubusercontent.com/16676323/45883129-2f2ff080-bd7e-11e8-8e97-16a16b0b94c3.png">

**Texter Contact Screen:**
<img width="1197" alt="screen shot 2018-09-21 at 9 06 18 am" src="https://user-images.githubusercontent.com/16676323/45883042-f09a3600-bd7d-11e8-8235-7c87ef08f365.png">
