### PR TITLE
Organization setting for customizing assignment email

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -342,9 +342,9 @@ it('should start the campaign', async() => {
     to: 'testtexter@example.com',
     replyTo: 'testuser@example.com',
     subject:
-        '~~~~~[Testy test organization] ~~ New assignment: test campaign',
-    text:
-        '~~~~You just got a new texting assignment from Testy test organization. You can start sending texts right away: \n\nundefined/app/1/todos'
+        '~~~~~[Testy test organization] ~~ New assignment: test campaign'
+    // text:
+    //     '~~~~You just got a new texting assignment from Testy test organization. You can start sending texts right away: \n\nundefined/app/1/todos'
   }))
 })
 

--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -3,6 +3,11 @@ export const schema = `
     campaignsFilter: CampaignsFilter
   }
 
+  type AssignmentMessage {
+    subject: String
+    body: String
+  }
+
   type Organization {
     id: ID
     uuid: String
@@ -12,9 +17,9 @@ export const schema = `
     optOuts: [OptOut]
     threeClickEnabled: Boolean
     optOutMessage: String
+    assignmentMessage: AssignmentMessage
     textingHoursEnforced: Boolean
     textingHoursStart: Int
     textingHoursEnd: Int
   }
 `
-

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -127,7 +127,7 @@ const rootSchema = `
     message: MessageInput!
     campaignContactId: String!
   }
-  
+
   input OffsetLimitCursor {
     offset: Int!
     limit: Int!
@@ -153,7 +153,7 @@ const rootSchema = `
   type FoundContact {
     found: Boolean
   }
-  
+
   type PageInfo {
     limit: Int!
     offset: Int!
@@ -193,6 +193,7 @@ const rootSchema = `
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
     updateOptOutMessage( organizationId: String!, optOutMessage: String!): Organization
+    updateUserAssignmentMessage( organizationId: String!, subject: String, body: String): Organization
     bulkSendMessages(assignmentId: Int!): [CampaignContact]
     sendMessage(message:MessageInput!, campaignContactId:String!): CampaignContact,
     createOptOut(optOut:OptOutInput!, campaignContactId:String!):CampaignContact,
@@ -235,4 +236,3 @@ export const schema = [
   inviteSchema,
   conversationSchema
 ]
-

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -46,8 +46,8 @@ export default class GSScriptField extends GSFormField {
 
   renderDialog() {
     const { open } = this.state
-    const { customFields, sampleContact } = this.props
-    const scriptFields = allScriptFields(customFields)
+    const { customFields, sampleContact, overrideFields } = this.props
+    const scriptFields = overrideFields || allScriptFields(customFields)
 
     return (
       <Dialog

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -21,7 +21,7 @@ import CampaignCannedResponsesForm from '../components/CampaignCannedResponsesFo
 import { dataTest, camelCase } from '../lib/attributes'
 import CampaignTextingHoursForm from '../components/CampaignTextingHoursForm'
 
-const campaignInfoFragment = `
+export const campaignInfoFragment = `
   id
   title
   description

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -42,7 +42,7 @@ const formatTextingHours = (hour) => moment(hour, 'H').format('h a')
 class Settings extends React.Component {
 
   state = {
-    formIsSubmitting: false
+    textingHoursDialogOpen: false
   }
 
   handleSubmitTextingHoursForm = async ({ textingHoursStart, textingHoursEnd }) => {
@@ -112,9 +112,16 @@ class Settings extends React.Component {
 
   render() {
     const { organization } = this.props.data
-    const {optOutMessage } = organization
-    const formSchema = yup.object({
-      optOutMessage: yup.string().required()
+    const { optOutMessage, assignmentMessage } = organization
+    const formSchemaOptOut = yup.object({
+      optOutMessage: yup.string().required(),
+      assignmentBody: yup.string(),
+      assignmentSubject: yup.string()
+    })
+
+    const formSchemaAssignmentMessage = yup.object({
+      subject: yup.string(),
+      body: yup.string()
     })
 
     return (
@@ -126,24 +133,54 @@ class Settings extends React.Component {
           <CardText>
             <div className={css(styles.section)}>
 
-            <GSForm
-              schema={formSchema}
-              onSubmit={this.props.mutations.updateOptOutMessage}
-              defaultValue={{ optOutMessage }}
-            >
+              <GSForm
+                schema={formSchemaOptOut}
+                onSubmit={this.props.mutations.updateOptOutMessage}
+                defaultValue={{ optOutMessage }}
+              >
 
-              <Form.Field 
-                label='Default Opt-Out Message' 
-                name='optOutMessage'  
-                fullWidth
-              />
+                <Form.Field
+                  label='Default Opt-Out Message'
+                  name='optOutMessage'
+                  fullWidth
+                />
 
-              <Form.Button
-                type='submit'
-                label={this.props.saveLabel || 'Save Opt-Out Message'}
-              />
+                <Form.Button
+                  type='submit'
+                  label={this.props.saveLabel || 'Save Opt-Out Message'}
+                />
 
-            </GSForm>
+              </GSForm>
+
+              <GSForm
+                schema={formSchemaAssignmentMessage}
+                onSubmit={this.props.mutations.updateUserAssignmentMessage}
+                defaultValue={assignmentMessage}
+              >
+                <Form.Field
+                  name='subject'
+                  type='script'
+                  fullWidth
+                  overrideFields={['organizationName', 'campaignTitle', 'todoUrl']}
+                  label='Assignment Email Subject'
+                  multiLine
+                />
+
+                <Form.Field
+                  name='body'
+                  type='script'
+                  fullWidth
+                  overrideFields={['organizationName', 'campaignTitle', 'todoUrl']}
+                  label='Assignment Email Body'
+                  multiLine
+                />
+
+                <Form.Button
+                  type='submit'
+                  label='Save Assignment Message'
+                />
+
+              </GSForm>
             </div>
           </CardText>
 
@@ -239,6 +276,23 @@ const mapMutationsToProps = ({ ownProps }) => ({
       organizationId: ownProps.params.organizationId,
       optOutMessage
     }
+  }),
+  updateUserAssignmentMessage: ({ subject, body }) => ({
+    mutation: gql`
+      mutation updateUserAssignmentMessage($subject: String, $body: String, $organizationId: String!) {
+        updateUserAssignmentMessage(subject: $subject, body: $body, organizationId: $organizationId) {
+          id
+          assignmentMessage {
+            subject
+            body
+          }
+        }
+      }`,
+    variables: {
+      organizationId: ownProps.params.organizationId,
+      subject,
+      body
+    }
   })
 
 })
@@ -253,6 +307,10 @@ const mapQueriesToProps = ({ ownProps }) => ({
         textingHoursStart
         textingHoursEnd
         optOutMessage
+        assignmentMessage {
+          subject
+          body
+        }
       }
     }`,
     variables: {

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -3,6 +3,7 @@ import { r, Organization } from '../models'
 import { accessRequired } from './errors'
 import { buildCampaignQuery } from './campaign'
 import { buildUserOrganizationQuery } from './user'
+import { ASSIGNMENT_CREATED_SUBJECT, ASSIGNMENT_CREATED_BODY } from '../notifications';
 
 export const resolvers = {
   Organization: {
@@ -38,8 +39,22 @@ export const resolvers = {
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,
-    optOutMessage: (organization) => (organization.features && organization.features.indexOf('opt_out_message') !== -1 ? JSON.parse(organization.features).opt_out_message : process.env.OPT_OUT_MESSAGE) || 'I\'m opting you out of texts immediately. Have a great day.',
+    optOutMessage: organization =>
+      (organization.features &&
+        organization.features.indexOf('opt_out_message') !== -1
+        ? JSON.parse(organization.features).opt_out_message
+        : process.env.OPT_OUT_MESSAGE) ||
+      'I\'m opting you out of texts immediately. Have a great day.',
+    assignmentMessage: organization =>
+      (organization.features &&
+        organization.features.indexOf('assignment_message') !== -1
+        ? JSON.parse(organization.features).assignment_message
+        : {}) || {},
     textingHoursStart: (organization) => organization.texting_hours_start,
     textingHoursEnd: (organization) => organization.texting_hours_end
+  },
+  AssignmentMessage: {
+    subject: s => s.subject || ASSIGNMENT_CREATED_SUBJECT,
+    body: b => b.body || ASSIGNMENT_CREATED_BODY
   }
 }

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -3,7 +3,7 @@ import { r, Organization } from '../models'
 import { accessRequired } from './errors'
 import { buildCampaignQuery } from './campaign'
 import { buildUserOrganizationQuery } from './user'
-import { ASSIGNMENT_CREATED_SUBJECT, ASSIGNMENT_CREATED_BODY } from '../notifications';
+import { defaultAssignmentSubject, defaultAssignmentBody } from '../notifications'
 
 export const resolvers = {
   Organization: {
@@ -54,7 +54,7 @@ export const resolvers = {
     textingHoursEnd: (organization) => organization.texting_hours_end
   },
   AssignmentMessage: {
-    subject: s => s.subject || ASSIGNMENT_CREATED_SUBJECT,
-    body: b => b.body || ASSIGNMENT_CREATED_BODY
+    subject: s => s.subject || defaultAssignmentSubject,
+    body: b => b.body || defaultAssignmentBody
   }
 }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -518,6 +518,23 @@ const rootMutations = {
 
       return await Organization.get(organizationId)
     },
+    updateUserAssignmentMessage: async (
+      _,
+      { organizationId, subject, body },
+      { user }
+    ) => {
+      await accessRequired(user, organizationId, 'OWNER')
+
+      const organization = await Organization.get(organizationId)
+      const featuresJSON = JSON.parse(organization.features || '{}')
+      featuresJSON.assignment_message = { subject, body }
+      organization.features = JSON.stringify(featuresJSON)
+
+      await organization.save()
+      await organizationCache.clear(organizationId)
+
+      return await Organization.get(organizationId)
+    },
     createInvite: async (_, { user }) => {
       if ((user && user.is_superadmin) || !process.env.SUPPRESS_SELF_INVITE) {
         const inviteInstance = new Invite({

--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -16,6 +16,9 @@ async function getOrganizationOwner(organizationId) {
     .limit(1)
     .eqJoin('user_id', r.table('user'))('right')(0)
 }
+
+export const ASSIGNMENT_CREATED_SUBJECT = '[{organizationName}] New assignment: {campaignTitle}'
+export const ASSIGNMENT_CREATED_BODY = 'You just got a new texting assignment from {organizationName}. You can start sending texts right away: \n\n{todoUrl}'
 const sendAssignmentUserNotification = async (assignment, notification) => {
   const campaign = await Campaign.get(assignment.campaign_id)
 
@@ -27,14 +30,15 @@ const sendAssignmentUserNotification = async (assignment, notification) => {
   const user = await User.get(assignment.user_id)
   const orgOwner = await getOrganizationOwner(organization.id)
 
+  const todoUrl = `${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
   let subject
   let text
   if (notification === Notifications.ASSIGNMENT_UPDATED) {
     subject = `[${organization.name}] Updated assignment: ${campaign.title}`
     text = `Your assignment changed: \n\n${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
   } else if (notification === Notifications.ASSIGNMENT_CREATED) {
-    subject = `[${organization.name}] New assignment: ${campaign.title}`
-    text = `You just got a new texting assignment from ${organization.name}. You can start sending texts right away: \n\n${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
+    subject = ASSIGNMENT_CREATED_SUBJECT
+    text = ASSIGNMENT_CREATED_BODY
   }
 
   try {

--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -24,8 +24,8 @@ const getNotificationFields = (organization, campaign) => ({
   todoUrl: `${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
 })
 
-export const ASSIGNMENT_CREATED_SUBJECT = '[{organizationName}] New assignment: {campaignTitle}'
-export const ASSIGNMENT_CREATED_BODY = 'You just got a new texting assignment from {organizationName}. You can start sending texts right away: \n\n{todoUrl}'
+export const defaultAssignmentSubject = '[{organizationName}] New assignment: {campaignTitle}'
+export const defaultAssignmentBody = 'You just got a new texting assignment from {organizationName}. You can start sending texts right away: \n\n{todoUrl}'
 
 const sendAssignmentUserNotification = async (assignment, notification) => {
   const campaign = await Campaign.get(assignment.campaign_id)
@@ -47,8 +47,8 @@ const sendAssignmentUserNotification = async (assignment, notification) => {
     text = `Your assignment changed: \n\n${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
   } else if (notification === Notifications.ASSIGNMENT_CREATED) {
     const custMessage = JSON.parse(organization.features || '{}').assignment_message || {}
-    subject = custMessage.subject || ASSIGNMENT_CREATED_SUBJECT
-    text = custMessage.body || ASSIGNMENT_CREATED_BODY
+    subject = custMessage.subject || defaultAssignmentSubject
+    text = custMessage.body || defaultAssignmentBody
     for (const field of Object.keys(fieldReplacements)) {
       const re = new RegExp(`${delimit(field)}`, 'g')
       subject = subject.replace(re, fieldReplacements[field])

--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -1,5 +1,6 @@
 import { r, Assignment, Campaign, User, Organization } from './models'
 import { log } from '../lib'
+import { delimit } from '../lib/scripts'
 import { sendEmail } from './mail'
 
 export const Notifications = {
@@ -17,8 +18,15 @@ async function getOrganizationOwner(organizationId) {
     .eqJoin('user_id', r.table('user'))('right')(0)
 }
 
+const getNotificationFields = (organization, campaign) => ({
+  organizationName: organization.name,
+  campaignTitle: campaign.title,
+  todoUrl: `${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
+})
+
 export const ASSIGNMENT_CREATED_SUBJECT = '[{organizationName}] New assignment: {campaignTitle}'
 export const ASSIGNMENT_CREATED_BODY = 'You just got a new texting assignment from {organizationName}. You can start sending texts right away: \n\n{todoUrl}'
+
 const sendAssignmentUserNotification = async (assignment, notification) => {
   const campaign = await Campaign.get(assignment.campaign_id)
 
@@ -30,15 +38,22 @@ const sendAssignmentUserNotification = async (assignment, notification) => {
   const user = await User.get(assignment.user_id)
   const orgOwner = await getOrganizationOwner(organization.id)
 
-  const todoUrl = `${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
+  const fieldReplacements = getNotificationFields(organization, campaign)
+
   let subject
   let text
   if (notification === Notifications.ASSIGNMENT_UPDATED) {
     subject = `[${organization.name}] Updated assignment: ${campaign.title}`
     text = `Your assignment changed: \n\n${process.env.BASE_URL}/app/${campaign.organization_id}/todos`
   } else if (notification === Notifications.ASSIGNMENT_CREATED) {
-    subject = ASSIGNMENT_CREATED_SUBJECT
-    text = ASSIGNMENT_CREATED_BODY
+    const custMessage = JSON.parse(organization.features || '{}').assignment_message || {}
+    subject = custMessage.subject || ASSIGNMENT_CREATED_SUBJECT
+    text = custMessage.body || ASSIGNMENT_CREATED_BODY
+    for (const field of Object.keys(fieldReplacements)) {
+      const re = new RegExp(`${delimit(field)}`, 'g')
+      subject = subject.replace(re, fieldReplacements[field])
+      text = text.replace(re, fieldReplacements[field])
+    }
   }
 
   try {


### PR DESCRIPTION
closes #719 

Reuses the script editor for editing these assignment emails in a way that hopefully isn't too confusing.

![image](https://user-images.githubusercontent.com/872456/45893401-1aad2180-bd99-11e8-8dc0-2f4fa13ada62.png)

Maybe the settings should only have one save button, but I'm not sure because I'd have to change around the way texting hours and opt-out message works.

Happy to make any changes.