### PR TITLE
[WIP] Profanity filter

### DIFF
--- a/__test__/lib/profanity.test.js
+++ b/__test__/lib/profanity.test.js
@@ -1,0 +1,13 @@
+import { isProfane } from '../../src/lib/profanity'
+
+describe('profanity test', () => {
+  it('correctly identifies profanity', () => {
+    expect(isProfane('fuck')).toEqual(true)
+    expect(isProfane('FUCK')).toEqual(true)
+    expect(isProfane('go fuck yourself')).toEqual(true)
+    expect(isProfane('fuck you')).toEqual(true)
+    expect(isProfane('you fuck')).toEqual(true)
+    expect(isProfane('you fucker')).toEqual(true)
+    expect(isProfane('fck')).toEqual(false)
+  })
+})

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -147,3 +147,5 @@ export const convertRowToContact = (row) => {
   contact.customFields = customFields
   return contact
 }
+
+export { isProfane } from './profanity'

--- a/src/lib/profanity.js
+++ b/src/lib/profanity.js
@@ -1,0 +1,5 @@
+export function isProfane(messageText) {
+  // TODO(lperson) future: return different categories, such as profane, abusive, etc.
+  const profanity = /.*fuck.*/i
+  return profanity.test(messageText)
+}

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -155,6 +155,21 @@ const migrations = [
 
       console.log('added texting hours fields to campaign')
     }
+  },
+  {
+    auto: true, // 13
+    date: '2018-09-22',
+    migrate: async () => {
+      console.log('creating campaign_contact_tag table')
+      await r.knex.schema.createTableIfNotExists('campaign_contact_tag', (table) => {
+        table.increments('id').unsigned().primary()
+        table.integer('campaign_contact_id').unsigned().notNullable().index().references('id').inTable('campaign_contact')
+        table.string('tag', 16).notNullable()
+        table.timestamp('created_at').notNullable()
+        table.integer('message_id').unsigned().nullable().references('id').inTable('message')
+      })
+      console.log('created campaign_contact_tag table')
+    }
   }
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically

--- a/src/server/api/lib/profanity.js
+++ b/src/server/api/lib/profanity.js
@@ -1,0 +1,13 @@
+import CampaignContactTag from '../../models/campaign-contact-tag'
+
+export async function tagProfaneMessage(campaignContact, message) {
+
+  const campaignContactTag = new CampaignContactTag({
+    campaign_contact_id: campaignContact.id,
+    tag: 'PROFANITY',
+    created_at: new Date(),
+    message_id: message.id
+  })
+
+  await campaignContactTag.save()
+}

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -960,8 +960,6 @@ const rootMutations = {
 
       await messageInstance.save()
 
-      const service = serviceMap[messageInstance.service || process.env.DEFAULT_SERVICE]
-
       if (contact.message_status === 'needsResponse') {
         contact.message_status = 'convo'
       } else {
@@ -976,6 +974,7 @@ const rootMutations = {
         tagProfaneMessage(contact, messageInstance)
       } else {
         //send the message
+        const service = serviceMap[messageInstance.service || process.env.DEFAULT_SERVICE]
         service.sendMessage(messageInstance)
       }
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -63,6 +63,7 @@ import {
   superAdminRequired
 } from './errors'
 import serviceMap from './lib/services'
+import { tagProfaneMessage } from './lib/profanity'
 import { saveNewIncomingMessage } from './lib/message-sending'
 import { gzip, log, makeTree, isProfane } from '../../lib'
 // import { isBetweenTextingHours } from '../../lib/timezones'
@@ -970,10 +971,9 @@ const rootMutations = {
       contact.updated_at = 'now()'
       await contact.save()
 
-      if (isProfane()) {
+      if (isProfane(message.text)) {
         // don't send the message
-
-        // apply tags
+        tagProfaneMessage(contact, messageInstance)
       } else {
         //send the message
         service.sendMessage(messageInstance)

--- a/src/server/models/campaign-contact-tag.js
+++ b/src/server/models/campaign-contact-tag.js
@@ -14,13 +14,12 @@ const CampaignContactTag = thinky.createModel(
       campaign_contact_id: requiredString(),
       tag: requiredString(),
       created_at: timestamp(),
-      message_id: type.integer().optional()
+      message_id: type.string().allowNull(true)
     })
     .allowExtra(false),
   { noAutoCreation: true, dependencies: [CampaignContact, Message] }
 )
 
 CampaignContactTag.ensureIndex('campaign_contact_id')
-CampaignContactTag.ensureIndex('message_id')
 
 export default CampaignContactTag

--- a/src/server/models/campaign-contact-tag.js
+++ b/src/server/models/campaign-contact-tag.js
@@ -1,0 +1,26 @@
+import thinky from './thinky'
+import { requiredString, timestamp } from './custom-types'
+import CampaignContact from './campaign-contact'
+import Message from './message'
+
+const type = thinky.type
+
+const CampaignContactTag = thinky.createModel(
+  'campaign_contact_tag',
+  type
+    .object()
+    .schema({
+      id: type.string(),
+      campaign_contact_id: requiredString(),
+      tag: requiredString(),
+      created_at: timestamp(),
+      message_id: type.integer().optional()
+    })
+    .allowExtra(false),
+  { noAutoCreation: true, dependencies: [CampaignContact, Message] }
+)
+
+CampaignContactTag.ensureIndex('campaign_contact_id')
+CampaignContactTag.ensureIndex('message_id')
+
+export default CampaignContactTag

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -7,6 +7,7 @@ import Organization from './organization'
 import Campaign from './campaign'
 import Assignment from './assignment'
 import CampaignContact from './campaign-contact'
+import CampaignContactTag from './campaign-contact-tag'
 import InteractionStep from './interaction-step'
 import QuestionResponse from './question-response'
 import OptOut from './opt-out'
@@ -45,14 +46,15 @@ const tableList = [
   'user', // good candidate
   'campaign', //good candidate
   'assignment',
-  // the rest are alphabetical
-  'campaign_contact', //?good candidate (or by cell)
-  'canned_response', //good candidate
+  'campaign_contact', // good candidat4e (or by cell)
+  // the rest are alphabetical, except as noted
+  'canned_response', // good candidate
   'interaction_step',
   'invite',
   'job_request',
   'log',
   'message',
+  'campaign_contact_tag', // depends on message and campaign_contact
   'migrations',
   'opt_out',  //good candidate
   'pending_message_part',
@@ -90,6 +92,7 @@ const createLoaders = () => ({
   user: createLoader(User),
   interactionStep: createLoader(InteractionStep),
   campaignContact: createLoader(CampaignContact),
+  campaignContactTag: createLoader(CampaignContactTag),
   zipCode: createLoader(ZipCode, {idKey: 'zip'}),
   log: createLoader(Log),
   cannedResponse: createLoader(CannedResponse),
@@ -117,6 +120,7 @@ export {
   Assignment,
   Campaign,
   CampaignContact,
+  CampaignContactTag,
   InteractionStep,
   Invite,
   JobRequest,


### PR DESCRIPTION
closes #359 

The first commit creates a table to associate tags with `campaign_contact`s, introduces a rudimentary profanity detection function, tests outgoing messages with that function, and if a message is profane, it doesn't send it and it adds an entry in the new `campaign_contact_tag` table.  

Next steps toward an MVP:

- [ ] apply profanity detection to incoming messages (same pattern -- create a tag, prevent the tester from seeing the incoming message)
- [ ] add ability to filter for tagged messages in Message Review
- [ ] add ability to resolve tagged messages in Message Review (resolution options may include opt the contact out, send the message if the flagged message is outgoing, reassign the contact, allow the message to be delivered to the tester, etc.)

Thoughts about profanity detection:

- [ ] to build out the profanity detection, will it just be a list of regular expressions?
- [ ] where will this be stored?  configuration file, database, hardcoded?
- [ ] should we have separate filters for incoming and outgoing messages?

