### PR TITLE
default to null for max_contacts assignments

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -467,7 +467,9 @@ const rootMutations = {
         await Assignment.save({
           user_id: user.id,
           campaign_id: campaign.id,
-          max_contacts: parseInt(process.env.MAX_CONTACTS_PER_TEXTER || 0, 10)
+          max_contacts: (typeof process.env.MAX_CONTACTS_PER_TEXTER != 'undefined'
+                         ? Number(process.env.MAX_CONTACTS_PER_TEXTER)
+                         : null)
         })
       }
       return campaign


### PR DESCRIPTION
null means infinite, 0 means none unless assigned.  this should be null since it's when the user logs in for the first time.