### PR TITLE
Scaling by stream contacts

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -11,6 +11,12 @@ const jobs = require('./build/server/workers/job-processes')
 // See: http://docs.aws.amazon.com/lambda/latest/dg/best-practices.html#function-code
 // "Separate the Lambda handler (entry point) from your core logic"
 
+let invocationContext = {}
+let invocationEvent = {}
+app.default.set('awsContextGetter', function(req, res) {
+  return [invocationEvent, invocationContext]
+})
+
 exports.handler = (event, context, handleCallback) => {
   // Note: When lambda is called with invoke() we MUST call handleCallback with a success
   // or Lambda will re-run/re-try the invocation twice:
@@ -21,6 +27,8 @@ exports.handler = (event, context, handleCallback) => {
   if (!event.command) {
     // default web server stuff
     const startTime = (context.getRemainingTimeInMillis ? context.getRemainingTimeInMillis() : 0)
+    invocationEvent = event
+    invocationContext = context
     const webResponse = awsServerlessExpress.proxy(server, event, context)
     if (process.env.DEBUG_SCALING) {
       const endTime = (context.getRemainingTimeInMillis ? context.getRemainingTimeInMillis() : 0)

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "passport-local": "^1.0.0",
     "passport-local-authenticate": "^1.2.0",
     "pg": "^6.4.2",
+    "pg-query-stream": "^1.1.1",
     "prop-types": "^15.6.0",
     "query-string": "^4.1.0",
     "react": "^15.6.1",

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -643,7 +643,7 @@ const rootMutations = {
       cacheableData.campaign.reload(id)
       return campaign
     },
-    startCampaign: async (_, { id }, { user, loaders }) => {
+    startCampaign: async (_, { id }, { user, loaders, remainingMilliseconds }) => {
       const campaign = await loaders.campaign.load(id)
       await accessRequired(user, campaign.organization_id, 'ADMIN')
       campaign.is_started = true
@@ -660,7 +660,7 @@ const rootMutations = {
       cacheableData.assignment.loadCampaignAssignments(campaign)
       cacheableData.campaignContact.loadMany(
         await loaders.organization.load(campaign.organization_id),
-        { campaign })
+        { campaign, remainingMilliseconds })
       return campaign
     },
     editCampaign: async (_, { id, campaign }, { user, loaders }) => {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -649,18 +649,18 @@ const rootMutations = {
       campaign.is_started = true
 
       await campaign.save()
-      // some synchronous caching:
+      // some synchronous tasks:
       await cacheableData.campaign.reload(id)
+      await sendUserNotification({
+        type: Notifications.CAMPAIGN_STARTED,
+        campaignId: id
+      })
 
       // some asynchronous cache-priming:
       cacheableData.assignment.loadCampaignAssignments(campaign)
       cacheableData.campaignContact.loadMany(
         await loaders.organization.load(campaign.organization_id),
         { campaign })
-      await sendUserNotification({
-        type: Notifications.CAMPAIGN_STARTED,
-        campaignId: id
-      })
       return campaign
     },
     editCampaign: async (_, { id, campaign }, { user, loaders }) => {

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -2,6 +2,7 @@ import { r, getMessageServiceSid, CampaignContact } from '../../models'
 import optOutCache from './opt-out'
 import { modelWithExtraProps } from './lib'
 import { updateAssignmentContact } from './assignment-contacts'
+import { Writable } from 'stream'
 
 // TODO: for dynamic assignment, the assignment_id should NOT be set
 // -- so it can be loaded before it's assigned
@@ -132,7 +133,7 @@ const campaignContactCache = {
     }
     return await CampaignContact.get(id)
   },
-  loadMany: async (organization, { campaign, queryFunc }) => {
+  loadMany: async (organization, { campaign, queryFunc, remainingMilliseconds }) => {
     // queryFunc(query) has query input of a knex query
     // queryFunc should return a query with added where clauses
     if (!r.redis || !organization || !(campaign || queryFunc)) {
@@ -162,13 +163,35 @@ const campaignContactCache = {
     if (queryFunc) {
       query = queryFunc(query)
     }
-    const dbResult = await query
-    // 2. cache the data
     const messageServiceSid = getMessageServiceSid(organization)
-    for (let i = 0, l = dbResult.length; i < l; i++) {
-      const dbRecord = dbResult[i]
-      await saveCacheRecord(dbRecord, organization, messageServiceSid)
-    }
+
+    // We process the results in a stream, because this could be a very large result
+    await query.stream((stream) => {
+      const cacheSaver = new Writable({ objectMode: true })
+      // eslint-disable-next-line no-underscore-dangle
+      cacheSaver._write = (dbRecord, enc, next) => {
+        // Note: non-async land
+        saveCacheRecord(dbRecord, organization, messageServiceSid)
+          .then(
+            () => {
+              // If we are passed a remainingMilliseconds function, then
+              // run it and see if we're almost at-time.
+              // The rest of the cache loading will have to be done later
+              // FUTURE: consider making this a job that can divide work up and complete
+              if (typeof remainingMilliseconds === 'function'
+                  && remainingMilliseconds() < 2000) {
+                stream.end()
+              }
+              next()
+            },
+            (err) => {
+              console.error('FAILED CACHE SAVE', err)
+              stream.end()
+              next()
+            })
+      }
+      stream.pipe(cacheSaver)
+    })
   },
   lookupByCell: async (cell, service, messageServiceSid, bailWithoutCache) => {
     // Used to lookup contact/campaign information by cell number for incoming messages

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -166,6 +166,9 @@ const campaignContactCache = {
     const messageServiceSid = getMessageServiceSid(organization)
 
     // We process the results in a stream, because this could be a very large result
+    // For docs see:
+    // https://knexjs.org/#Interfaces-Streams
+    // https://github.com/substack/stream-handbook#creating-a-writable-stream
     await query.stream((stream) => {
       const cacheSaver = new Writable({ objectMode: true })
       // eslint-disable-next-line no-underscore-dangle


### PR DESCRIPTION
If we try to load all the contacts of a HUGE campaign when the campaign starts, it very well could terminate, and the resultant data alone would go out-of-memory.

So instead, we use a 'stream' to pipe the results and cache everything we can.

In order to do this we need the aws lambda `context` object to know when to stop.