### PR TITLE
Clear loader cache

### DIFF
--- a/src/server/models/cacheable_queries/assignment.js
+++ b/src/server/models/cacheable_queries/assignment.js
@@ -1,4 +1,4 @@
-import { r } from '../../models'
+import { r, loaders } from '../../models'
 import campaignCache from './campaign'
 import { loadAssignmentContacts, getContacts, optOutContact } from './assignment-contacts'
 
@@ -115,6 +115,7 @@ const loadDeep = async (id) => {
     // console.log('cached campaign for assn', campaign)
     await saveCache(assignment, campaign)
   }
+  loaders.assignment.clear(id)
   return { assignment }
 }
 
@@ -133,12 +134,14 @@ const assignmentCache = {
     if (r.redis) {
       await r.redis.delAsync(assignmentHashKey(id))
     }
+    loaders.assignment.clear(id)
   },
   clearAll: async (ids) => {
     if (r.redis && ids && ids.length) {
       const keys = ids.map(id => assignmentHashKey(id))
       await r.redis.delAsync(...keys)
     }
+    loaders.assignment.clearAll()
   },
   reload: loadDeep,
   load: async (id) => {

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -1,4 +1,4 @@
-import { r, getMessageServiceSid, CampaignContact } from '../../models'
+import { r, loaders, getMessageServiceSid, CampaignContact } from '../../models'
 import optOutCache from './opt-out'
 import { modelWithExtraProps } from './lib'
 import { updateAssignmentContact } from './assignment-contacts'
@@ -111,6 +111,7 @@ const campaignContactCache = {
     if (r.redis) {
       await r.redis.delAsync(cacheKey(id), messageStatusKey(id))
     }
+    loaders.campaignContact.clear(id)
   },
   load: async(id) => {
     if (r.redis) {
@@ -139,6 +140,7 @@ const campaignContactCache = {
     if (!r.redis || !organization || !(campaign || queryFunc)) {
       return
     }
+    loaders.campaignContact.clearAll()
     // 1. load the data
     let query = r.knex('campaign_contact')
       .leftJoin('zip_code', 'zip_code.zip', 'campaign_contact.zip')

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -1,4 +1,4 @@
-import { r, Campaign } from '../../models'
+import { r, loaders, Campaign } from '../../models'
 import { modelWithExtraProps } from './lib'
 import { assembleAnswerOptions } from '../../../lib/interaction-step-helpers'
 
@@ -51,10 +51,12 @@ const clear = async (id) => {
     // console.log('clearing campaign cache')
     await r.redis.delAsync(cacheKey(id))
   }
+  loaders.campaign.clear(id)
 }
 
 const loadDeep = async (id) => {
   // console.log('load campaign deep', id)
+  loaders.campaign.clear(id)
   if (r.redis) {
     const campaign = await Campaign.get(id)
     if (Array.isArray(campaign) && campaign.length === 0) {

--- a/src/server/models/cacheable_queries/organization.js
+++ b/src/server/models/cacheable_queries/organization.js
@@ -1,4 +1,4 @@
-import { r } from '../../models'
+import { r, loaders } from '../../models'
 
 const cacheKey = (orgId) => `${process.env.CACHE_PREFIX || ''}org-${orgId}`
 
@@ -7,6 +7,7 @@ const organizationCache = {
     if (r.redis) {
       await r.redis.delAsync(cacheKey(id))
     }
+    loaders.organization.clear(id)
   },
   load: async (id) => {
     if (r.redis) {

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -99,7 +99,9 @@ function getMessageServiceSid(organization) {
   return orgSid
 }
 
-const createLoaders = () => ({
+const loaders = {
+  // Note: loaders with cacheObj should also run loaders.XX.clear(id)
+  //  on clear on the cache as well.
   assignment: createLoader(Assignment, {cacheObj: cacheableData.assignment}),
   campaign: createLoader(Campaign, {cacheObj: cacheableData.campaign}),
   invite: createLoader(Invite),
@@ -118,11 +120,14 @@ const createLoaders = () => ({
   questionResponse: createLoader(QuestionResponse),
   userCell: createLoader(UserCell),
   userOrganization: createLoader(UserOrganization)
-})
+}
+
+const createLoaders = () => loaders
 
 const r = thinky.r
 
 export {
+  loaders,
   createLoaders,
   r,
   cacheableData,


### PR DESCRIPTION
when something is reloaded or cleared we should make sure that application state memoized cache (in DataLoader) is also cleared
See:
https://github.com/facebook/dataloader#disabling-cache