### PR TITLE
934 orgless user

### DIFF
--- a/docs/REFERENCE-environment_variables.md
+++ b/docs/REFERENCE-environment_variables.md
@@ -76,3 +76,5 @@ WAREHOUSE_DB_{TYPE,HOST,PORT,NAME,USER,PASSWORD}   | Enables ability to load con
 WAREHOUSE_DB_LAMBDA_ITERATION     | If the WAREHOUSE_DB_ connection/feature is enabled, then on AWS Lambda, queries that take longer than 5min can expire.  This will enable incrementing through queries on new lambda invocations to avoid timeouts.
 WEBPACK_HOST                      | Host domain or IP for Webpack development server. _Default_: 127.0.0.1.
 WEBPACK_PORT                      | Port for Webpack development server. _Defaut_: 3000.
+FIX_ORGLESS                       | Set to any truthy value only if you want to run the job that automatically assigns the default org (see DEFAULT_ORG) to new users who have no assigned org.
+DEFAULT_ORG                       | Set only with FIX_ORGLESS. Set to integer organization.id corresponding to the organization you want orgless users to be assigned to.

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -429,14 +429,21 @@ const rootMutations = {
           .filter({ organization_id: organization.id })
           .limit(1)(0)
           .default(null)
-
         if (!userOrg) {
           await UserOrganization.save({
             user_id: user.id,
             organization_id: organization.id,
             role: 'TEXTER'
-          })
+          }).error(function(error) {
+            // Unexpected errors
+            console.log("error on userOrganization save", error)
+          });
+
+        } else { // userOrg exists
+          console.log('existing userOrg ' + userOrg.id + ' user ' + user.id + ' organizationUuid ' + organizationUuid )
         }
+      } else { // no organization 
+        console.log('no organization with id ' + organizationUuid + ' for user ' + user.id)
       }
       return organization
     },

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -8,6 +8,7 @@ import { exportCampaign,
          assignTexters,
          sendMessages,
          handleIncomingMessageParts,
+         fixOrgless,
          clearOldJobs } from './jobs'
 import { runMigrations } from '../migrations'
 import { setupUserNotificationObservers } from '../server/notifications'
@@ -187,7 +188,8 @@ const processMap = {
   messageSender234,
   messageSender56,
   messageSender789,
-  handleIncomingMessages
+  handleIncomingMessages,
+  fixOrgless
 }
 
 // if process.env.JOBS_SAME_PROCESS then we don't need to run
@@ -196,6 +198,7 @@ const syncProcessMap = {
   // 'failedMessageSender': failedMessageSender, //see method for danger
   handleIncomingMessages,
   checkMessageQueue,
+  fixOrgless,
   clearOldJobs
 }
 

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -918,6 +918,9 @@ export async function handleIncomingMessageParts() {
   }
 }
 
+// Temporary fix for orgless users
+// See https://github.com/MoveOnOrg/Spoke/issues/934
+// and job-processes.js
 export async function fixOrgless() {
   if (process.env.FIX_ORGLESS) {
     const orgless = await r.knex


### PR DESCRIPTION
To address #934. The fixOrgless job runs with the other "cleanup" jobs and adds orgless users to a default organization as texters. Two new env variables can be used to toggled on and off and set the default org, respectively. An earlier commit adds some error logging that might help us better understand how users end up being orgless in the first place.

I don't know exactly how to test the jobs that run as a scheduled event on Lambda - is there a better way of doing that than deploying to stage?