### PR TITLE
Texter tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ before_script:
 - chmod +x ./travis-run-e2e-tests
 script:
 - npm run test
+- npm run test-fakeredis
 - ./travis-run-e2e-tests

--- a/__test__/server/texter.test.js
+++ b/__test__/server/texter.test.js
@@ -63,8 +63,8 @@ it('should send an inital message to test contacts', async () => {
     false
   )
 
-  const ret2 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
-  const contact = ret2.data.getAssignmentContacts[0]
+  const contactResponse = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  const contact = contactResponse.data.getAssignmentContacts[0]
 
   const message = {
     contactNumber: contact.cell,
@@ -112,8 +112,8 @@ it('should send an inital message to test contacts', async () => {
   })
 
   // Refetch the contacts via gql to check the caching
-  const ret3 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
-  expect(ret3.data.getAssignmentContacts[0].messageStatus).toEqual('messaged')
+  const contactResponseAfterSending = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  expect(contactResponseAfterSending.data.getAssignmentContacts[0].messageStatus).toEqual('messaged')
 })
 
 it('should be able to receive a response and reply (using fakeService)', async () => {
@@ -132,8 +132,8 @@ it('should be able to receive a response and reply (using fakeService)', async (
     false
   )
 
-  const ret2 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
-  const contact = ret2.data.getAssignmentContacts[0]
+  const contactResponse = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  const contact = contactResponse.data.getAssignmentContacts[0]
 
   const message = {
     contactNumber: contact.cell,
@@ -168,8 +168,8 @@ it('should be able to receive a response and reply (using fakeService)', async (
   })
 
   // Refetch the contacts via gql to check the caching
-  const ret3 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
-  expect(ret3.data.getAssignmentContacts[0].messageStatus).toEqual('needsResponse')
+  const contactResponseAfterSending = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  expect(contactResponseAfterSending.data.getAssignmentContacts[0].messageStatus).toEqual('needsResponse')
 
   // Then we reply
   const message2 = {

--- a/__test__/server/texter.test.js
+++ b/__test__/server/texter.test.js
@@ -1,0 +1,207 @@
+/* eslint-disable no-unused-expressions, consistent-return */
+import { r } from '../../src/server/models/'
+import {
+  runGql,
+  setupTest,
+  cleanupTest,
+  getGql,
+  createUser,
+  createInvite,
+  createOrganization,
+  createCampaign,
+  createContact,
+  createTexter,
+  assignTexter,
+  createScript,
+  startCampaign,
+  getCampaignContact
+} from '../test_helpers'
+import waitForExpect from 'wait-for-expect'
+
+let testAdminUser
+let testInvite
+let testOrganization
+let testCampaign
+let testTexterUser
+let testContact
+let assignmentId
+
+beforeEach(async () => {
+  // Set up an entire working campaign
+  await setupTest()
+  testAdminUser = await createUser()
+  testInvite = await createInvite()
+  testOrganization = await createOrganization(testAdminUser, testInvite)
+  testCampaign = await createCampaign(testAdminUser, testOrganization)
+  testContact = await createContact(testCampaign)
+  testTexterUser = await createTexter(testOrganization)
+  await assignTexter(testAdminUser, testTexterUser, testCampaign)
+  const dbCampaignContact = await getCampaignContact(testContact.id)
+  assignmentId = dbCampaignContact.assignment_id
+  await createScript(testAdminUser, testCampaign)
+  await startCampaign(testAdminUser, testCampaign)
+}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT)
+
+afterEach(async () => {
+  await cleanupTest()
+  if (r.redis) r.redis.flushdb()
+}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT)
+
+it('should send an inital message to test contacts', async () => {
+  const {
+    query: [getContacts, getContactsVars],
+    mutations
+  } = getGql('../src/containers/TexterTodo', {
+    messageStatus: 'needsMessage',
+    params: { assignmentId }
+  })
+
+  const contactsResult = await runGql(getContacts, getContactsVars, testTexterUser)
+
+  const [getAssignmentContacts, assignVars] = mutations.getAssignmentContacts(
+    contactsResult.data.assignment.contacts.map(e => e.id),
+    false
+  )
+
+  const ret2 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  const contact = ret2.data.getAssignmentContacts[0]
+
+  const message = {
+    contactNumber: contact.cell,
+    userId: testTexterUser.id,
+    text: 'test text',
+    assignmentId
+  }
+
+  const [messageMutation, messageVars] = mutations.sendMessage(message, contact.id)
+
+  const messageResult = await runGql(messageMutation, messageVars, testTexterUser)
+  const campaignContact = messageResult.data.sendMessage
+
+  // These things are expected to be returned from the sendMessage mutation
+  expect(campaignContact.messageStatus).toBe('messaged')
+  expect(campaignContact.messages.length).toBe(1)
+  expect(campaignContact.messages[0].text).toBe(message.text)
+
+  const expectedDbMessage = {
+    user_id: testTexterUser.id,
+    contact_number: testContact.cell,
+    text: message.text,
+    assignment_id: assignmentId,
+    campaign_contact_id: testContact.id
+  }
+
+  // wait for fakeservice to mark the message as sent
+  await waitForExpect(async () => {
+    const dbMessage = await r.knex('message')
+    expect(dbMessage.length).toEqual(2)
+    expect(dbMessage[0]).toEqual(
+      expect.objectContaining({
+        send_status: 'SENDING',
+        ...expectedDbMessage
+      })
+    )
+    expect(dbMessage[1]).toEqual(
+      expect.objectContaining({
+        send_status: 'SENT',
+        ...expectedDbMessage
+      })
+    )
+    const dbCampaignContact = await getCampaignContact(testContact.id)
+    expect(dbCampaignContact.message_status).toBe('messaged')
+  })
+
+  // Refetch the contacts via gql to check the caching
+  const ret3 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  expect(ret3.data.getAssignmentContacts[0].messageStatus).toEqual('messaged')
+})
+
+it('should be able to receive a response and reply (using fakeService)', async () => {
+  const {
+    query: [getContacts, getContactsVars],
+    mutations
+  } = getGql('../src/containers/TexterTodo', {
+    messageStatus: 'needsMessage',
+    params: { assignmentId }
+  })
+
+  const contactsResult = await runGql(getContacts, getContactsVars, testTexterUser)
+
+  const [getAssignmentContacts, assignVars] = mutations.getAssignmentContacts(
+    contactsResult.data.assignment.contacts.map(e => e.id),
+    false
+  )
+
+  const ret2 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  const contact = ret2.data.getAssignmentContacts[0]
+
+  const message = {
+    contactNumber: contact.cell,
+    userId: testTexterUser.id,
+    text: 'test text autorespond',
+    assignmentId
+  }
+
+  const [messageMutation, messageVars] = mutations.sendMessage(message, contact.id)
+
+  await runGql(messageMutation, messageVars, testTexterUser)
+
+  // wait for fakeservice to autorespond
+  await waitForExpect(async () => {
+    const dbMessage = await r.knex('message')
+    expect(dbMessage.length).toEqual(3)
+    expect(dbMessage[2]).toEqual(
+      expect.objectContaining({
+        send_status: 'DELIVERED',
+        text: `responding to ${message.text}`,
+        user_id: testTexterUser.id,
+        contact_number: testContact.cell,
+        assignment_id: assignmentId,
+        campaign_contact_id: testContact.id
+      })
+    )
+  })
+
+  await waitForExpect(async () => {
+    const dbCampaignContact = await getCampaignContact(testContact.id)
+    expect(dbCampaignContact.message_status).toBe('needsResponse')
+  })
+
+  // Refetch the contacts via gql to check the caching
+  const ret3 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  expect(ret3.data.getAssignmentContacts[0].messageStatus).toEqual('needsResponse')
+
+  // Then we reply
+  const message2 = {
+    contactNumber: contact.cell,
+    userId: testTexterUser.id,
+    text: 'reply',
+    assignmentId
+  }
+
+  const [replyMutation, replyVars] = mutations.sendMessage(message2, contact.id)
+
+  await runGql(replyMutation, replyVars, testTexterUser)
+
+  // wait for fakeservice to mark the message as sent
+  await waitForExpect(async () => {
+    const dbMessage = await r.knex('message')
+    expect(dbMessage.length).toEqual(5)
+    expect(dbMessage[3]).toEqual(
+      expect.objectContaining({
+        send_status: 'SENDING'
+      })
+    )
+    expect(dbMessage[4]).toEqual(
+      expect.objectContaining({
+        send_status: 'SENT'
+      })
+    )
+    const dbCampaignContact = await getCampaignContact(testContact.id)
+    expect(dbCampaignContact.message_status).toBe('convo')
+  })
+
+  // Refetch the contacts via gql to check the caching
+  const ret4 = await runGql(getAssignmentContacts, assignVars, testTexterUser)
+  expect(ret4.data.getAssignmentContacts[0].messageStatus).toEqual('convo')
+})

--- a/__test__/setup.js
+++ b/__test__/setup.js
@@ -1,6 +1,6 @@
 import { configure } from 'enzyme'
 import Adapter from 'enzyme-adapter-react-15'
+import 'babel-polyfill'
 
 
 configure({ adapter: new Adapter() })
-

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -138,7 +138,6 @@ export async function createCampaign(user, organization) {
   const title = 'test campaign'
   const description = 'test description'
   const organizationId = organization.data.createOrganization.id
-  const contacts = []
   const context = getContext({ user })
 
   const campaignQuery = `mutation createCampaign($input: CampaignInput!) {
@@ -150,8 +149,7 @@ export async function createCampaign(user, organization) {
     input: {
       title,
       description,
-      organizationId,
-      contacts
+      organizationId
     }
   }
   const ret = await graphql(mySchema, campaignQuery, rootValue, context, variables)

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -1,5 +1,6 @@
-import { createLoaders, createTables, dropTables, r } from '../src/server/models/'
-import { sleep } from '../src/workers/lib'
+import _ from 'lodash'
+import { createLoaders, createTables, dropTables, User, CampaignContact, r } from '../src/server/models/'
+import { graphql } from 'graphql'
 
 export async function setupTest() {
   await createTables()
@@ -14,7 +15,249 @@ export function getContext(context) {
   return {
     ...context,
     req: {},
-    loaders: createLoaders(),
+    loaders: createLoaders()
   }
 }
+import loadData from '../src/containers/hoc/load-data'
+jest.mock('../src/containers/hoc/load-data')
+/* Used to get graphql queries from components.
+*  Because of some limitations with the jest require cache that
+*  I can't find a way of getting around, it should only be called once
+*  per test.
 
+*  The query it returns will be that of the requested component, but
+*  the mutations will be merged from the component and its children.
+*/
+export function getGql(componentPath, props) {
+  require(componentPath) // eslint-disable-line
+
+  const { mapQueriesToProps } = _.last(loadData.mock.calls)[1]
+
+  const mutations = loadData.mock.calls.reduce((acc, mapping) => {
+    if (!mapping[1].mapMutationsToProps) return acc
+    return {
+      ...acc,
+      ..._.mapValues(
+        mapping[1].mapMutationsToProps({ ownProps: props }),
+        mutation => (...params) => {
+          const m = mutation(...params)
+          return [m.mutation.loc.source.body, m.variables]
+        }
+      )
+    }
+  }, {})
+
+  let query
+  if (mapQueriesToProps) {
+    const data = mapQueriesToProps({ ownProps: props }).data
+    query = [data.query.loc.source.body, data.variables]
+  }
+
+  return { query, mutations }
+}
+
+export async function createUser(
+  userInfo = {
+    auth0_id: 'test123',
+    first_name: 'TestUserFirst',
+    last_name: 'TestUserLast',
+    cell: '555-555-5555',
+    email: 'testuser@example.com'
+  }
+) {
+  const user = new User(userInfo)
+  await user.save()
+  return user
+}
+
+export async function createContact(campaign) {
+  const campaignId = campaign.id
+
+  const contact = new CampaignContact({
+    first_name: 'Ann',
+    last_name: 'Lewis',
+    cell: '5555555555',
+    zip: '12345',
+    campaign_id: campaignId
+  })
+  await contact.save()
+  return contact
+}
+
+
+import { makeExecutableSchema } from 'graphql-tools'
+import { resolvers } from '../src/server/api/schema'
+import { schema } from '../src/api/schema'
+
+const mySchema = makeExecutableSchema({
+  typeDefs: schema,
+  resolvers,
+  allowUndefinedInResolve: true
+})
+
+const rootValue = {}
+
+export async function runGql(query, vars, user) {
+  const context = getContext({ user })
+  return await graphql(mySchema, query, rootValue, context, vars)
+}
+
+export async function createInvite() {
+  const inviteQuery = `mutation {
+    createInvite(invite: {is_valid: true}) {
+      id
+    }
+  }`
+  const context = getContext()
+  return await graphql(mySchema, inviteQuery, rootValue, context)
+}
+
+export async function createOrganization(user, invite) {
+  const name = 'Testy test organization'
+  const userId = user.id
+  const inviteId = invite.data.createInvite.id
+
+  const context = getContext({ user })
+
+  const orgQuery = `mutation createOrganization($name: String!, $userId: String!, $inviteId: String!) {
+    createOrganization(name: $name, userId: $userId, inviteId: $inviteId) {
+      id
+      uuid
+    }
+  }`
+
+  const variables = {
+    userId,
+    name,
+    inviteId
+  }
+  return await graphql(mySchema, orgQuery, rootValue, context, variables)
+}
+
+export async function createCampaign(user, organization) {
+  const title = 'test campaign'
+  const description = 'test description'
+  const organizationId = organization.data.createOrganization.id
+  const contacts = []
+  const context = getContext({ user })
+
+  const campaignQuery = `mutation createCampaign($input: CampaignInput!) {
+    createCampaign(campaign: $input) {
+      id
+    }
+  }`
+  const variables = {
+    input: {
+      title,
+      description,
+      organizationId,
+      contacts
+    }
+  }
+  const ret = await graphql(mySchema, campaignQuery, rootValue, context, variables)
+  return ret.data.createCampaign
+}
+
+export async function createTexter(organization) {
+  const user = await createUser({
+    auth0_id: 'test456',
+    first_name: 'TestTexterFirst',
+    last_name: 'TestTexterLast',
+    cell: '555-555-6666',
+    email: 'testtexter@example.com'
+  })
+  const joinQuery = `
+  mutation joinOrganization($organizationUuid: String!) {
+    joinOrganization(organizationUuid: $organizationUuid) {
+      id
+    }
+  }`
+  const variables = {
+    organizationUuid: organization.data.createOrganization.uuid
+  }
+  const context = getContext({ user })
+  await graphql(mySchema, joinQuery, rootValue, context, variables)
+  return user
+}
+
+export async function assignTexter(admin, user, campaign) {
+  const campaignEditQuery = `
+  mutation editCampaign($campaignId: String!, $campaign: CampaignInput!) {
+    editCampaign(id: $campaignId, campaign: $campaign) {
+      id
+    }
+  }`
+  const context = getContext({ user: admin })
+  const updateCampaign = Object.assign({}, campaign)
+  const campaignId = updateCampaign.id
+  updateCampaign.texters = [
+    {
+      id: user.id
+    }
+  ]
+  delete updateCampaign.id
+  delete updateCampaign.contacts
+  const variables = {
+    campaignId,
+    campaign: updateCampaign
+  }
+  return await graphql(mySchema, campaignEditQuery, rootValue, context, variables)
+}
+
+export async function createScript(admin, campaign) {
+  const campaignEditQuery = `
+  mutation editCampaign($campaignId: String!, $campaign: CampaignInput!) {
+    editCampaign(id: $campaignId, campaign: $campaign) {
+      id
+    }
+  }`
+  const context = getContext({ user: admin })
+  const campaignId = campaign.id
+  const variables = {
+    campaignId,
+    campaign: {
+      interactionSteps: {
+        id: '1',
+        questionText: 'Test',
+        script: '{zip}',
+        answerOption: '',
+        answerActions: '',
+        parentInteractionId: null,
+        isDeleted: false,
+        interactionSteps: [
+          {
+            id: '2',
+            questionText: 'hmm',
+            script: '{lastName}',
+            answerOption: 'hmm',
+            answerActions: '',
+            parentInteractionId: '1',
+            isDeleted: false,
+            interactionSteps: []
+          }
+        ]
+      }
+    }
+  }
+  return await graphql(mySchema, campaignEditQuery, rootValue, context, variables)
+}
+
+
+jest.mock('../src/server/mail')
+export async function startCampaign(admin, campaign) {
+  const startCampaignQuery = `mutation startCampaign($campaignId: String!) {
+    startCampaign(id: $campaignId) {
+      id
+    }
+  }`
+  const context = getContext({ user: admin })
+  const variables = { campaignId: campaign.id }
+  return await graphql(mySchema, startCampaignQuery, rootValue, context, variables)
+}
+
+export async function getCampaignContact(id) {
+  return await r
+  .knex('campaign_contact')
+  .where({ id })
+  .first()
+}

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -1,5 +1,3 @@
-There are current two ways to run tests, using either PostgreSQL or SQLite.
-
 ## PostgreSQL Testing (default, closer to most prod environments)
 
 1) Install PostgreSQL
@@ -11,17 +9,27 @@ GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 ```
 3) Run `npm test`
 
+## Testing with PostgreSQL and fakeredis
+
+Spoke has an additional cache in redis as described in [this document](./HOWTO-scale-spoke-plan.md). You can run the tests with this cache enabled with:
+```
+npm run test-fakeredis
+```
+You don't need to have redis running, as this uses an emulated version from npm.
+
+Note that this also requires the `spoke_test` PostgreSQL database described above.
+
 ## SQLite Testing (simpler)
 
 1) Run `npm run test-sqlite`
 
 ## End-To-End (Interactive Browser) Testing
 
-1. Remember to set `NODE_ENV=dev` 
+1. Remember to set `NODE_ENV=dev`
 1. **Start DB** and **Start Spoke Server** as described in the [Getting Started](
-https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section. 
+https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section.
 1. Install browser driver(s)
-    
+
     * Installing chromedriver on MacOS
         ```
         brew tap homebrew/cask
@@ -40,7 +48,7 @@ https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section.
       npm run test-e2e <test name>
       ```
     * ... using Sauce Labs browser with your local host
-      
+
       **Note:** You must first setup [Sauce Labs](https://github.com/MoveOnOrg/Spoke/blob/main/docs/EXPLANATION-end-to-end-tests.md#saucelabs)
       ```
       export SAUCE_USERNAME=<Sauce Labs user name>

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,9 +25,6 @@ module.exports = {
     "js",
     "jsx"
   ],
-  transform: {
-    ".*.js": "<rootDir>/node_modules/babel-jest"
-  },
   moduleDirectories: [
     "node_modules"
   ],

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "test": "jest --runInBand --forceExit",
+    "test-fakeredis": "REDIS_FAKE=1 npm run test",
     "test-e2e": "jest --runInBand --config jest.config.e2e.js",
     "test-sqlite": "jest --runInBand --config jest.config.sqlite.js",
     "test-coverage": "jest --coverage",
@@ -171,6 +172,7 @@
     "saucelabs": "^1.5.0",
     "selenium-webdriver": "^3.6.0",
     "sqlite3": "^3.1.9",
+    "wait-for-expect": "^1.0.1",
     "wait-on": "^2.1.0",
     "webpack-dev-server": "^2.9.4"
   }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -974,7 +974,7 @@ const rootMutations = {
       contact = await cacheableData.message.save({ messageInstance, contact })
       console.log('contact saved', contact)
 
-      const service = serviceMap[messageInstance.service || process.env.DEFAULT_SERVICE]
+      const service = serviceMap[messageInstance.service || process.env.DEFAULT_SERVICE || global.DEFAULT_SERVICE]
       service.sendMessage(messageInstance, contact)
       return contact
     },


### PR DESCRIPTION
This tests the texter flow by sending graphql queries.

- adds a test that sends initial message to a test contact
- adds a test that receives a response to a test contact and replies to that response
- adds `npm run test-fakeredis` that runs all tests with the redis cache enabled (and also runs this on travis)

Feel free to let me know if there is other data I should check in these tests, or other tests I should run.

closes #951 #307 #308 #309