### PR TITLE
Fix role change in admin filter people by campaign

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -127,7 +127,7 @@ const rootSchema = `
     message: MessageInput!
     campaignContactId: String!
   }
-  
+
   input OffsetLimitCursor {
     offset: Int!
     limit: Int!
@@ -153,7 +153,7 @@ const rootSchema = `
   type FoundContact {
     found: Boolean
   }
-  
+
   type PageInfo {
     limit: Int!
     offset: Int!
@@ -188,7 +188,7 @@ const rootSchema = `
     createCannedResponse(cannedResponse:CannedResponseInput!): CannedResponse
     createOrganization(name: String!, userId: String!, inviteId: String!): Organization
     joinOrganization(organizationUuid: String!): Organization
-    editOrganizationRoles(organizationId: String!, userId: String!, roles: [String]): Organization
+    editOrganizationRoles(organizationId: String!, userId: String!, campaignId: String, roles: [String]): Organization
     editUser(organizationId: String!, userId: Int!, userData:UserInput): User
     updateTextingHours( organizationId: String!, textingHoursStart: Int!, textingHoursEnd: Int!): Organization
     updateTextingHoursEnforcement( organizationId: String!, textingHoursEnforced: Boolean!): Organization
@@ -235,4 +235,3 @@ export const schema = [
   inviteSchema,
   conversationSchema
 ]
-

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -212,11 +212,11 @@ AdminPersonList.propTypes = {
   location: PropTypes.object
 }
 
-const mapMutationsToProps = () => ({
+const mapMutationsToProps = ({ ownProps }) => ({
   editOrganizationRoles: (organizationId, userId, roles) => ({
     mutation: gql`
-      mutation editOrganizationRoles($organizationId: String!, $userId: String!, $roles: [String]) {
-        editOrganizationRoles(organizationId: $organizationId, userId: $userId, roles: $roles) {
+      mutation editOrganizationRoles($organizationId: String!, $userId: String!, $roles: [String], $campaignId: String) {
+        editOrganizationRoles(organizationId: $organizationId, userId: $userId, roles: $roles, campaignId: $campaignId) {
           ${organizationFragment}
         }
       }
@@ -224,7 +224,8 @@ const mapMutationsToProps = () => ({
     variables: {
       organizationId,
       userId,
-      roles
+      roles,
+      campaignId: ownProps.location.query.campaignId
     }
   })
 })


### PR DESCRIPTION
The organization fragment we wanted to return after the role mutation required a campaignId. Introduced in #947 