### PR TITLE
Lambda version for assign texters

### DIFF
--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -167,11 +167,11 @@ export async function runDatabaseMigrations(event, dispatcher, eventCallback) {
   }
 }
 
-export async function loadContactsFromDataWarehouseFragmentJob(event, dispatcher, eventCallback) {
+async function asyncRunEventOrError(func, event, eventCallback) {
   const eventAsJob = event
   console.log('LAMBDA INVOCATION job-processes', event)
   try {
-    const rv = await loadContactsFromDataWarehouseFragment(eventAsJob)
+    const rv = await func(eventAsJob)
     if (eventCallback) {
       eventCallback(null, rv)
     }
@@ -180,6 +180,14 @@ export async function loadContactsFromDataWarehouseFragmentJob(event, dispatcher
       eventCallback(err, null)
     }
   }
+}
+
+export async function loadContactsFromDataWarehouseFragmentJob(event, dispatcher, eventCallback) {
+  return await asyncRunEventOrError(loadContactsFromDataWarehouseFragment, event, eventCallback)
+}
+
+export async function assignTextersJob(event, dispatcher, eventCallback) {
+  return await asyncRunEventOrError(assignTexters, event, eventCallback)
 }
 
 const processMap = {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -478,6 +478,17 @@ export async function assignTexters(job) {
 
   TODO: what happens when we switch modes? Do we allow it?
   */
+  if (process.env.ASSIGNTEXTERS_LAMBDA_ITERATION && !job.command) {
+    try {
+      await sendJobToAWSLambda({
+        command: 'assignTextersJob',
+          ...job
+      })
+      return // We'll do it in the lambda!
+    } catch(err) {
+      console.error('FAILED LAMBDA INVOCATION FOR assignTexters', err)
+    }
+  }
   const payload = JSON.parse(job.payload)
   const cid = job.campaign_id
   const campaign = (await r.knex('campaign').where({ id: cid }))[0]


### PR DESCRIPTION
The theory here is that sometimes the lambda will die before assignTexters finishes.
This way, we start a fresh lambda each time so we have the full 5 minutes
(When we enable `ASSIGNTEXTERS_LAMBDA_ITERATION`)

Addresses: #956 