### PR TITLE
People admin pagination

### DIFF
--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -8,7 +8,8 @@ export const schema = `
     uuid: String
     name: String
     campaigns(campaignsFilter: CampaignsFilter): [Campaign]
-    people(role: String, campaignId: String): [User]
+    people(role: String, campaignId: String, offset: Int): [User]
+    peopleCount: Int
     optOuts: [OptOut]
     threeClickEnabled: Boolean
     optOutMessage: String

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -79,7 +79,7 @@ class AdminPersonList extends React.Component {
     const LIMIT = 200
     const { personData: { organization} } = this.props
     if (organization.peopleCount > LIMIT) {
-      const offsetList = Array.apply(null, { length: parseInt(organization.peopleCount / LIMIT, 10) })
+      const offsetList = Array.apply(null, { length: Math.ceil(organization.peopleCount / LIMIT) })
       return (
         <DropDownMenu
           value={Number(this.props.location.query.offset || 0)}

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -34,15 +34,16 @@ export const resolvers = {
     },
     people: async (organization, { role, campaignId, offset }, { user }) => {
       await accessRequired(user, organization.id, 'SUPERVOLUNTEER')
-      let query = buildUserOrganizationQuery(
+      const query = buildUserOrganizationQuery(
         r.knex.select('user.*'), organization.id, role, campaignId, offset)
         .orderBy('created_at', 'desc')
-      if (typeof offset == 'number') {
+      if (typeof offset === 'number') {
         return query.limit(200)
       }
       return query
     },
     peopleCount: async (organization, _, { user }) => {
+      await accessRequired(user, organization.id, 'SUPERVOLUNTEER')
       return r.getCount(r.knex('user')
                         .join('user_organization', 'user.id', 'user_organization.user_id')
                         .where('user_organization.organization_id', organization.id))

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -32,9 +32,20 @@ export const resolvers = {
       return r.table('opt_out')
         .getAll(organization.id, { index: 'organization_id' })
     },
-    people: async (organization, { role, campaignId }, { user }) => {
+    people: async (organization, { role, campaignId, offset }, { user }) => {
       await accessRequired(user, organization.id, 'SUPERVOLUNTEER')
-      return buildUserOrganizationQuery(r.knex.select('user.*'), organization.id, role, campaignId)
+      let query = buildUserOrganizationQuery(
+        r.knex.select('user.*'), organization.id, role, campaignId, offset)
+        .orderBy('created_at', 'desc')
+      if (typeof offset == 'number') {
+        return query.limit(200)
+      }
+      return query
+    },
+    peopleCount: async (organization, _, { user }) => {
+      return r.getCount(r.knex('user')
+                        .join('user_organization', 'user.id', 'user_organization.user_id')
+                        .where('user_organization.organization_id', organization.id))
     },
     threeClickEnabled: (organization) => organization.features.indexOf('threeClick') !== -1,
     textingHoursEnforced: (organization) => organization.texting_hours_enforced,

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -1,7 +1,7 @@
 import { mapFieldsToModel } from './lib/utils'
 import { r, User } from '../models'
 
-export function buildUserOrganizationQuery(queryParam, organizationId, role, campaignId) {
+export function buildUserOrganizationQuery(queryParam, organizationId, role, campaignId, offset) {
   const roleFilter = role ? { role } : {}
 
   queryParam
@@ -14,6 +14,9 @@ export function buildUserOrganizationQuery(queryParam, organizationId, role, cam
   if (campaignId) {
     queryParam.innerJoin('assignment', 'assignment.user_id', 'user.id')
     .where({ 'assignment.campaign_id': campaignId })
+  }
+  if (typeof offset == 'number') {
+    queryParam.offset(offset)
   }
   return queryParam
 }


### PR DESCRIPTION
This adds a crude pagination drop-down to avoid trying to load too many texters into a single page, capping at 200.

After testing on stage, we could potentially roll this out to beta-only, since only our admin uses the page, and they can access it there.