### PR TITLE
Fixes #818

### DIFF
--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -1,52 +1,70 @@
 export const delimiters = {
-  startDelimiter: '{',
-  endDelimiter: '}'
-}
+  startDelimiter: "{",
+  endDelimiter: "}"
+};
 
-export const delimit = (text) => {
-  const { startDelimiter, endDelimiter } = delimiters
-  return `${startDelimiter}${text}${endDelimiter}`
-}
+export const delimit = text => {
+  const { startDelimiter, endDelimiter } = delimiters;
+  return `${startDelimiter}${text}${endDelimiter}`;
+};
 
 // const REQUIRED_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell']
-const TOP_LEVEL_UPLOAD_FIELDS = ['firstName', 'lastName', 'cell', 'zip', 'external_id']
-const TEXTER_SCRIPT_FIELDS = ['texterFirstName', 'texterLastName']
+const TOP_LEVEL_UPLOAD_FIELDS = [
+  "firstName",
+  "lastName",
+  "cell",
+  "zip",
+  "external_id"
+];
+const TEXTER_SCRIPT_FIELDS = ["texterFirstName", "texterLastName"];
 
 // Fields that should be capitalized when a script is applied
-const CAPITALIZE_FIELDS = ['firstName', 'lastName', 'texterFirstName', 'texterLastName']
+const CAPITALIZE_FIELDS = [
+  "firstName",
+  "lastName",
+  "texterFirstName",
+  "texterLastName"
+];
 
 // TODO: This will include zipCode even if you ddin't upload it
-export const allScriptFields = (customFields) => TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS).concat(customFields)
+export const allScriptFields = customFields =>
+  TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS).concat(customFields);
 
-const capitalize = str => { return str.charAt(0).toUpperCase() + str.slice(1).toLowerCase() }
+const capitalize = str => {
+  const strTrimmed = str.trim();
+  return strTrimmed.charAt(0).toUpperCase() + strTrimmed.slice(1).toLowerCase();
+};
 
 const getScriptFieldValue = (contact, texter, fieldName) => {
-  let result
-  if (fieldName === 'texterFirstName') {
-    result = texter.firstName
-  } else if (fieldName === 'texterLastName') {
-    result = texter.lastName
+  let result;
+  if (fieldName === "texterFirstName") {
+    result = texter.firstName;
+  } else if (fieldName === "texterLastName") {
+    result = texter.lastName;
   } else if (TOP_LEVEL_UPLOAD_FIELDS.indexOf(fieldName) !== -1) {
-    result = contact[fieldName]
+    result = contact[fieldName];
   } else {
-    const customFieldNames = JSON.parse(contact.customFields)
-    result = customFieldNames[fieldName]
+    const customFieldNames = JSON.parse(contact.customFields);
+    result = customFieldNames[fieldName];
   }
 
   if (CAPITALIZE_FIELDS.indexOf(fieldName) >= 0) {
-    result = capitalize(result)
+    result = capitalize(result);
   }
 
-  return result
-}
+  return result;
+};
 
 export const applyScript = ({ script, contact, customFields, texter }) => {
-  const scriptFields = allScriptFields(customFields)
-  let appliedScript = script
+  const scriptFields = allScriptFields(customFields);
+  let appliedScript = script;
 
   for (const field of scriptFields) {
-    const re = new RegExp(`${delimit(field)}`, 'g')
-    appliedScript = appliedScript.replace(re, getScriptFieldValue(contact, texter, field))
+    const re = new RegExp(`${delimit(field)}`, "g");
+    appliedScript = appliedScript.replace(
+      re,
+      getScriptFieldValue(contact, texter, field)
+    );
   }
-  return appliedScript
-}
+  return appliedScript;
+};


### PR DESCRIPTION
![screenshot of what I did](https://dl.dropbox.com/s/38evrojx7y7ptpv/fix-818.png?dl=0)

Issue #818 reported that contacts uploaded from CSV with trailing whitespace were formatted incorrectly when sending texts: _"ConstituentFN , ConstitutentLN "_ would appear like: _Hello, ConstitutentFN , your last name is ConstituentLN ._

I implemented the vanilla JS string method [String.prototype.trim()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim) within the function `capitalize` which appears to only be called on FirstName and LastName data from the db before it is inserted into the script.

I chose this method over trimming CSV input fields on insertion to the database, because that approach would have required users to re-upload their contact.csv files, and some of the files may no longer exist.

Also, I linted the file because my editor lints on save. Sorry, or you're welcome, depending on how you feel about that. :smiley: 