### PR TITLE
skip auth0: create an admin link to share to a texter to skipo login

### DIFF
--- a/src/api/user.js
+++ b/src/api/user.js
@@ -6,6 +6,7 @@ export const schema = `
     displayName: String
     email: String
     cell: String
+    fastLogin(organizationId: String): String
     organizations(role: String): [Organization]
     todos(organizationId: String): [Assignment]
     roles(organizationId: String!): [String]

--- a/src/containers/AdminPersonList.jsx
+++ b/src/containers/AdminPersonList.jsx
@@ -9,9 +9,11 @@ import FloatingActionButton from 'material-ui/FloatingActionButton'
 import DropDownMenu from 'material-ui/DropDownMenu'
 import MenuItem from 'material-ui/MenuItem'
 import ContentAdd from 'material-ui/svg-icons/content/add'
+import ContentCopy from 'material-ui/svg-icons/content/content-copy'
 import { Table, TableBody, TableRow, TableRowColumn } from 'material-ui/Table'
 import Dialog from 'material-ui/Dialog'
 import PeopleIcon from 'material-ui/svg-icons/social/people'
+import Snackbar from 'material-ui/Snackbar'
 import { getHighestRole, ROLE_HIERARCHY } from '../lib'
 import theme from '../styles/theme'
 import loadData from './hoc/load-data'
@@ -26,6 +28,7 @@ const organizationFragment = `
     displayName
     email
     roles(organizationId: $organizationId)
+    fastLogin(organizationId: $organizationId)
   }
 `
 class AdminPersonList extends React.Component {
@@ -141,6 +144,22 @@ class AdminPersonList extends React.Component {
                   onTouchTap={() => { this.editUser(person.id) }}
                 />
               </TableRowColumn>
+              {person.fastLogin
+               ? <TableRowColumn>
+                 Login Link:
+                 <ContentCopy
+                   onClick={() => {
+                     const copyInput = document.getElementById(`copyfastlogin${person.id}`)
+                     console.log('login link', this, person.id)
+                     copyInput.select();
+                     document.execCommand("copy");
+                     this.setState({snackbarMessage: "copied"})
+                   }}
+                   label="Click to copy a link to login quickly as this user. Be careful! This link lasts for a day."
+                 />
+                 <input id={`copyfastlogin${person.id}`} width="1" value={`${window.location.origin}${person.fastLogin}`} />
+               </TableRowColumn>
+               : null}
             </TableRow>
           ))}
         </TableBody>
@@ -162,6 +181,12 @@ class AdminPersonList extends React.Component {
         >
           <ContentAdd />
         </FloatingActionButton>
+        <Snackbar
+          open={this.state.snackbarMessage}
+          message={this.state.snackbarMessage}
+          autoHideDuration={3000}
+          onRequestClose={() => { this.setState({ snackbarMessage: ''}) }}
+        />
         {organizationData.organization && (
           <div>
             <Dialog
@@ -198,6 +223,7 @@ class AdminPersonList extends React.Component {
           </div>
         )}
       </div>
+
     )
   }
 }

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -1,5 +1,6 @@
 import { mapFieldsToModel } from './lib/utils'
 import { r, User } from '../models'
+import { getAuth0Skipper } from '../auth-passport'
 
 export function buildUserOrganizationQuery(queryParam, organizationId, role, campaignId) {
   const roleFilter = role ? { role } : {}
@@ -51,6 +52,13 @@ export const resolvers = {
         .getAll([organizationId, user.id], { index: 'organization_user' })
         .pluck('role')('role')
     ),
+    fastLogin: async (texter, { organizationId }, { user }) => {
+      if (process.env.AUTH0_SHORT_CIRCUIT_INSECUREHASH) {
+        const token = getAuth0Skipper(texter.id)
+        return `/loginfast?o=${organizationId}&id=${texter.id}&h=${token}`
+      }
+      return null
+    },
     todos: async (user, { organizationId }) =>
       r.table('assignment')
         .getAll(user.id, { index: 'assignment.user_id' })

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -11,7 +11,7 @@ import mocks from './api/mocks'
 import { createLoaders, createTablesIfNecessary } from './models'
 import passport from 'passport'
 import cookieSession from 'cookie-session'
-import { setupAuth0Passport } from './auth-passport'
+import { setupAuth0Passport, skipAuth0 } from './auth-passport'
 import wrap from './wrap'
 import { log } from '../lib'
 import nexmo from './api/lib/nexmo'
@@ -135,6 +135,10 @@ app.get('/logout-callback', (req, res) => {
 
 if (loginCallbacks) {
   app.get('/login-callback', ...loginCallbacks)
+}
+
+if (process.env.AUTH0_SHORT_CIRCUIT_INSECUREHASH) {
+  app.get('/loginfast', skipAuth0)
 }
 
 const executableSchema = makeExecutableSchema({


### PR DESCRIPTION
so they can login without going through auth0 -- this only works for existing accounts and requires an environment variable to be present.

This is a disaster-preparedness PR, for a situation where auth0 goes down.