### PR TITLE
Unique campaign contact cell and campaign_id migration

### DIFF
--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -156,6 +156,20 @@ const migrations = [
       console.log('added texting hours fields to campaign')
     }
   }
+  { auto: true, //13
+    date: '2018-10-26',
+    // eslint-disable-next-line
+    migrate: async function() {
+      // it is ok if this function fails if run again, but
+      // it should be ok to be run twice.  If not, then make auto=false
+      await r.knex.raw(`
+        CREATE UNIQUE INDEX "campaign_contact_cell_campaign_id_idx"
+          ON "campaign_contact" ("cell","campaign_id");
+      `)
+      console.log('added unique index campaign_contact_cell_campaign_id_idx to campaign_contact')
+    }
+   }
+
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically
       date: '2017-08-23',


### PR DESCRIPTION
Add migration to create index on campaign contact unique to campaign_id and cell

With the injection of campaign contacts we're needing to restrict rows to unique
combination of cell and campaign id to stop injection of duplicate records.