### PR TITLE
Fix send_before column type

### DIFF
--- a/src/server/models/custom-types.js
+++ b/src/server/models/custom-types.js
@@ -31,3 +31,8 @@ export function timestamp() {
     .allowNull(false)
     .default(r.now())
 }
+
+export function optionalTimestamp() {
+  return type
+    .date()
+}

--- a/src/server/models/message.js
+++ b/src/server/models/message.js
@@ -1,6 +1,6 @@
 import thinky from './thinky'
 const type = thinky.type
-import { requiredString, optionalString, timestamp } from './custom-types'
+import { requiredString, optionalString, timestamp, optionalTimestamp } from './custom-types'
 
 import User from './user'
 import Assignment from './assignment'
@@ -31,7 +31,7 @@ const Message = thinky.createModel('message', type.object().schema({
   queued_at: timestamp(),
   sent_at: timestamp(),
   service_response_at: timestamp(),
-  send_before: timestamp()
+  send_before: optionalTimestamp()
 }).allowExtra(false), { noAutoCreation: true,
                         dependencies: [User, Assignment] })
 


### PR DESCRIPTION
`send_before` should be an optional column, not a required one. `migrations.js` declares it as optional and there are a few places in the codebase where it is checked for truthyness indicating it could be `null`. This causes crashes if texting hours are not enforced.

Issue stems from this block: https://github.com/moveonorg/Spoke/blob/main/src/server/api/schema.js#L942-L972

On line 942, `getSendBeforeTimeUtc()` returns `null` if `campaign.texting_hours_enforced === false`. This results in `sendBeforeDate = null` being passed to `Message:send_before`.