### PR TITLE
Fix Auth0 browser compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,38 @@ context.idToken["https://spoke/user_metadata"] = user.user_metadata;
 callback(null, user, context);
 }
 ```
-11. If the application is still running from step 8, kill the process and re-run `npm run dev` to restart the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)
-12. Go to `http://localhost:3000` to load the app.
-13. As long as you leave `SUPPRESS_SELF_INVITE=` blank and unset in your `.env` you should be able to invite yourself from the homepage.
+11. Update the Auth0 [Universal Landing page](https://manage.auth0.com/#/login_page) to include custom fields. You may also include other Auth0 Lock [configuration options](https://auth0.com/docs/libraries/lock/v11/configuration).
+    ```javascript
+    ...
+
+    var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
+      ...
+
+      allowedConnections: ['Username-Password-Authentication'],
+      additionalSignUpFields: [{
+        name: 'given_name',
+        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
+        placeholder: 'First Name'
+      }, {
+        name: 'family_name',
+        placeholder: 'Last Name',
+        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png'
+      }, {
+        name: 'cell',
+        placeholder: 'Cell Phone',
+        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
+        validator: (cell) => ({
+          valid: cell.length >= 10,
+          hint: 'Must be a valid phone number'
+        })
+      }],
+
+      ...
+    });
+    ```
+12. If the application is still running from step 8, kill the process and re-run `npm run dev` to restart the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)
+13. Go to `http://localhost:3000` to load the app.
+14. As long as you leave `SUPPRESS_SELF_INVITE=` blank and unset in your `.env` you should be able to invite yourself from the homepage.
     - If you DO set that variable, then spoke will be invite-only and you'll need to generate an invite. Run:
 ```
 echo "INSERT INTO invite (hash,is_valid) VALUES ('abc', 1);" |sqlite3 mydb.sqlite
@@ -54,7 +83,7 @@ echo "INSERT INTO invite (hash,is_valid) VALUES ('abc', 1);" |sqlite3 mydb.sqlit
 ```
   - Then use the generated key to visit an invite link, e.g.: http://localhost:3000/invite/abc. This should redirect you to the login screen. Use the "Sign Up" option to create your account.
 
-14. You should then be prompted to create an organization. Create it.
+15. You should then be prompted to create an organization. Create it.
 
 If you want to create an invite via the home page "Login and get started" link, make sure your `SUPPRESS_SELF_INVITE` variable is not set.
 

--- a/README.md
+++ b/README.md
@@ -44,34 +44,99 @@ context.idToken["https://spoke/user_metadata"] = user.user_metadata;
 callback(null, user, context);
 }
 ```
-11. Update the Auth0 [Universal Landing page](https://manage.auth0.com/#/login_page) to include custom fields. You may also include other Auth0 Lock [configuration options](https://auth0.com/docs/libraries/lock/v11/configuration).
-    ```javascript
-    ...
+11. Update the Auth0 [Universal Landing page](https://manage.auth0.com/#/login_page), click on the `Customize Login Page` toggle, and copy and paste following code into the `Default Templates` space:
+    ```html
+    <!DOCTYPE html>
+    <html>
+    <head>
+      <meta charset="utf-8">
+      <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+      <title>Sign In with Auth0</title>
+      <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    </head>
+    <body>
 
-    var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
-      ...
+      <!--[if IE 8]>
+      <script src="//cdnjs.cloudflare.com/ajax/libs/ie8/0.2.5/ie8.js"></script>
+      <![endif]-->
 
-      allowedConnections: ['Username-Password-Authentication'],
-      additionalSignUpFields: [{
-        name: 'given_name',
-        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
-        placeholder: 'First Name'
-      }, {
-        name: 'family_name',
-        placeholder: 'Last Name',
-        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png'
-      }, {
-        name: 'cell',
-        placeholder: 'Cell Phone',
-        icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
-        validator: (cell) => ({
-          valid: cell.length >= 10,
-          hint: 'Must be a valid phone number'
-        })
-      }],
+      <!--[if lte IE 9]>
+      <script src="https://cdn.auth0.com/js/base64.js"></script>
+      <script src="https://cdn.auth0.com/js/es5-shim.min.js"></script>
+      <![endif]-->
 
-      ...
-    });
+      <script src="https://cdn.auth0.com/js/lock/11.11/lock.min.js"></script>
+      <script>
+        // Decode utf8 characters properly
+        var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));
+        config.extraParams = config.extraParams || {};
+        var connection = config.connection;
+        var prompt = config.prompt;
+        var languageDictionary;
+        var language;
+
+        if (config.dict && config.dict.signin && config.dict.signin.title) {
+          languageDictionary = { title: config.dict.signin.title };
+        } else if (typeof config.dict === 'string') {
+          language = config.dict;
+        }
+        var loginHint = config.extraParams.login_hint;
+
+        // Available Lock configuration options: https://auth0.com/docs/libraries/lock/v11/configuration
+        var lock = new Auth0Lock(config.clientID, config.auth0Domain, {
+          auth: {
+            redirectUrl: config.callbackURL,
+            responseType: (config.internalOptions || {}).response_type ||
+              (config.callbackOnLocationHash ? 'token' : 'code'),
+            params: config.internalOptions
+          },
+          /* additional configuration needed for custom domains
+          configurationBaseUrl: config.clientConfigurationBaseUrl,
+          overrides: {
+            __tenant: config.auth0Tenant,
+            __token_issuer: 'YOUR_CUSTOM_DOMAIN'
+          }, */
+          assetsUrl:  config.assetsUrl,
+          allowedConnections: ['Username-Password-Authentication'],
+          rememberLastLogin: !prompt,
+          language: language,
+          languageDictionary: {
+            title: 'Spoke',
+            signUpTerms: 'I agree to the <a href="YOUR_LINK HERE" target="_new">terms of service and privacy policy</a>.'
+          },
+          mustAcceptTerms: true,
+          theme: {
+            logo:            '',
+            primaryColor:    'rgb(83, 180, 119)'
+          },
+          additionalSignUpFields: [{
+            name: 'given_name',
+            icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
+            placeholder: 'First Name'
+          }, {
+            name: 'family_name',
+            placeholder: 'Last Name',
+            icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png'
+          }, {
+            name: 'cell',
+            placeholder: 'Cell Phone',
+            icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
+            validator: (cell) => ({
+              valid: cell.length >= 10,
+              hint: 'Must be a valid phone number'
+            })
+          }],
+          prefill: loginHint ? { email: loginHint, username: loginHint } : null,
+          closable: false,
+          defaultADUsernameFromEmailPrefix: false,
+          // uncomment if you want small buttons for social providers
+          // socialButtonStyle: 'small'
+        });
+
+        lock.show();
+      </script>
+    </body>
+    </html>
     ```
 12. If the application is still running from step 8, kill the process and re-run `npm run dev` to restart the app. Wait until you see both "Node app is running ..." and "webpack: Compiled successfully." before attempting to connect. (make sure environment variable `JOBS_SAME_PROCESS=1`)
 13. Go to `http://localhost:3000` to load the app.

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "aphrodite": "^0.4.1",
     "apollo-client": "^0.4.7",
     "apollo-server-express": "^1.2.0",
+    "auth0-js": "^9.10.0",
     "aws-sdk": "^2.6.3",
     "aws-serverless-express": "https://registry.npmjs.org/aws-serverless-express/-/aws-serverless-express-3.0.2.tgz",
     "babel-cli": "^6.26.0",

--- a/src/client/auth-service.js
+++ b/src/client/auth-service.js
@@ -1,53 +1,26 @@
-import theme from '../styles/theme'
+import auth0 from 'auth0-js'
 
 export function logout() {
-  const lock = new window.Auth0Lock(window.AUTH0_CLIENT_ID, window.AUTH0_DOMAIN)
-  lock.logout({
+  var webAuth = new auth0.WebAuth({
+    domain: window.AUTH0_DOMAIN,
+    clientID: window.AUTH0_CLIENT_ID,
+  })
+
+  webAuth.logout({
     returnTo: `${window.BASE_URL}/logout-callback`,
     client_id: window.AUTH0_CLIENT_ID
   })
 }
 
 export function login(nextUrl) {
-  const lock = new window.Auth0Lock(window.AUTH0_CLIENT_ID, window.AUTH0_DOMAIN, {
-    auth: {
-      redirect: true,
-      redirectUrl: `${window.BASE_URL}/login-callback`,
-      responseType: 'code',
-      params: {
-        state: nextUrl || '/',
-        scope: 'openid profile email'
-      }
-    },
-    allowedConnections: ['Username-Password-Authentication'],
-    languageDictionary: {
-      title: 'Spoke',
-      signUpTerms: 'I agree to the <a href="' + window.PRIVACY_URL + '" target="_new">terms of service and privacy policy</a>.'
-    },
-    mustAcceptTerms: true,
-    closable: false,
-    theme: {
-      logo: '',
-      primaryColor: theme.colors.green
-    },
-    additionalSignUpFields: [{
-      name: 'given_name',
-      icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
-      placeholder: 'first name'
-    }, {
-      name: 'family_name',
-      placeholder: 'last name',
-      icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png'
-    }, {
-      name: 'cell',
-      placeholder: 'cell phone',
-      icon: 'https://upload.wikimedia.org/wikipedia/commons/c/ca/1x1.png',
-      validator: (cell) => ({
-        valid: cell.length >= 10,
-        hint: 'Must be a valid phone number'
-      })
-    }]
+  const webAuth = new auth0.WebAuth({
+    domain: window.AUTH0_DOMAIN,
+    clientID: window.AUTH0_CLIENT_ID,
+    redirectUri: `${window.BASE_URL}/login-callback`,
+    responseType: 'code',
+    state: nextUrl || '/',
+    scope: 'openid profile email'
   })
-  lock.show()
-}
 
+  webAuth.authorize()
+}

--- a/src/server/middleware/render-index.js
+++ b/src/server/middleware/render-index.js
@@ -23,8 +23,7 @@ const rollbarScript = process.env.ROLLBAR_CLIENT_TOKEN ?
 // the site is not very useful without auth0, unless you have a session cookie already
 // good for doing dev offline
 const externalLinks = (process.env.NO_EXTERNAL_LINKS ? '' :
-  `<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Poppins">
-  <script src="https://cdn.auth0.com/js/lock/11.0.1/lock.min.js"></script>`)
+  '<link rel="stylesheet" type="text/css" href="https://fonts.googleapis.com/css?family=Poppins">')
 
 export default function renderIndex(html, css, assetMap, store) {
   return `


### PR DESCRIPTION
Various browsers block third-party cookies when doing Cross-Origin authentication. This breaks Auth0's embedded Lock unless you pay for a custom domain with Auth0 to keep requests on the same domain. This PR migrates from Auth0 Lock to Auth0 Universal Login page.

From [Auth0 Employee](https://community.auth0.com/t/unable-to-configure-verification-page-error-on-hosted-login/9214/20):

> [If] using embedded login, custom domain becomes almost a necessity.
> ...
> [We] recommend either using custom domains or moving to universal login (hosted login page).

[Rendered readme changes](https://github.com/bchrobot/Spoke/blob/fix-auth0-compatibility/README.md#getting-started).

This fixes #995 and fixes #776.