### PR TITLE
Add admin reply to Message Review

### DIFF
--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -1,0 +1,62 @@
+import React from 'react'
+import type from 'prop-types'
+import Dialog from 'material-ui/Dialog'
+
+const MessageList = (props) => {
+  return  (
+    <div>
+      {props.messages.map((message, index) => {
+        const isFromContact = message.isFromContact
+        const style = {
+          color: isFromContact ? 'blue' : 'black',
+          textAlign: isFromContact ? 'left' : 'right'
+        }
+
+        return (
+          <p key={index} style={style}>
+            {message.text}
+          </p>
+        )
+      })}
+    </div>
+  )
+}
+
+MessageList.propTypes = {
+  messages: type.arrayOf(type.object),
+}
+
+const ConversationPreviewBody = (props) => {
+  const { contact } = props
+
+  return (
+      <MessageList messages={contact.messages} />
+  )
+}
+
+ConversationPreviewBody.propTypes = {
+  contact: type.object
+}
+
+const ConversationPreviewModal = (props) => {
+  const { contact } = props,
+        isOpen = contact !== undefined
+  return (
+    <Dialog
+      title='Messages'
+      open={isOpen}
+      modal={false}
+      autoScrollBodyContent
+      onRequestClose={props.onRequestClose}
+    >
+      {isOpen && <ConversationPreviewBody contact={contact} />}
+    </Dialog>
+  )
+}
+
+ConversationPreviewModal.propTypes = {
+  contact: type.object,
+  onRequestClose: type.func
+}
+
+export default ConversationPreviewModal

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -42,12 +42,26 @@ MessageList.propTypes = {
 }
 
 class ConversationPreviewBody extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      messages: props.conversation.contact.messages
+    }
+
+    this.messagesChanged = this.messagesChanged.bind(this)
+  }
+
+  messagesChanged(messages) {
+    this.setState({ messages })
+  }
+
   render() {
     return (
       <div>
-        <MessageList messages={this.props.conversation.contact.messages} />
+        <MessageList messages={this.state.messages} />
         <Divider />
-        <MessageResponse conversation={this.props.conversation} />
+        <MessageResponse conversation={this.props.conversation} messagesChanged={this.messagesChanged} />
       </div>
     )
   }

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -1,10 +1,12 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
+import gql from 'graphql-tag'
 import { StyleSheet, css } from 'aphrodite'
 import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
-import Divider from 'material-ui/Divider'
 
+import loadData from '../../containers//hoc/load-data'
+import wrapMutations from '../../containers/hoc/wrap-mutations'
 import MessageResponse from './MessageResponse';
 
 const styles = StyleSheet.create({
@@ -16,25 +18,35 @@ const styles = StyleSheet.create({
   }
 })
 
-const MessageList = (props) => {
-  return  (
-    <div>
-      {props.messages.map((message, index) => {
-        const isFromContact = message.isFromContact
-        const messageStyle = {
-          marginLeft: isFromContact ? undefined : '60px',
-          marginRight: isFromContact ? '60px' : undefined,
-          backgroundColor: isFromContact ? '#AAAAAA' : 'rgb(33, 150, 243)',
-        }
+class MessageList extends Component {
+  componentDidMount() {
+    this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight)
+  }
 
-        return (
-          <p key={index} className={css(styles.conversationRow)} style={messageStyle}>
-            {message.text}
-          </p>
-        )
-      })}
-    </div>
-  )
+  componentDidUpdate() {
+    this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight)
+  }
+
+  render() {
+    return  (
+      <div ref="messageWindow" style={{maxHeight: '300px', overflowY: 'scroll'}}>
+        {this.props.messages.map((message, index) => {
+          const isFromContact = message.isFromContact
+          const messageStyle = {
+            marginLeft: isFromContact ? undefined : '60px',
+            marginRight: isFromContact ? '60px' : undefined,
+            backgroundColor: isFromContact ? '#AAAAAA' : 'rgb(33, 150, 243)',
+          }
+
+          return (
+            <p key={index} className={css(styles.conversationRow)} style={messageStyle}>
+              {message.text}
+            </p>
+          )
+        })}
+      </div>
+    )
+  }
 }
 
 MessageList.propTypes = {
@@ -60,7 +72,6 @@ class ConversationPreviewBody extends Component {
     return (
       <div>
         <MessageList messages={this.state.messages} />
-        <Divider />
         <MessageResponse conversation={this.props.conversation} messagesChanged={this.messagesChanged} />
       </div>
     )
@@ -71,30 +82,70 @@ ConversationPreviewBody.propTypes = {
   conversation: PropTypes.object
 }
 
-const ConversationPreviewModal = (props) => {
-  const { conversation } = props,
-        isOpen = conversation !== undefined
+class ConversationPreviewModal extends Component {
+  constructor(props) {
+    super(props)
 
-  const actions = [
-    <FlatButton
-      label="Close"
-      primary={true}
-      onClick={props.onRequestClose}
-    />
-  ]
+    this.state = {
+      optOutError: ''
+    }
+  }
 
-  return (
-    <Dialog
-      title='Messages'
-      open={isOpen}
-      actions={actions}
-      modal={false}
-      autoScrollBodyContent
-      onRequestClose={props.onRequestClose}
-    >
-      {isOpen && <ConversationPreviewBody {...props} />}
-    </Dialog>
-  )
+  handleClickOptOut = async () => {
+    const { contact } = this.props.conversation
+    const optOut = {
+      cell: contact.cell,
+      assignmentId: contact.assignmentId
+    }
+    try {
+      const response = await this.props.mutations.createOptOut(optOut, campaignContactId)
+      if (response.errors) {
+        const errorText = response.errors.join('\n')
+        throw new Error(errorText)
+      }
+    } catch (error) {
+      this.setState({ optOutError: error.message })
+    }
+  }
+
+  render() {
+    const { conversation } = this.props,
+          isOpen = conversation !== undefined
+
+    const primaryActions = [
+      <FlatButton
+        label="Opt-Out"
+        secondary={true}
+        onClick={this.handleClickOptOut}
+      />,
+      <FlatButton
+        label="Close"
+        primary={true}
+        onClick={this.props.onRequestClose}
+      />
+    ]
+
+    return (
+      <Dialog
+        title='Messages'
+        open={isOpen}
+        actions={primaryActions}
+        modal={false}
+        onRequestClose={this.props.onRequestClose}
+      >
+        <div>
+          {isOpen && <ConversationPreviewBody {...this.props} />}
+          <Dialog
+            title='Error Opting Out'
+            open={!!this.state.optOutError}
+            modal={false}
+          >
+            <p>{this.state.optOutError}</p>
+          </Dialog>
+        </div>
+      </Dialog>
+    )
+  }
 }
 
 ConversationPreviewModal.propTypes = {
@@ -102,4 +153,26 @@ ConversationPreviewModal.propTypes = {
   onRequestClose: PropTypes.func
 }
 
-export default ConversationPreviewModal
+const mapMutationsToProps = () => ({
+  createOptOut: (optOut, campaignContactId) => ({
+    mutation: gql`
+      mutation createOptOut($optOut: OptOutInput!, $campaignContactId: String!) {
+        createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
+          id
+          optOut {
+            id
+            createdAt
+          }
+        }
+      }
+    `,
+    variables: {
+      optOut,
+      campaignContactId
+    }
+  })
+})
+
+export default loadData(wrapMutations(ConversationPreviewModal), {
+  mapMutationsToProps
+})

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -1,19 +1,51 @@
-import React from 'react'
-import type from 'prop-types'
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-formal'
+import yup from 'yup'
+import { StyleSheet, css } from 'aphrodite'
 import Dialog from 'material-ui/Dialog'
+import FlatButton from 'material-ui/FlatButton'
+import RaisedButton from 'material-ui/RaisedButton'
+import Divider from 'material-ui/Divider'
+
+import GSForm from '../../components/forms/GSForm'
+import SendButton from '../../components/SendButton'
+
+const styles = StyleSheet.create({
+  mobile: {
+    '@media(min-width: 425px)': {
+      display: 'none !important'
+    }
+  },
+  desktop: {
+    '@media(max-width: 450px)': {
+      display: 'none !important'
+    }
+  },
+  conversationRow: {
+    color: 'white',
+    padding: '10px',
+    borderRadius: '5px',
+    fontWeight: 'normal',
+  },
+  messageField: {
+    padding: '0px 8px',
+  },
+})
 
 const MessageList = (props) => {
   return  (
     <div>
       {props.messages.map((message, index) => {
         const isFromContact = message.isFromContact
-        const style = {
-          color: isFromContact ? 'blue' : 'black',
-          textAlign: isFromContact ? 'left' : 'right'
+        const messageStyle = {
+          marginLeft: isFromContact ? undefined : '60px',
+          marginRight: isFromContact ? '60px' : undefined,
+          backgroundColor: isFromContact ? '#AAAAAA' : 'rgb(33, 150, 243)',
         }
 
         return (
-          <p key={index} style={style}>
+          <p key={index} className={css(styles.conversationRow)} style={messageStyle}>
             {message.text}
           </p>
         )
@@ -23,28 +55,137 @@ const MessageList = (props) => {
 }
 
 MessageList.propTypes = {
-  messages: type.arrayOf(type.object),
+  messages: PropTypes.arrayOf(PropTypes.object),
+}
+
+class MessageResponse extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      messageText: '',
+      disabled: false
+    }
+  }
+
+  createMessageToContact(text) {
+    const { assignment, contact, texter  } = this.props
+
+    return {
+      assignmentId: assignment.id,
+      contactNumber: contact.cell,
+      userId: texter.id,
+      text
+    }
+  }
+
+  handleMessageFormChange = ({ messageText }) => this.setState({ messageText })
+
+  handleMessageFormSubmit = async ({ messageText }) => {
+    try {
+      const { contact } = this.props
+      const message = this.createMessageToContact(messageText)
+      if (this.state.disabled) {
+        return // stops from multi-send
+      }
+      console.log(`Sending message to ${contact.id}: ${message}`)
+      // this.setState({ disabled: true })
+      // await this.props.mutations.sendMessage(message, contact.id)
+    } catch (e) {
+      this.handleSendMessageError(e)
+    }
+  }
+
+  handleSendMessageError = (e) => {
+    console.error(e)
+    const newState = {
+      // snackbarActionTitle: 'Back to todos',
+      // snackbarOnTouchTap: this.goBackToTodos,
+      snackbarError: e.message
+    }
+    this.setState(newState)
+  }
+
+  handleClickSendMessageButton = () => {
+    this.refs.messageForm.submit()
+  }
+
+  render() {
+    const messageSchema = yup.object({
+      messageText: yup.string().required("Can't send empty message").max(window.MAX_MESSAGE_LENGTH)
+    })
+
+    return (
+      <div className={css(styles.messageField)}>
+        <GSForm
+          ref='messageForm'
+          schema={messageSchema}
+          value={{ messageText: this.state.messageText }}
+          onSubmit={this.handleMessageFormSubmit}
+          onChange={this.handleMessageFormChange}
+        >
+          <div style={{position: 'relative'}}>
+            <div style={{position: 'absolute', right: 0, bottom: 0, width: '120px'}}>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.state.messageText.trim() === ''}
+              />
+            </div>
+            <div style={{marginRight: '120px'}}>
+              <Form.Field
+                className={css(styles.textField)}
+                name='messageText'
+                label='Send a response'
+                multiLine
+                fullWidth
+                rowsMax={6}
+              />
+            </div>
+          </div>
+        </GSForm>
+      </div>
+    )
+  }
+}
+
+MessageResponse.propTypes = {
+  contact: PropTypes.object,
 }
 
 const ConversationPreviewBody = (props) => {
   const { contact } = props
 
   return (
+    <div>
       <MessageList messages={contact.messages} />
+      <Divider />
+      <MessageResponse />
+    </div>
   )
 }
 
 ConversationPreviewBody.propTypes = {
-  contact: type.object
+  contact: PropTypes.object
 }
 
 const ConversationPreviewModal = (props) => {
   const { contact } = props,
         isOpen = contact !== undefined
+
+  const actions = [
+    <FlatButton
+      label="Close"
+      primary={true}
+      onClick={props.onRequestClose}
+    />
+  ]
+
   return (
     <Dialog
       title='Messages'
       open={isOpen}
+      actions={actions}
       modal={false}
       autoScrollBodyContent
       onRequestClose={props.onRequestClose}
@@ -55,8 +196,8 @@ const ConversationPreviewModal = (props) => {
 }
 
 ConversationPreviewModal.propTypes = {
-  contact: type.object,
-  onRequestClose: type.func
+  contact: PropTypes.object,
+  onRequestClose: PropTypes.func
 }
 
 export default ConversationPreviewModal

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -1,36 +1,19 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import Form from 'react-formal'
-import yup from 'yup'
 import { StyleSheet, css } from 'aphrodite'
 import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
-import RaisedButton from 'material-ui/RaisedButton'
 import Divider from 'material-ui/Divider'
 
-import GSForm from '../../components/forms/GSForm'
-import SendButton from '../../components/SendButton'
+import MessageResponse from './MessageResponse';
 
 const styles = StyleSheet.create({
-  mobile: {
-    '@media(min-width: 425px)': {
-      display: 'none !important'
-    }
-  },
-  desktop: {
-    '@media(max-width: 450px)': {
-      display: 'none !important'
-    }
-  },
   conversationRow: {
     color: 'white',
     padding: '10px',
     borderRadius: '5px',
     fontWeight: 'normal',
-  },
-  messageField: {
-    padding: '0px 8px',
-  },
+  }
 })
 
 const MessageList = (props) => {
@@ -58,120 +41,25 @@ MessageList.propTypes = {
   messages: PropTypes.arrayOf(PropTypes.object),
 }
 
-class MessageResponse extends Component {
-  constructor(props) {
-    super(props)
-
-    this.state = {
-      messageText: '',
-      disabled: false
-    }
-  }
-
-  createMessageToContact(text) {
-    const { assignment, contact, texter  } = this.props
-
-    return {
-      assignmentId: assignment.id,
-      contactNumber: contact.cell,
-      userId: texter.id,
-      text
-    }
-  }
-
-  handleMessageFormChange = ({ messageText }) => this.setState({ messageText })
-
-  handleMessageFormSubmit = async ({ messageText }) => {
-    try {
-      const { contact } = this.props
-      const message = this.createMessageToContact(messageText)
-      if (this.state.disabled) {
-        return // stops from multi-send
-      }
-      console.log(`Sending message to ${contact.id}: ${message}`)
-      // this.setState({ disabled: true })
-      // await this.props.mutations.sendMessage(message, contact.id)
-    } catch (e) {
-      this.handleSendMessageError(e)
-    }
-  }
-
-  handleSendMessageError = (e) => {
-    console.error(e)
-    const newState = {
-      // snackbarActionTitle: 'Back to todos',
-      // snackbarOnTouchTap: this.goBackToTodos,
-      snackbarError: e.message
-    }
-    this.setState(newState)
-  }
-
-  handleClickSendMessageButton = () => {
-    this.refs.messageForm.submit()
-  }
-
+class ConversationPreviewBody extends Component {
   render() {
-    const messageSchema = yup.object({
-      messageText: yup.string().required("Can't send empty message").max(window.MAX_MESSAGE_LENGTH)
-    })
-
     return (
-      <div className={css(styles.messageField)}>
-        <GSForm
-          ref='messageForm'
-          schema={messageSchema}
-          value={{ messageText: this.state.messageText }}
-          onSubmit={this.handleMessageFormSubmit}
-          onChange={this.handleMessageFormChange}
-        >
-          <div style={{position: 'relative'}}>
-            <div style={{position: 'absolute', right: 0, bottom: 0, width: '120px'}}>
-              <SendButton
-                threeClickEnabled={false}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.state.messageText.trim() === ''}
-              />
-            </div>
-            <div style={{marginRight: '120px'}}>
-              <Form.Field
-                className={css(styles.textField)}
-                name='messageText'
-                label='Send a response'
-                multiLine
-                fullWidth
-                rowsMax={6}
-              />
-            </div>
-          </div>
-        </GSForm>
+      <div>
+        <MessageList messages={this.props.conversation.contact.messages} />
+        <Divider />
+        <MessageResponse conversation={this.props.conversation} />
       </div>
     )
   }
 }
 
-MessageResponse.propTypes = {
-  contact: PropTypes.object,
-}
-
-const ConversationPreviewBody = (props) => {
-  const { contact } = props
-
-  return (
-    <div>
-      <MessageList messages={contact.messages} />
-      <Divider />
-      <MessageResponse />
-    </div>
-  )
-}
-
 ConversationPreviewBody.propTypes = {
-  contact: PropTypes.object
+  conversation: PropTypes.object
 }
 
 const ConversationPreviewModal = (props) => {
-  const { contact } = props,
-        isOpen = contact !== undefined
+  const { conversation } = props,
+        isOpen = conversation !== undefined
 
   const actions = [
     <FlatButton
@@ -190,13 +78,13 @@ const ConversationPreviewModal = (props) => {
       autoScrollBodyContent
       onRequestClose={props.onRequestClose}
     >
-      {isOpen && <ConversationPreviewBody contact={contact} />}
+      {isOpen && <ConversationPreviewBody {...props} />}
     </Dialog>
   )
 }
 
 ConversationPreviewModal.propTypes = {
-  contact: PropTypes.object,
+  conversation: PropTypes.object,
   onRequestClose: PropTypes.func
 }
 

--- a/src/components/IncomingMessageList/MessageResponse.jsx
+++ b/src/components/IncomingMessageList/MessageResponse.jsx
@@ -137,23 +137,6 @@ MessageResponse.propTypes = {
 }
 
 const mapMutationsToProps = () => ({
-  createOptOut: (optOut, campaignContactId) => ({
-    mutation: gql`
-      mutation createOptOut($optOut: OptOutInput!, $campaignContactId: String!) {
-        createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
-          id
-          optOut {
-            id
-            createdAt
-          }
-        }
-      }
-    `,
-    variables: {
-      optOut,
-      campaignContactId
-    }
-  }),
   sendMessage: (message, campaignContactId) => ({
     mutation: gql`
       mutation sendMessage($message: MessageInput!, $campaignContactId: String!) {

--- a/src/components/IncomingMessageList/MessageResponse.jsx
+++ b/src/components/IncomingMessageList/MessageResponse.jsx
@@ -4,6 +4,8 @@ import Form from 'react-formal'
 import yup from 'yup'
 import gql from 'graphql-tag'
 import { StyleSheet, css } from 'aphrodite'
+import Dialog from 'material-ui/Dialog'
+import FlatButton from 'material-ui/FlatButton'
 
 import loadData from '../../containers//hoc/load-data'
 import wrapMutations from '../../containers/hoc/wrap-mutations'
@@ -22,8 +24,11 @@ class MessageResponse extends Component {
 
     this.state = {
       messageText: '',
-      isSending: false
+      isSending: false,
+      sendError: ''
     }
+
+    this.handleCloseErrorDialog = this.handleCloseErrorDialog.bind(this)
   }
 
   createMessageToContact(text) {
@@ -54,20 +59,14 @@ class MessageResponse extends Component {
       this.props.messagesChanged(messages)
       finalState.messageText = ''
     } catch (e) {
-      this.handleSendMessageError(e)
+      finalState.sendError = e.message
     }
 
     this.setState(finalState)
   }
 
-  handleSendMessageError = (e) => {
-    console.error(e)
-    const newState = {
-      // snackbarActionTitle: 'Back to todos',
-      // snackbarOnTouchTap: this.goBackToTodos,
-      snackbarError: e.message
-    }
-    this.setState(newState)
+  handleCloseErrorDialog() {
+    this.setState({ sendError: '' })
   }
 
   handleClickSendMessageButton = () => {
@@ -81,6 +80,14 @@ class MessageResponse extends Component {
 
     const { messageText, isSending } = this.state
     const isSendDisabled = isSending || messageText.trim() === ''
+
+    const errorActions = [
+      <FlatButton
+        label="OK"
+        primary={true}
+        onClick={this.handleCloseErrorDialog}
+      />
+    ]
 
     return (
       <div className={css(styles.messageField)}>
@@ -111,6 +118,14 @@ class MessageResponse extends Component {
             </div>
           </div>
         </GSForm>
+        <Dialog
+          title='Error Sending'
+          open={!!this.state.sendError}
+          actions={errorActions}
+          modal={false}
+        >
+          <p>{this.state.sendError}</p>
+        </Dialog>
       </div>
     )
   }

--- a/src/components/IncomingMessageList/MessageResponse.jsx
+++ b/src/components/IncomingMessageList/MessageResponse.jsx
@@ -1,0 +1,154 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import Form from 'react-formal'
+import yup from 'yup'
+import gql from 'graphql-tag'
+import { StyleSheet, css } from 'aphrodite'
+
+import loadData from '../../containers//hoc/load-data'
+import wrapMutations from '../../containers/hoc/wrap-mutations'
+import GSForm from '../../components/forms/GSForm'
+import SendButton from '../../components/SendButton'
+
+const styles = StyleSheet.create({
+  messageField: {
+    padding: '0px 8px',
+  },
+})
+
+class MessageResponse extends Component {
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      messageText: '',
+      disabled: false
+    }
+  }
+
+  createMessageToContact(text) {
+    const { contact, texter  } = this.props.conversation
+
+    return {
+      assignmentId: contact.assignmentId,
+      contactNumber: contact.cell,
+      userId: texter.id,
+      text
+    }
+  }
+
+  handleMessageFormChange = ({ messageText }) => this.setState({ messageText })
+
+  handleMessageFormSubmit = async ({ messageText }) => {
+    try {
+      const { contact } = this.props.conversation
+      const message = this.createMessageToContact(messageText)
+      if (this.state.disabled) {
+        return // stops from multi-send
+      }
+      this.setState({ disabled: true })
+      await this.props.mutations.sendMessage(message, contact.id)
+    } catch (e) {
+      this.handleSendMessageError(e)
+    }
+  }
+
+  handleSendMessageError = (e) => {
+    console.error(e)
+    const newState = {
+      // snackbarActionTitle: 'Back to todos',
+      // snackbarOnTouchTap: this.goBackToTodos,
+      snackbarError: e.message
+    }
+    this.setState(newState)
+  }
+
+  handleClickSendMessageButton = () => {
+    this.refs.messageForm.submit()
+  }
+
+  render() {
+    const messageSchema = yup.object({
+      messageText: yup.string().required("Can't send empty message").max(window.MAX_MESSAGE_LENGTH)
+    })
+
+    return (
+      <div className={css(styles.messageField)}>
+        <GSForm
+          ref='messageForm'
+          schema={messageSchema}
+          value={{ messageText: this.state.messageText }}
+          onSubmit={this.handleMessageFormSubmit}
+          onChange={this.handleMessageFormChange}
+        >
+          <div style={{position: 'relative'}}>
+            <div style={{position: 'absolute', right: 0, bottom: 0, width: '120px'}}>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.state.messageText.trim() === ''}
+              />
+            </div>
+            <div style={{marginRight: '120px'}}>
+              <Form.Field
+                name='messageText'
+                label='Send a response'
+                multiLine
+                fullWidth
+                rowsMax={6}
+              />
+            </div>
+          </div>
+        </GSForm>
+      </div>
+    )
+  }
+}
+
+MessageResponse.propTypes = {
+  conversation: PropTypes.object
+}
+
+const mapMutationsToProps = () => ({
+  createOptOut: (optOut, campaignContactId) => ({
+    mutation: gql`
+      mutation createOptOut($optOut: OptOutInput!, $campaignContactId: String!) {
+        createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
+          id
+          optOut {
+            id
+            createdAt
+          }
+        }
+      }
+    `,
+    variables: {
+      optOut,
+      campaignContactId
+    }
+  }),
+  sendMessage: (message, campaignContactId) => ({
+    mutation: gql`
+      mutation sendMessage($message: MessageInput!, $campaignContactId: String!) {
+        sendMessage(message: $message, campaignContactId: $campaignContactId) {
+          id
+          messageStatus
+          messages {
+            id
+            createdAt
+            text
+            isFromContact
+          }
+        }
+      }
+    `,
+    variables: {
+      message,
+      campaignContactId
+    }
+  })
+})
+
+export default loadData(wrapMutations(MessageResponse), {
+  mapMutationsToProps
+})

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -1,15 +1,15 @@
 import React, { Component } from 'react'
 import type from 'prop-types'
-import Dialog from 'material-ui/Dialog'
 import FlatButton from 'material-ui/FlatButton'
 import ActionOpenInNew from 'material-ui/svg-icons/action/open-in-new'
-import loadData from '../containers/hoc/load-data'
+import loadData from '../../containers/hoc/load-data'
 import { withRouter } from 'react-router'
 import gql from 'graphql-tag'
-import LoadingIndicator from '../components/LoadingIndicator'
+import LoadingIndicator from '../../components/LoadingIndicator'
 import DataTables from 'material-ui-datatables'
+import ConversationPreviewModal from './ConversationPreviewModal';
 
-import { MESSAGE_STATUSES } from '../components/IncomingMessageFilter'
+import { MESSAGE_STATUSES } from '../../components/IncomingMessageFilter'
 
 function prepareDataTableData(conversations) {
   return conversations.map(conversation => {
@@ -227,31 +227,10 @@ export class IncomingMessageList extends Component {
           onRowSelection={this.handleRowsSelected}
           selectedRows={this.state.selectedRows}
         />
-        <Dialog
-          title='Messages'
-          open={this.state.activeConversation !== undefined}
-          modal={false}
-          autoScrollBodyContent
+        <ConversationPreviewModal
+          contact={this.state.activeConversation}
           onRequestClose={this.handleCloseConversation}
-        >
-          {this.state.activeConversation !== undefined && (
-            <div>
-              {this.state.activeConversation.messages.map((message, index) => {
-                const isFromContact = message.isFromContact
-                const style = {
-                  color: isFromContact ? 'blue' : 'black',
-                  textAlign: isFromContact ? 'left' : 'right'
-                }
-
-                return (
-                  <p key={index} style={style}>
-                    {message.text}
-                  </p>
-                )
-              })}
-            </div>
-          )}
-        </Dialog>
+        />
       </div>
     )
   }

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -12,13 +12,14 @@ import ConversationPreviewModal from './ConversationPreviewModal';
 import { MESSAGE_STATUSES } from '../../components/IncomingMessageFilter'
 
 function prepareDataTableData(conversations) {
-  return conversations.map(conversation => {
+  return conversations.map((conversation, index) => {
     return {
       campaignTitle: conversation.campaign.title,
       texter: conversation.texter.displayName,
       to: conversation.contact.firstName + ' ' + conversation.contact.lastName + (conversation.contact.optOut.cell ? '⛔️' : ''),
       status: conversation.contact.messageStatus,
-      messages: conversation.contact.messages
+      messages: conversation.contact.messages,
+      index
     }
   })
 }
@@ -154,7 +155,7 @@ export class IncomingMessageList extends Component {
               <FlatButton
                 onClick={event => {
                   event.stopPropagation()
-                  this.handleOpenConversation(row)
+                  this.handleOpenConversation(row.index)
                 }}
                 icon={<ActionOpenInNew />}
               />
@@ -192,8 +193,13 @@ export class IncomingMessageList extends Component {
     this.props.onConversationSelected(rowsSelected, selectedConversations)
   }
 
-  handleOpenConversation(contact) {
-    this.setState({ activeConversation: contact })
+  handleOpenConversation(index) {
+    const conversation = this.props.conversations.conversations.conversations[index]
+    const activeConversation = {
+      contact: conversation.contact,
+      texter: conversation.texter
+    }
+    this.setState({ activeConversation })
   }
 
   handleCloseConversation() {
@@ -228,7 +234,7 @@ export class IncomingMessageList extends Component {
           selectedRows={this.state.selectedRows}
         />
         <ConversationPreviewModal
-          contact={this.state.activeConversation}
+          conversation={this.state.activeConversation}
           onRequestClose={this.handleCloseConversation}
         />
       </div>
@@ -280,8 +286,10 @@ const mapQueriesToProps = ({ ownProps }) => ({
             }
             contact {
               id
+              assignmentId
               firstName
               lastName
+              cell
               messageStatus
               messages {
                 id

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -95,6 +95,7 @@ export async function getConversations(
     'campaign_contact.id as cc_id',
     'campaign_contact.first_name as cc_first_name',
     'campaign_contact.last_name as cc_last_name',
+    'campaign_contact.cell',
     'campaign_contact.message_status',
     'campaign_contact.is_opted_out',
     'campaign_contact.updated_at',

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -973,7 +973,7 @@ const rootMutations = {
 
       await messageInstance.save()
 
-      if (contact.message_status === 'needsResponse') {
+      if (contact.message_status === 'needsResponse' || contact.message_status === 'convo') {
         const service = serviceMap[messageInstance.service || process.env.DEFAULT_SERVICE]
         contact.message_status = 'convo'
         contact.updated_at = 'now()'


### PR DESCRIPTION
This PR adds the ability for an admin to send a reply to a conversation directly from Message Review.

A [change](https://github.com/MoveOnOrg/Spoke/compare/main...bchrobot:feature/add-admin-sweep-reply#diff-e3e0c0fe13e813c7748359d6a931a6faR976) to `sendMessage` also fixes #707

<img width="1440" alt="screen shot 2019-01-29 at 2 43 42 pm" src="https://user-images.githubusercontent.com/2145526/51940709-c1a56800-23e0-11e9-9473-dc6af9a8fe9c.png">