### PR TITLE
Removes deprecated prop from material-ui component

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -880,7 +880,7 @@ export class AssignmentTexterContact extends React.Component {
           open={!!this.state.snackbarError}
           message={this.state.snackbarError || ''}
           action={this.state.snackbarActionTitle}
-          onActionTouchTap={this.state.snackbarOnTouchTap}
+          onActionClick={this.state.snackbarOnTouchTap}
         />
       </div>
     )


### PR DESCRIPTION
fixes #1015 

`onActionTouchTap` is a deprecated property for material-ui component `<Snackbar />`, the event handler was not properly being passed into the component. 

- I did manual testing, but please let me know if there is any addition frontend testing you would like me to do.

https://github.com/mui-org/material-ui/issues/9052
Switched property to `onActionClick` , now available through new release