### PR TITLE
Fix for 904 campaign starts without scripts

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -333,7 +333,10 @@ class AdminCampaignEdit extends React.Component {
       title: 'Interactions',
       content: CampaignInteractionStepsForm,
       keys: ['interactionSteps'],
-      checkCompleted: () => this.state.campaignFormValues.interactionSteps.length > 0,
+      checkCompleted: () => (
+        this.state.campaignFormValues.interactionSteps[0]
+          && this.state.campaignFormValues.interactionSteps.some(step => step.script)
+      ),
       blocksStarting: true,
       expandAfterCampaignStarts: true,
       expandableBySuperVolunteers: true,

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -510,15 +510,13 @@ class AdminCampaignEdit extends React.Component {
             label='Start This Campaign!'
             disabled={!isCompleted}
             onTouchTap={async () => {
-              if (isCompleted) {
-                this.setState({
-                  startingCampaign: true
-                })
-                await this.props.mutations.startCampaign(this.props.campaignData.campaign.id)
-                this.setState({
-                  startingCampaign: false
-                })
-              }
+              this.setState({
+                startingCampaign: true
+              })
+              await this.props.mutations.startCampaign(this.props.campaignData.campaign.id)
+              this.setState({
+                startingCampaign: false
+              })
             }}
           />
         </div>

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -507,13 +507,15 @@ class AdminCampaignEdit extends React.Component {
             label='Start This Campaign!'
             disabled={!isCompleted}
             onTouchTap={async () => {
-              this.setState({
-                startingCampaign: true
-              })
-              await this.props.mutations.startCampaign(this.props.campaignData.campaign.id)
-              this.setState({
-                startingCampaign: false
-              })
+              if (isCompleted) {
+                this.setState({
+                  startingCampaign: true
+                })
+                await this.props.mutations.startCampaign(this.props.campaignData.campaign.id)
+                this.setState({
+                  startingCampaign: false
+                })
+              }
             }}
           />
         </div>


### PR DESCRIPTION
Resolves #904.

The `AdminCampaignEdit.state.campaignFormValues.interactionSteps` array can still have an item in it, even if the script is not filled in. So rather than check for length, check that the `script` key in any of the `interactionSteps` array items is not an empty string.