### PR TITLE
Fix deleting a texter

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -533,13 +533,13 @@ export async function assignTexters(job) {
   const dynamic = campaign.use_dynamic_assignment
   // detect changed assignments
   currentAssignments.map((assignment) => {
-    const texter = texters.filter((ele) => parseInt(ele.id, 10) === assignment.user_id)[0]
-    const unchangedMaxContacts =
-      parseInt(texter.maxContacts, 10) === assignment.max_contacts || // integer = integer
-      texter.maxContacts === assignment.max_contacts // null = null
-    const unchangedNeedsMessageCount =
-      texter.needsMessageCount === parseInt(assignment.needs_message_count, 10)
+    const texter = texters.filter((texter) => parseInt(texter.id, 10) === assignment.user_id)[0]
     if (texter) {
+      const unchangedMaxContacts =
+        parseInt(texter.maxContacts, 10) === assignment.max_contacts || // integer = integer
+        texter.maxContacts === assignment.max_contacts // null = null
+      const unchangedNeedsMessageCount =
+        texter.needsMessageCount === parseInt(assignment.needs_message_count, 10)
       if ((!dynamic && unchangedNeedsMessageCount) || (dynamic && unchangedMaxContacts)) {
         unchangedTexters[assignment.user_id] = true
         return null
@@ -559,7 +559,8 @@ export async function assignTexters(job) {
         }
       }
       return assignment
-    } else { // new texter
+    } else { // deleted texter
+      demotedTexters[assignment.id] = assignment.needs_message_count
       return assignment
     }
   }).filter((ele) => ele !== null)


### PR DESCRIPTION
Two fixes:

1. Calculate `unchangedMaxContacts` and `unchangedNeedsMessageCount` after confirming `texter` exists as these two values depend on `texter`.
2. If a database assignment's texter does not exist in `payload.texters`, then that texter must have been deleted. Handle this as a demotion (takes care of complete removal as well as partial removal due to having sent some texts).