### PR TITLE
Add creator_id to campaign

### DIFF
--- a/__test__/containers/CampaignList.test.js
+++ b/__test__/containers/CampaignList.test.js
@@ -1,0 +1,63 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from 'react'
+import { mount } from 'enzyme'
+import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider'
+import { CampaignList } from '../../src/containers/CampaignList'
+
+describe('Campaign list for campaign with null creator', () => {
+  // given
+  const campaignWithoutCreator = {
+    id: 1,
+    title: 'Yes on A',
+    creator: null,
+  }
+
+  const data = {
+    organization: {
+      campaigns: {
+        campaigns: [ campaignWithoutCreator ],
+      },
+    },
+  }
+
+  // when
+  test('Renders for campaign with null creator, doesn\'t include created by', () => {
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <CampaignList data={data} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.text().includes('Created by')).toBeFalsy()
+  })
+})
+
+describe('Campaign list for campaign with creator', () => {
+  // given
+  const campaignWithCreator = {
+    id: 1,
+    creator: {
+      displayName: 'Lorem Ipsum'
+    },
+  }
+
+  const data = {
+    organization: {
+      campaigns: {
+        campaigns: [ campaignWithCreator ],
+      },
+    },
+  }
+
+  // when
+  test('Renders for campaign with creator, includes created by', () => {
+    const wrapper = mount(
+      <MuiThemeProvider>
+        <CampaignList data={data} />
+      </MuiThemeProvider>
+    )
+    expect(wrapper.containsMatchingElement(<span> &mdash; Created by Lorem Ipsum</span>)).toBeTruthy()
+  })
+})
+

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -28,6 +28,7 @@ export const schema = `
     dueBy: Date
     isStarted: Boolean
     isArchived: Boolean
+    creator: User
     texters: [User]
     assignments(assignmentsFilter: AssignmentsFilter): [Assignment]
     interactionSteps: [InteractionStep]
@@ -57,9 +58,9 @@ export const schema = `
   }
 
   union CampaignsReturn = PaginatedCampaigns | CampaignsList
-  
+
   type PaginatedCampaigns {
     campaigns: [Campaign]
     pageInfo: PageInfo
-  }  
+  }
 `

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -45,7 +45,7 @@ const inlineStyles = {
   }
 }
 
-class CampaignList extends React.Component {
+export class CampaignList extends React.Component {
   renderRow(campaign) {
     const {
       isStarted,

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -25,6 +25,9 @@ const campaignInfoFragment = `
   hasUnsentInitialMessages
   description
   dueBy
+  creator {
+    displayName
+  }
 `
 
 const inlineStyles = {
@@ -67,6 +70,7 @@ class CampaignList extends React.Component {
     }
 
     const dueByMoment = moment(campaign.dueBy)
+    const creatorName = campaign.creator ? campaign.creator.displayName : null
     const tags = []
     if (!isStarted) {
       tags.push('Not started')
@@ -92,6 +96,8 @@ class CampaignList extends React.Component {
           Campaign ID: {campaign.id}
           <br />
           {campaign.description}
+          {creatorName ?
+              (<span> &mdash; Created by {creatorName}</span>) : null}
           <br />
           {dueByMoment.isValid() ?
             dueByMoment.format('MMM D, YYYY') :

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -164,7 +164,26 @@ const migrations = [
       })
       console.log('added send_before column to message table')
     }
-  }
+  },
+  {
+    auto: true, // 14
+    date: '2019-02-24',
+    migrate: async () => {
+      console.log('adding creator_id field to campaign')
+      await r.knex.schema.alterTable('campaign', (table) => {
+        table.integer('creator_id')
+          .unsigned()
+          .nullable()
+          .default(null)
+          .index()
+          .references('id')
+          .inTable('user')
+      })
+
+      console.log('added creator_id field to campaign')
+    }
+  },
+
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically
       date: '2017-08-23',

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -235,6 +235,11 @@ export const resolvers = {
         return currentEditors(r.redis, campaign, user)
       }
       return ''
-    }
+    },
+    creator: async (campaign, _, { loaders }) => (
+      campaign.creator_id
+      ? loaders.user.load(campaign.creator_id)
+      : null
+    )
   }
 }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -422,7 +422,7 @@ const rootMutations = {
         } else { // userOrg exists
           console.log('existing userOrg ' + userOrg.id + ' user ' + user.id + ' organizationUuid ' + organizationUuid )
         }
-      } else { // no organization 
+      } else { // no organization
         console.log('no organization with id ' + organizationUuid + ' for user ' + user.id)
       }
       return organization
@@ -519,6 +519,7 @@ const rootMutations = {
       await accessRequired(user, campaign.organizationId, 'ADMIN', /* allowSuperadmin=*/ true)
       const campaignInstance = new Campaign({
         organization_id: campaign.organizationId,
+        creator_id: user.id,
         title: campaign.title,
         description: campaign.description,
         due_by: campaign.dueBy,
@@ -534,6 +535,7 @@ const rootMutations = {
 
       const campaignInstance = new Campaign({
         organization_id: campaign.organization_id,
+        creator_id: user.id,
         title: 'COPY - ' + campaign.title,
         description: campaign.description,
         due_by: campaign.dueBy,

--- a/src/server/models/campaign.js
+++ b/src/server/models/campaign.js
@@ -7,6 +7,7 @@ import Organization from './organization'
 const Campaign = thinky.createModel('campaign', type.object().schema({
   id: type.string(),
   organization_id: requiredString(),
+  creator_id: type.string().allowNull(true),
   title: optionalString(),
   description: optionalString(),
   is_started: type
@@ -55,5 +56,6 @@ const Campaign = thinky.createModel('campaign', type.object().schema({
 }).allowExtra(false), { noAutoCreation: true })
 
 Campaign.ensureIndex('organization_id')
+Campaign.ensureIndex('creator_id')
 
 export default Campaign


### PR DESCRIPTION
Summary: This adds a column to the campaign table to track which user
created the campaign, and displays that information on the admin
campaign list, as requested in #1046.

I modeled the migration off of migration #11, which added a similar
column to the message table.

I updated the two GraphQL mutations that can create campaigns,
`createCampaign` and `copyCampaign` to store the ID of the logged in
user as creator_id.

Finally, I added a `creator` field to `Campaign` in GraphQL and used
that in `CampaignList` to show which user created the campaign. Let me
know if you have feedback on how I added it to the UI, I added it to the
same line as the description since I didn't want to increase the height
of each campaign row, but I can make it it's own line if you'd prefer
that instead. I see the github issue also mentioned showing the raw ID,
and the time the campaign was created. I think I'll check with joemcl
first to make sure what I added is about what he was looking for, and
then look into adding those pieces of information.

I did notice that when adding the `user_id` field to the `message` schema,
the same commit also updated the `dependencies` we pass as options to
include `User` (this line: https://github.com/MoveOnOrg/Spoke/blob/main/src/server/models/message.js#L36).
I looked at `createModel` in `rethink-knex-adapter`, and it
looks like `dependencies` isn't used at all, so I didn't update that in
this commit, but let me know if I missed something and I should update
it!

Test Plan: Confirmed that a campaign with a null creator_id still
rendered properly, and that a campaign with a non-null creator_id showed
the correct name on the campaign list. Tested copying a campaign with no
creator_id to confirm the copied campaign had the logged-in user's id as
creator_id.