### PR TITLE
Make empty screen messages more accessible

### DIFF
--- a/src/components/Empty.jsx
+++ b/src/components/Empty.jsx
@@ -32,7 +32,6 @@ const styles = StyleSheet.create({
   },
   title: {
     ...theme.text.header,
-    opacity: 0.2,
     textAlign: 'center'
   },
   content: {
@@ -45,7 +44,7 @@ const Empty = ({ title, icon, content, hideMobile }) => (
   <div className={hideMobile ? css(styles.hideMobile) : css(styles.container)} {...dataTest('empty')}>
     {React.cloneElement(icon, { style: inlineStyles.icon })}
     <div className={css(styles.title)}>
-     {title}
+      {title}
     </div>
     {content ? (<div className={css(styles.content)}>
       {content}


### PR DESCRIPTION
Resolves MoveOnOrg#991.

Will also affect all the following messages, which use the `<Empty />` component on a white background:
- https://github.com/MoveOnOrg/Spoke/blob/main/src/components/AssignmentTexter.jsx#L302
- https://github.com/MoveOnOrg/Spoke/blob/main/src/containers/AdminOptOutList.jsx#L16
- https://github.com/MoveOnOrg/Spoke/blob/main/src/containers/AdminPersonList.jsx#L105
- https://github.com/MoveOnOrg/Spoke/blob/main/src/containers/AssignmentTexterContact.jsx#L577
- https://github.com/MoveOnOrg/Spoke/blob/main/src/containers/CampaignList.jsx#L140

