### PR TITLE
948 always capitalize first letter

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -7,6 +7,7 @@ import { organizationCache } from '../models/cacheable_queries/organization'
 
 import { gzip, log, makeTree } from '../../lib'
 import { applyScript } from '../../lib/scripts'
+import { capitalizeWord } from './lib/utils'
 import { assignTexters, exportCampaign, importScript, loadContactsFromDataWarehouse, uploadContacts } from '../../workers/jobs'
 import {
   Assignment,
@@ -380,23 +381,23 @@ const rootMutations = {
         return null
       } else {
         const member = userRes[0]
+
+        const newUserData = {
+          first_name: capitalizeWord(userData.firstName),
+          last_name: capitalizeWord(userData.lastName),
+          email: userData.email,
+          cell: userData.cell
+        }
+
         if (userData) {
           const userRes = await r
             .knex('user')
             .where('id', userId)
-            .update({
-              first_name: userData.firstName,
-              last_name: userData.lastName,
-              email: userData.email,
-              cell: userData.cell
-            })
+            .update(newUserData)
           await cacheableData.user.clearUser(member.id, member.auth0_id)
           userData = {
             id: userId,
-            first_name: userData.firstName,
-            last_name: userData.lastName,
-            email: userData.email,
-            cell: userData.cell
+            ...newUserData
           }
         } else {
           userData = member
@@ -1034,8 +1035,8 @@ const rootMutations = {
 
       log.info(
         `Sending (${service}): ${messageInstance.user_number} -> ${
-          messageInstance.contact_number
-          }\nMessage: ${messageInstance.text}`
+        messageInstance.contact_number
+        }\nMessage: ${messageInstance.text}`
       )
 
       service.sendMessage(messageInstance, contact)


### PR DESCRIPTION
Resolves MoveOnOrg/Spoke#948 and MoveOnOrg/Spoke#974.

This fix does not apply retroactively, only to campaigns created after the fix is deployed. I've also sorted the users in the "People" menu by first name. Let me know if both are OK.

An alternative would be to capitalize user's first and last name on account creation, and then create a migration to change the existing data in the DB. Let me know if this would be a better approach.