### PR TITLE
add permissions for campaign queries 

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -297,6 +297,7 @@ it('should assign texters to campaign contacts', async () => {
 
 describe('Campaign', () => {
   let organization
+  const adminUser = { is_superadmin: true, id: 1 }
 
   beforeEach(async () => {
     organization = await (new Organization({
@@ -309,7 +310,6 @@ describe('Campaign', () => {
   describe('contacts', async () => {
     let campaigns
     let contacts
-
     beforeEach(async () => {
       campaigns = await Promise.all([
         new Campaign({
@@ -337,13 +337,13 @@ describe('Campaign', () => {
     })
 
     test('resolves contacts', async () => {
-      const results = await campaignResolvers.Campaign.contacts(campaigns[0])
+      const results = await campaignResolvers.Campaign.contacts(campaigns[0], null, { user: adminUser })
       expect(results).toHaveLength(1)
       expect(results[0].campaign_id).toEqual(campaigns[0].id)
     })
 
     test('resolves contacts count', async () => {
-      const results = await campaignResolvers.Campaign.contactsCount(campaigns[0])
+      const results = await campaignResolvers.Campaign.contactsCount(campaigns[0], null, { user: adminUser })
       expect(results).toEqual(1)
     })
 
@@ -354,7 +354,7 @@ describe('Campaign', () => {
         is_archived: false,
         due_by: new Date()
       })).save()
-      const results = await campaignResolvers.Campaign.contactsCount(campaign)
+      const results = await campaignResolvers.Campaign.contactsCount(campaign, null, { user: adminUser })
       expect(results).toEqual(0)
     })
   })
@@ -367,6 +367,7 @@ describe('Campaign', () => {
         organization_id: organization.id,
         is_started: false,
         is_archived: false,
+        use_dynamic_assignment: true,
         due_by: new Date()
       })).save()
     })
@@ -378,8 +379,10 @@ describe('Campaign', () => {
         cell: '',
       })).save()
 
-      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign)
+      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign, null, { user: adminUser })
       expect(results).toEqual(true)
+      const resultsForTexter = await campaignResolvers.Campaign.hasUnassignedContactsForTexter(campaign, null, { user: adminUser })
+      expect(resultsForTexter).toEqual(true)
     })
 
     test('resolves unassigned contacts when false with assigned contacts', async () => {
@@ -403,12 +406,14 @@ describe('Campaign', () => {
         cell: '',
       })).save()
 
-      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign)
+      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign, null, { user: adminUser })
       expect(results).toEqual(false)
+      const resultsForTexter = await campaignResolvers.Campaign.hasUnassignedContactsForTexter(campaign, null, { user: adminUser })
+      expect(resultsForTexter).toEqual(false)
     })
 
     test('resolves unassigned contacts when false with no contacts', async () => {
-      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign)
+      const results = await campaignResolvers.Campaign.hasUnassignedContacts(campaign, null, { user: adminUser })
       expect(results).toEqual(false)
     })
   })

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -35,6 +35,7 @@ export const schema = `
     contacts: [CampaignContact]
     contactsCount: Int
     hasUnassignedContacts: Boolean
+    hasUnassignedContactsForTexter: Boolean
     hasUnsentInitialMessages: Boolean
     customFields: [String]
     cannedResponses(userId: String): [CannedResponse]
@@ -46,6 +47,7 @@ export const schema = `
     primaryColor: String
     logoImageUrl: String
     editors: String
+    cacheable: Boolean
     overrideOrganizationTextingHours: Boolean
     textingHoursEnforced: Boolean
     textingHoursStart: Int

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -91,7 +91,7 @@ export class AssignmentSummary extends Component {
 
   render() {
     const { assignment, unmessagedCount, unrepliedCount, badTimezoneCount, totalMessagedCount, pastMessagesCount, skippedMessagesCount } = this.props
-    const { title, description, hasUnassignedContacts, dueBy,
+    const { title, description, hasUnassignedContactsForTexter, dueBy,
             primaryColor, logoImageUrl, introHtml,
             useDynamicAssignment } = assignment.campaign
     const maxContacts = assignment.maxContacts
@@ -117,7 +117,7 @@ export class AssignmentSummary extends Component {
               title: 'Send first texts',
               count: unmessagedCount,
               primary: true,
-              disabled: (useDynamicAssignment && !hasUnassignedContacts && unmessagedCount == 0) || (useDynamicAssignment && maxContacts === 0),
+              disabled: (useDynamicAssignment && !hasUnassignedContactsForTexter && unmessagedCount == 0) || (useDynamicAssignment && maxContacts === 0),
               contactsFilter: 'text',
               hideIfZero: !useDynamicAssignment
             })}

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -83,7 +83,6 @@ const mapQueriesToProps = ({ ownProps }) => ({
       currentUser {
         id
         terms
-        cacheable
         todos(organizationId: $organizationId) {
           id
           campaign {

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -83,6 +83,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
       currentUser {
         id
         terms
+        cacheable
         todos(organizationId: $organizationId) {
           id
           campaign {
@@ -90,7 +91,7 @@ const mapQueriesToProps = ({ ownProps }) => ({
             title
             description
             useDynamicAssignment
-            hasUnassignedContacts
+            hasUnassignedContactsForTexter
             introHtml
             primaryColor
             logoImageUrl

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -1,3 +1,4 @@
+import { accessRequired } from './errors'
 import { mapFieldsToModel } from './lib/utils'
 import { Campaign, JobRequest, r, cacheableData } from '../models'
 import { currentEditors } from '../models/cacheable_queries'
@@ -85,38 +86,30 @@ export const resolvers = {
     ], JobRequest)
   },
   CampaignStats: {
-    sentMessagesCount: async (campaign) => (
-      r.table('assignment')
+    sentMessagesCount: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return r.table('assignment')
         .getAll(campaign.id, { index: 'campaign_id' })
         .eqJoin('id', r.table('message'), { index: 'assignment_id' })
         .filter({ is_from_contact: false })
         .count()
-        // TODO: NEEDS TESTING
-        // this is a change to avoid very weird map(...).sum() pattern
-        // that will work better with RDBMs
-        // main question is will/should filter work, or do we need to specify,
-        // e.g. 'right_is_from_contact': false, or something
-        // .map((assignment) => (
-        //   r.table('message')
-        //     .getAll(assignment('id'), { index: 'assignment_id' })
-        //     .filter({ is_from_contact: false })
-        //     .count()
-        // )).sum()
-    ),
-    receivedMessagesCount: async (campaign) => (
-      r.table('assignment')
+    },
+    receivedMessagesCount: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return r.table('assignment')
         .getAll(campaign.id, { index: 'campaign_id' })
         // TODO: NEEDSTESTING -- see above setMessagesCount()
         .eqJoin('id', r.table('message'), { index: 'assignment_id' })
         .filter({ is_from_contact: true })
         .count()
-    ),
-    optOutsCount: async (campaign) => (
-      await r.getCount(
+    },
+    optOutsCount: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return await r.getCount(
         r.knex('campaign_contact')
           .where({ is_opted_out: true, campaign_id: campaign.id })
       )
-    )
+    }
   },
   CampaignsReturn: {
     __resolveType(obj, context, _) {
@@ -173,11 +166,17 @@ export const resolvers = {
     datawarehouseAvailable: (campaign, _, { user }) => (
       user.is_superadmin && !!process.env.WAREHOUSE_DB_HOST
     ),
-    pendingJobs: async (campaign) => r.table('job_request')
-      .filter({ campaign_id: campaign.id }).orderBy('updated_at', 'desc'),
-    texters: async (campaign) =>
-      getUsers(campaign.organization_id, null, {campaignId: campaign.id }) ,
-    assignments: async (campaign, {assignmentsFilter} ) => {
+    pendingJobs: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return r.table('job_request')
+      .filter({ campaign_id: campaign.id }).orderBy('updated_at', 'desc')
+    },
+    texters: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return getUsers(campaign.organization_id, null, {campaignId: campaign.id })
+    },
+    assignments: async (campaign, { assignmentsFilter }, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
       let query = r.table('assignment')
         .getAll(campaign.id, { index: 'campaign_id' })
 
@@ -187,34 +186,55 @@ export const resolvers = {
 
       return query
     },
-    interactionSteps: async (campaign) => (
-      campaign.interactionSteps
-      || cacheableData.campaign.dbInteractionSteps(campaign.id)
-    ),
-    cannedResponses: async (campaign, { userId }) => (
-      await cacheableData.cannedResponse.query({
+    interactionSteps: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      return campaign.interactionSteps
+        || cacheableData.campaign.dbInteractionSteps(campaign.id)
+    },
+    cannedResponses: async (campaign, { userId }, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      return await cacheableData.cannedResponse.query({
         userId: userId || '',
         campaignId: campaign.id
       })
-    ),
-    contacts: async (campaign) => (
-      r.knex('campaign_contact')
+    },
+    contacts: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'ADMIN', true)
+      // TODO: should we include a limit() since this is only for send-replies
+      return r.knex('campaign_contact')
         .where({ campaign_id: campaign.id })
-    ),
-    contactsCount: async (campaign) => (
-      await r.getCount(
+    },
+    contactsCount: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      return await r.getCount(
         r.knex('campaign_contact')
           .where({ campaign_id: campaign.id })
       )
-    ),
-    hasUnassignedContacts: async (campaign) => {
+    },
+    hasUnassignedContactsForTexter: async (campaign, _, { user }) => {
+      // This is the same as hasUnassignedContacts, but the access control
+      // is different because for TEXTERs it's just for dynamic campaigns
+      // but hasUnassignedContacts for admins is for the campaigns list
+      await accessRequired(user, campaign.organization_id, 'TEXTER', true)
+      if (!campaign.use_dynamic_assignment || campaign.is_archived) {
+        return false
+      }
       const contacts = await r.knex('campaign_contact')
         .select('id')
         .where({ campaign_id: campaign.id, assignment_id: null })
         .limit(1)
       return contacts.length > 0
     },
-    hasUnsentInitialMessages: async (campaign) => {
+    hasUnassignedContacts: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
+      const contacts = await r.knex('campaign_contact')
+        .select('id')
+        .where({ campaign_id: campaign.id, assignment_id: null })
+        .limit(1)
+      return contacts.length > 0
+    },
+    hasUnsentInitialMessages: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
       const contacts = await r.knex('campaign_contact')
         .select('id')
         .where({
@@ -230,9 +250,11 @@ export const resolvers = {
       || cacheableData.campaign.dbCustomFields(campaign.id)
     ),
     stats: async (campaign) => campaign,
+    cacheable: (campaign, _, { user }) => Boolean(r.redis),
     editors: async (campaign, _, { user }) => {
+      await accessRequired(user, campaign.organization_id, 'SUPERVOLUNTEER', true)
       if (r.redis) {
-        return currentEditors(r.redis, campaign, user)
+        return cacheableData.campaign.currentEditors(campaign, user)
       }
       return ''
     },

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -64,6 +64,26 @@ const loadDeep = async (id) => {
   return null
 }
 
+const currentEditors = async (campaign, user) => {
+  // Add user ID in case of duplicate admin names
+  const displayName = `${user.id}~${user.first_name} ${user.last_name}`
+
+  await r.redis.hsetAsync(`campaign_editors_${campaign.id}`, displayName, new Date())
+  await r.redis.expire(`campaign_editors_${campaign.id}`, 120)
+
+  let editors = await r.redis.hgetallAsync(`campaign_editors_${campaign.id}`)
+
+  // Only get editors that were active in the last 2 mins, and exclude the
+  // current user
+  editors = Object.entries(editors).filter(editor => {
+    const rightNow = new Date()
+    return rightNow - new Date(editor[1]) <= 120000 && editor[0] !== displayName
+  })
+
+  // Return a list of comma-separated names
+  return editors.map(editor => editor[0].split('~')[1]).join(', ')
+}
+
 export const campaignCache = {
   clear,
   load: async(id) => {
@@ -90,6 +110,7 @@ export const campaignCache = {
     return await Campaign.get(id)
   },
   reload: loadDeep,
+  currentEditors,
   dbCustomFields,
   dbInteractionSteps
 }

--- a/src/server/models/cacheable_queries/user.js
+++ b/src/server/models/cacheable_queries/user.js
@@ -55,25 +55,3 @@ export async function userLoggedIn(field, val) {
   }
   return userAuth
 }
-
-export async function currentEditors(redis, campaign, user) {
-  // Add user ID in case of duplicate admin names
-  const displayName = `${user.id}~${user.first_name} ${user.last_name}`
-
-  await r.redis.hsetAsync(`campaign_editors_${campaign.id}`, displayName, new Date())
-  await r.redis.expire(`campaign_editors_${campaign.id}`, 120)
-
-  let editors = await r.redis.hgetallAsync(`campaign_editors_${campaign.id}`)
-
-  // Only get editors that were active in the last 2 mins, and exclude the
-  // current user
-  editors = Object.entries(editors).filter(editor => {
-    const rightNow = new Date()
-    return rightNow - new Date(editor[1]) <= 120000 && editor[0] !== displayName
-  })
-
-  // Return a list of comma-separated names
-  return editors.map(editor => {
-    return editor[0].split('~')[1]
-  }).join(', ')
-}


### PR DESCRIPTION
and add a shortcut for texters with campaign data.

closes up a security hole (this is ported from scaling branches)