### PR TITLE
improve access for lambda aws context from graphQL contexts

### DIFF
--- a/lambda.js
+++ b/lambda.js
@@ -21,6 +21,12 @@ try {
 // See: http://docs.aws.amazon.com/lambda/latest/dg/best-practices.html#function-code
 // "Separate the Lambda handler (entry point) from your core logic"
 
+let invocationContext = {}
+let invocationEvent = {}
+app.default.set('awsContextGetter', function(req, res) {
+  return [invocationEvent, invocationContext]
+})
+
 function cleanHeaders(event) {
   // X-Twilio-Body can contain unicode and disallowed chars by aws-serverless-express like "'"
   // We don't need it anyway
@@ -42,6 +48,8 @@ exports.handler = (event, context, handleCallback) => {
   if (!event.command) {
     // default web server stuff
     const startTime = (context.getRemainingTimeInMillis ? context.getRemainingTimeInMillis() : 0)
+    invocationEvent = event
+    invocationContext = context
     cleanHeaders(event)
     const webResponse = awsServerlessExpress.proxy(server, event, context)
     if (process.env.DEBUG_SCALING) {


### PR DESCRIPTION
expose lambda context and event and remainingMilliseconds to graphQL context to allow us to cancel a job when it is completed.

This is necessary as a foundational step.