### PR TITLE
Use the sequence for canned_response ids

### DIFF
--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -188,9 +188,9 @@ const migrations = [
     date: '2019-05-13',
     migrate: async () => {
       console.log('setting sequence value for canned_response')
-      const maxId = await r.knex('canned_response').max('id').first()
-      await r.knex.raw(`ALTER SEQUENCE canned_response_id_seq RESTART WITH ${maxId.max + 1}`)
-      console.log(`set sequence canned_response_id_seq to ${maxId.max + 1}`)
+      const maxId = (await r.knex('canned_response').max('id').first()).max || 0
+      await r.knex.raw(`ALTER SEQUENCE canned_response_id_seq RESTART WITH ${maxId + 1}`)
+      console.log(`set sequence canned_response_id_seq to ${maxId + 1}`)
     }
   }
 

--- a/src/migrations/index.js
+++ b/src/migrations/index.js
@@ -1,4 +1,4 @@
-import { r, Migrations } from '../server/models'
+import { r, Migrations, CannedResponse } from '../server/models'
 import { log } from '../lib'
 
 // To add a migrations, add a new migration object to the
@@ -183,6 +183,16 @@ const migrations = [
       console.log('added creator_id field to campaign')
     }
   },
+  {
+    auto: true, // 14
+    date: '2019-05-13',
+    migrate: async () => {
+      console.log('setting sequence value for canned_response')
+      const maxId = await r.knex('canned_response').max('id').first()
+      await r.knex.raw(`ALTER SEQUENCE canned_response_id_seq RESTART WITH ${maxId.max + 1}`)
+      console.log(`set sequence canned_response_id_seq to ${maxId.max + 1}`)
+    }
+  }
 
   /* migration template
      {auto: true, //if auto is false, then it will block the migration running automatically

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -4,6 +4,7 @@ import GraphQLJSON from 'graphql-type-json'
 import { GraphQLError } from 'graphql/error'
 import isUrl from 'is-url'
 import { organizationCache } from '../models/cacheable_queries/organization'
+import _ from 'lodash'
 
 import { gzip, log, makeTree } from '../../lib'
 import { applyScript } from '../../lib/scripts'
@@ -177,12 +178,10 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     const convertedResponses = []
     for (let index = 0; index < cannedResponses.length; index++) {
       const response = cannedResponses[index]
-      const newId = await Math.floor(Math.random() * 10000000)
-      convertedResponses.push({
+      convertedResponses.push(_.omit({
         ...response,
-        campaign_id: id,
-        id: newId
-      })
+        campaign_id: id
+      }, ['id']))
     }
 
     await r

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -4,7 +4,6 @@ import GraphQLJSON from 'graphql-type-json'
 import { GraphQLError } from 'graphql/error'
 import isUrl from 'is-url'
 import { organizationCache } from '../models/cacheable_queries/organization'
-import _ from 'lodash'
 
 import { gzip, log, makeTree } from '../../lib'
 import { applyScript } from '../../lib/scripts'
@@ -178,10 +177,11 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     const convertedResponses = []
     for (let index = 0; index < cannedResponses.length; index++) {
       const response = cannedResponses[index]
-      convertedResponses.push(_.omit({
+      convertedResponses.push({
         ...response,
-        campaign_id: id
-      }, ['id']))
+        campaign_id: id,
+        id: undefined
+      })
     }
 
     await r


### PR DESCRIPTION
`canned_response` id is being assigned a random number.  This is suspected as the cause of a problem WFP is experiencing which presents as "all the canned responses I just created disappear."  It's plausible that if we attempt to save a `canned_response` with a duplicate ID, the update fails, the new canned_responses are not saved, and it appears to the user as if they disappeared.

This PR sets `canned_response_id_seq` to `max(id)+1` in a migration, then sets ids of new canned responses using the sequence.