### PR TITLE
disable cacheable flag for now, since full assignment info is not yet…

### DIFF
--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -133,6 +133,6 @@ export const resolvers = {
                  'is_archived': false }
                )('left')
     ),
-    cacheable: () => Boolean(r.redis)
+    cacheable: () => false // FUTURE: Boolean(r.redis) when full assignment data is cached
   }
 }


### PR DESCRIPTION
… cached, so the client should not poll yet

This was prematurely included in https://github.com/MoveOnOrg/Spoke/pull/1110
but will need more work from https://github.com/MoveOnOrg/Spoke/pull/965
before updating