### PR TITLE
add a title= attr to contact firstname so on-hover provides debug info

### DIFF
--- a/src/components/ContactToolbar.jsx
+++ b/src/components/ContactToolbar.jsx
@@ -64,7 +64,10 @@ const ContactToolbar = function ContactToolbar(props) {
         style={inlineStyles.toolbar}
       >
         <ToolbarGroup >
-          <ToolbarTitle text={campaignContact.firstName} />
+          <ToolbarTitle
+            text={campaignContact.firstName}
+            title={`id:${campaignContact.id} m:${campaignContact.messages.length} s:${campaignContact.messageStatus}`}
+          />
           <ToolbarTitle
             style={inlineStyles.cellToolbarTitle}
           />


### PR DESCRIPTION
![spokecontact-hover](https://user-images.githubusercontent.com/52117/59317913-19a78180-8c93-11e9-9d4f-99b0080d0126.png)

This could provide contact id from the texter interface in case someone needs it.

Open to other suggestions on where we could put this (or what data to include)