### PR TITLE
Set the devtools folder linefeed standard to LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 # Set the default behavior, in case people don't have core.autocrlf set.
 * text=auto
 
+# devtools need to use lf linefeeds or nf will not be able to find the Procfile
 dev-tools/* text eol=lf
 
 # Denote all files that are truly binary and should not be modified.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+dev-tools/* text eol=lf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -1,0 +1,2 @@
+This folder needs to retain Unix style linefeeds or `nf` wont be able to find the Procfile
+


### PR DESCRIPTION
# What is this
Create a repo-level `.gitattributes` file so that all future clones of the repo will use LF linefeeds in the devtools folder.

# Context
I had issues in my dev setup which turned out to be because the devtools folder was using CRLF line separators and `nf` was unable to find the Procfile. I think #1137 is experiencing the same problem. I wanted to fix this issue on a more macro level so that future folks who pull the repo get the correct line endings.

# Testing
I have tested this by doing fresh clones of my branch and seeing that the linefeeds are LF in my MacOSX environment. I have no been able to test this on Linux systems or Windows machines or on prod. Due to this being a devtools/ change, I'm not too worried about prod though.