### PR TITLE
upgrade react-formal, which gets rid of browser-console warnings related to prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "react-async-script": "^0.6.0",
     "react-chartjs": "^0.7.3",
     "react-dom": "^15.6.1",
-    "react-formal": "^0.18.5",
+    "react-formal": "^0.20.0",
     "react-router": "^2.5.2",
     "react-router-redux": "^4.0.5",
     "react-tap-event-plugin": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -835,13 +835,6 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-transform-typescript" "^7.1.0"
 
-"@babel/runtime@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0.tgz#adeb78fedfc855aa05bc041640f3f6f98e85424c"
-  integrity sha512-7hGhzlcmg01CvH1EHdSPVXYX1aJ8KCEyz6I9xYIi/asDtzBPMyMhVibhM/K6g/5qnKBwjZtp10bNZIEFTRW1MA==
-  dependencies:
-    regenerator-runtime "^0.12.0"
-
 "@babel/runtime@7.1.5":
   version "7.1.5"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.1.5.tgz#4170907641cf1f61508f563ece3725150cc6fe39"
@@ -5781,11 +5774,6 @@ fn-name@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-1.0.1.tgz#de8d8a15388b33cbf2145782171f73770c6030f0"
   integrity sha1-3o2KFTiLM8vyFFeCFx9zdwxgMPA=
-
-fn-name@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/fn-name/-/fn-name-2.0.1.tgz#5214d7537a4d06a4a301c0cc262feb84188002e7"
-  integrity sha1-UhTXU3pNBqSjAcDMJi/rhBiAAuc=
 
 follow-redirects@^1.0.0:
   version "1.6.1"
@@ -11382,7 +11370,7 @@ prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7,
     loose-envify "^1.3.1"
     object-assign "^4.1.1"
 
-property-expr@^1.2.0, property-expr@^1.3.1, property-expr@^1.5.0:
+property-expr@^1.2.0, property-expr@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-1.5.1.tgz#22e8706894a0c8e28d58735804f6ba3a3673314f"
   integrity sha512-CGuc0VUTGthpJXL36ydB6jnbyOf/rAHFvmVrJlH+Rg0DqqLFQGAP6hIaxD/G0OAmBJPhXDHuEJigrp0e0wFV6g==
@@ -11755,10 +11743,10 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
-react-formal@^0.18.5:
-  version "0.18.9"
-  resolved "https://registry.yarnpkg.com/react-formal/-/react-formal-0.18.9.tgz#f941ca20d135e7b95187dbd822acc3b623d084ea"
-  integrity sha1-+UHKINE157lRh9vYIqzDtiPQhOo=
+react-formal@^0.20.0:
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/react-formal/-/react-formal-0.20.6.tgz#086b636c28bf761403c04ccd659db3bde139eb57"
+  integrity sha1-CGtjbCi/dhQDwEzNZZ2zveE561c=
   dependencies:
     chain-function "^1.0.0"
     classnames "^2.2.5"
@@ -11766,14 +11754,15 @@ react-formal@^0.18.5:
     lodash "^3.10.1"
     pick-attributes "^1.0.2"
     property-expr "^1.3.1"
-    react-input-message "^0.13.1"
+    react-input-message "^0.14.1"
     react-prop-types "^0.3.2"
     react-pure-render "^1.0.2"
-    spy-on-component "^1.0.0"
-    topeka "^0.3.5"
-    uncontrollable "^3.1.0"
+    spy-on-component "^1.0.2"
+    topeka "^0.4.1"
+    uncontrollable "^4.0.3"
+    universal-promise "^1.1.0"
     warning "^2.0.0"
-    yup ">=0.17.0"
+    yup "^0.21.1"
 
 react-hot-api@^0.4.5:
   version "0.4.7"
@@ -11788,13 +11777,13 @@ react-hot-loader@^1.3.0:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
 
-react-input-message@^0.13.1:
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/react-input-message/-/react-input-message-0.13.3.tgz#ee69c76f0628ede1db39c1a7ce751fc6e9cb3564"
-  integrity sha1-7mnHbwYo7eHbOcGnznUfxunLNWQ=
+react-input-message@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/react-input-message/-/react-input-message-0.14.2.tgz#134f8d99d84261234d78929ad855f71eed39687b"
+  integrity sha1-E0+NmdhCYSNNeJKa2FX3Hu05aHs=
   dependencies:
     classnames "^2.2.3"
-    topeka "^0.3.0"
+    topeka "^0.4.0"
     universal-promise "^1.1.0"
 
 react-is@^16.7.0:
@@ -13231,7 +13220,7 @@ sprintf-js@~1.0.2:
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
-spy-on-component@^1.0.0:
+spy-on-component@^1.0.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/spy-on-component/-/spy-on-component-1.1.2.tgz#70cec3a0b87dfb9d5356e288135fd349d138d407"
   integrity sha512-ndyPLiqAPcDETg2VO0TM35uq6kLKvhss2ILBV+jfXZz55lRk5zphmbrHKwwIu9++n56+56KLbY/zhJnPF6Yqyg==
@@ -13580,11 +13569,6 @@ synchronous-promise@^1.0.18:
   resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-1.0.18.tgz#936e8763e6554088cdcf78dc64f7473b972fcefc"
   integrity sha512-UqMAK6BBBXu8qaDI5omlyV9iDpM9nQfgthaBOK0nlfXnMgiuOBv+meWG73CGeCCFRhOOOa2e4rvqYzfynzy5zg==
 
-synchronous-promise@^2.0.5:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/synchronous-promise/-/synchronous-promise-2.0.6.tgz#de76e0ea2b3558c1e673942e47e714a930fa64aa"
-  integrity sha512-TyOuWLwkmtPL49LHCX1caIwHjRzcVd62+GF6h8W/jHOeZUFHpnd2XJDVuUlaTaLPH1nuu2M69mfHr5XbQJnf/g==
-
 table@^3.7.8:
   version "3.8.3"
   resolved "https://registry.yarnpkg.com/table/-/table-3.8.3.tgz#2bbc542f0fda9861a755d3947fefd8b3f513855f"
@@ -13827,10 +13811,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-topeka@^0.3.0, topeka@^0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/topeka/-/topeka-0.3.6.tgz#708ca4ec03f2bcdd664dcccc8f3b94a27f8c43dd"
-  integrity sha1-cIyk7APyvN1mTczMjzuUon+MQ90=
+topeka@^0.4.0, topeka@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/topeka/-/topeka-0.4.1.tgz#faa979de592710fc270a02139173125f4f9dced6"
+  integrity sha1-+ql53lknEPwnCgITkXMSX0+dztY=
   dependencies:
     chain-function "^1.0.0"
     classnames "^2.1.5"
@@ -13856,11 +13840,6 @@ toposort@^0.2.10:
   version "0.2.12"
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-0.2.12.tgz#c7d2984f3d48c217315cc32d770888b779491e81"
   integrity sha1-x9KYTz1IwhcxXMMtdwiIt3lJHoE=
-
-toposort@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
-  integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
 touch@^3.1.0:
   version "3.1.0"
@@ -14072,10 +14051,17 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-uncontrollable@^3.1.0, uncontrollable@^3.1.3:
+uncontrollable@^3.1.3:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-3.3.1.tgz#e23b402e7a4c69b1853fb4b43ce34b6480c65b6f"
   integrity sha1-4jtALnpMabGFP7S0PONLZIDGW28=
+  dependencies:
+    invariant "^2.1.0"
+
+uncontrollable@^4.0.3:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
+  integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
   dependencies:
     invariant "^2.1.0"
 
@@ -14155,7 +14141,7 @@ unique-string@^1.0.0:
   dependencies:
     crypto-random-string "^1.0.0"
 
-universal-promise@^1.1.0:
+universal-promise@^1.0.1, universal-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/universal-promise/-/universal-promise-1.1.0.tgz#563f9123372940839598c9d48be5ec33fa69cff1"
   integrity sha1-Vj+RIzcpQIOVmMnUi+XsM/ppz/E=
@@ -15167,17 +15153,18 @@ yargs@~3.10.0:
     decamelize "^1.0.0"
     window-size "0.1.0"
 
-yup@>=0.17.0:
-  version "0.26.10"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.26.10.tgz#3545839663289038faf25facfc07e11fd67c0cb1"
-  integrity sha512-keuNEbNSnsOTOuGCt3UJW69jDE3O4P+UHAakO7vSeFMnjaitcmlbij/a3oNb9g1Y1KvSKH/7O1R2PQ4m4TRylw==
+yup@^0.21.1:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/yup/-/yup-0.21.3.tgz#46fc72b46cb58a1e70f4cb78cb645209632e193a"
+  integrity sha1-RvxytGy1ih5w9Mt4y2RSCWMuGTo=
   dependencies:
-    "@babel/runtime" "7.0.0"
-    fn-name "~2.0.1"
-    lodash "^4.17.10"
-    property-expr "^1.5.0"
-    synchronous-promise "^2.0.5"
-    toposort "^2.0.2"
+    case "^1.2.1"
+    fn-name "~1.0.1"
+    lodash "^4.17.0"
+    property-expr "^1.2.0"
+    toposort "^0.2.10"
+    type-name "^2.0.1"
+    universal-promise "^1.0.1"
 
 yup@^0.24.0:
   version "0.24.1"


### PR DESCRIPTION
Fixes #1334 

Here's an example:

```
Warning: You are manually calling a React.PropTypes validation function for the `mapValue` prop on `Binding`. This is deprecated and will throw in the standalone `prop-types` package. You may be seeing this warning due to a third-party PropTypes library. See https://fb.me/react-warning-dont-call-proptypes for details.
```