### PR TITLE
[WIP] Changed "current question" to "log their answer"

### DIFF
--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -128,7 +128,7 @@ class AssignmentTexterSurveys extends Component {
       >
         <CardHeader
           style={styles.cardHeader}
-          title={showAllQuestions ? 'All questions' : 'Current question'}
+          title={showAllQuestions ? 'All questions' : 'Log their answer'}
           showExpandableButton={interactionSteps.length > 1}
         />
         <CardText


### PR DESCRIPTION
# Fixes # (issue)
## Description
[For issue 980](https://github.com/MoveOnOrg/Spoke/issues/980)
Changed the wording of "Current Question" as requested. 

I haven't added a button-like styling yet because I wanted to clarify that doing so wouldn't confuse users — I'm assuming from the description that it should look like the buttons below but shouldn't act like a button? In that case, I'm assuming that users might try to click/tap the section. Let me know if I'm misunderstanding the original instructions. (I'll follow up in the [thread](https://github.com/MoveOnOrg/Spoke/issues/980) for the issue)
<img width="1440" alt="Screen Shot 2019-09-02 at 4 57 29 PM" src="https://user-images.githubusercontent.com/45137225/64133239-c7ae5d80-cda2-11e9-9290-55e27c0526ad.png">

# Checklist:
- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
