### PR TITLE
Changed "canned responses" to "canned replies"

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -695,7 +695,7 @@ export class AssignmentTexterContact extends React.Component {
               />
               {this.renderNeedsResponseToggleButton(contact)}
               <RaisedButton
-                label='Canned responses'
+                label='Canned replies'
                 onTouchTap={this.handleOpenPopover}
               />
               <RaisedButton


### PR DESCRIPTION
**IGNORE - phrasing changed to "other responses"**
# Fixes #
[Issue 980](https://github.com/MoveOnOrg/Spoke/issues/980)
## Description
Changed "Canned Reponses" button to display "Canned Replies" instead, as requested in issue thread.
<img width="1440" alt="Screen Shot 2019-09-02 at 5 01 25 PM" src="https://user-images.githubusercontent.com/45137225/64133339-65a22800-cda3-11e9-98a5-431c32161800.png">

# Checklist:
- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
