### PR TITLE
Changed "canned responses" to "other responses"

### DIFF
--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -695,7 +695,7 @@ export class AssignmentTexterContact extends React.Component {
               />
               {this.renderNeedsResponseToggleButton(contact)}
               <RaisedButton
-                label='Canned responses'
+                label='Other responses'
                 onTouchTap={this.handleOpenPopover}
               />
               <RaisedButton


### PR DESCRIPTION
# Fixes # (#980 UI improvement to help solve 'texters aren't using current question menu' problem)
## Description
Changed "canned responses" button to read to "other responses"
<img width="1440" alt="Screen Shot 2019-09-13 at 6 32 45 PM" src="https://user-images.githubusercontent.com/45137225/64898512-636a8400-d655-11e9-80b3-aba75aa5e0a2.png">

# Checklist:
- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
