### PR TITLE
Fix for unable to select a texter to reassign conversations in message review

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -1,11 +1,6 @@
 import { resolvers } from "../src/server/api/schema";
 import { schema } from "../src/api/schema";
-import {
-  accessRequired,
-  assignmentRequired,
-  authRequired,
-  superAdminRequired
-} from "../src/server/api/errors";
+import { assignmentRequired } from "../src/server/api/errors";
 import { graphql } from "graphql";
 import {
   User,
@@ -24,7 +19,7 @@ import { makeExecutableSchema } from "graphql-tools";
 
 const mySchema = makeExecutableSchema({
   typeDefs: schema,
-  resolvers: resolvers,
+  resolvers,
   allowUndefinedInResolve: true
 });
 
@@ -112,9 +107,9 @@ async function createOrganization(user, name, userId, inviteId) {
   }`;
 
   const variables = {
-    userId: userId,
-    name: name,
-    inviteId: inviteId
+    userId,
+    name,
+    inviteId
   };
 
   try {
@@ -153,10 +148,10 @@ async function createCampaign(
   }`;
   const variables = {
     input: {
-      title: title,
-      description: description,
-      organizationId: organizationId,
-      contacts: contacts
+      title,
+      description,
+      organizationId,
+      contacts
     }
   };
 
@@ -337,7 +332,7 @@ it("should assign texters to campaign contacts", async () => {
   delete updateCampaign.id;
   delete updateCampaign.contacts;
   const variables = {
-    campaignId: campaignId,
+    campaignId,
     campaign: updateCampaign
   };
   const result = await graphql(

--- a/__test__/server/api/user.test.js
+++ b/__test__/server/api/user.test.js
@@ -1,0 +1,95 @@
+import { setupTest, cleanupTest } from "../../test_helpers";
+
+import { getUsers } from "../../../src/server/api/user";
+
+import {
+  User,
+  Organization,
+  UserOrganization
+} from "../../../src/server/models/";
+
+describe("User", () => {
+  beforeAll(
+    async () => await setupTest(),
+    global.DATABASE_SETUP_TEARDOWN_TIMEOUT
+  );
+  afterAll(
+    async () => await cleanupTest(),
+    global.DATABASE_SETUP_TEARDOWN_TIMEOUT
+  );
+
+  let organization;
+  beforeEach(async () => {
+    organization = await new Organization({
+      name: "organization",
+      texting_hours_start: 0,
+      texting_hours_end: 0
+    }).save();
+  });
+
+  describe("getUsers", async () => {
+    it("returns pageInfo.total == user.length when there's a cursor", async () => {
+      const users = [
+        await new User({
+          auth0_id: "abc",
+          first_name: "First1",
+          last_name: "Last1",
+          cell: "212-555-5555",
+          email: "email1@example.com"
+        }).save(),
+        await new User({
+          auth0_id: "def",
+          first_name: "First2",
+          last_name: "Last2",
+          cell: "646-555-5555",
+          email: "email2@example.com"
+        }).save()
+      ];
+
+      await new UserOrganization({
+        user_id: users[0].id,
+        organization_id: organization.id,
+        role: "OWNER"
+      }).save();
+      await new UserOrganization({
+        user_id: users[0].id,
+        organization_id: organization.id,
+        role: "ADMIN"
+      }).save();
+      await new UserOrganization({
+        user_id: users[0].id,
+        organization_id: organization.id,
+        role: "TEXTER"
+      }).save();
+      await new UserOrganization({
+        user_id: users[1].id,
+        organization_id: organization.id,
+        role: "OWNER"
+      }).save();
+      await new UserOrganization({
+        user_id: users[1].id,
+        organization_id: organization.id,
+        role: "ADMIN"
+      }).save();
+      await new UserOrganization({
+        user_id: users[1].id,
+        organization_id: organization.id,
+        role: "TEXTER"
+      }).save();
+
+      const getUsersResult = await getUsers(
+        organization.id,
+        {
+          offset: 0,
+          limit: 1000
+        },
+        null,
+        null,
+        null
+      );
+
+      expect(getUsersResult.users.length).toEqual(2);
+      expect(getUsersResult.pageInfo.total).toEqual(2);
+    });
+  });
+});

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -15,7 +15,7 @@ function buildSelect(sortBy) {
 
   switch (sortBy) {
     case "COUNT_ONLY":
-      return r.knex.countDistinct("user.id");
+      return r.knex;
     case "LAST_NAME":
       fragmentArray = [userStar];
       break;
@@ -132,7 +132,7 @@ export async function getUsers(
       "COUNT_ONLY"
     );
 
-    const usersCount = await r.getCount(usersCountQuery);
+    const usersCount = await r.getCountDistinct(usersCountQuery, "user.id");
 
     const pageInfo = {
       limit: cursor.limit,

--- a/src/server/models/thinky.js
+++ b/src/server/models/thinky.js
@@ -21,6 +21,11 @@ thinkyConn.r.getCount = async query => {
   return Number((await query.count("* as count").first()).count);
 };
 
+thinkyConn.r.getCountDistinct = async (query, distinctConstraint) =>
+  Number(
+    (await query.countDistinct(distinctConstraint + " as count").first()).count
+  );
+
 if (process.env.REDIS_URL) {
   thinkyConn.r.redis = redis.createClient({ url: process.env.REDIS_URL });
 } else if (process.env.REDIS_FAKE) {


### PR DESCRIPTION
# Fixes #1234 

## Description

When called with a cursor, the `people` resolver returns a list of users and a pageInfo object.  The count of users in the pageInfo object was incorrect because a refactoring of count queries caused the distinct clause in a query getting count of matching users to be rendered a no-op.  The web app would not render the list of users in message reassignment unless the number of users returned matched the count.  The users returned were distinct, but the count was not, so the browser never rendered the list.  (The reason users would not be distinct is a join from `user` to `user_organization`.  If a user has 3 roles, they'll show up 3 times unless the query is distinct by user.id.)

The fix is to add a getCountDistinct method to the `r` object which does a distinct query in a (hopefully) database independent manner.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] **sqlite tests have the same failures in main and this branch**
- [N/A] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [N/A] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A ] My PR is labeled [WIP] if it is in progress