### PR TITLE
remove faker which is 86M and not really used at all in live code

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "dotenv": "^2.0.0",
     "draft-js": "^0.7.0",
     "express": "^4.14.0",
-    "faker": "^3.1.0",
     "fs": "^0.0.2",
     "google-libphonenumber": "^1.0.25",
     "googleapis": "^39.2.0",

--- a/src/server/api/lib/nexmo.js
+++ b/src/server/api/lib/nexmo.js
@@ -3,7 +3,6 @@ import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { Message, PendingMessagePart } from "../../models";
 import { getLastMessage } from "./message-sending";
 import { log } from "../../../lib";
-import faker from "faker";
 
 let nexmo = null;
 const MAX_SEND_ATTEMPTS = 5;
@@ -45,8 +44,12 @@ async function convertMessagePartsToMessage(messageParts) {
 
 async function findNewCell() {
   if (!nexmo) {
+    const num = "1234"
+      .split("")
+      .map(() => parseInt(Math.random() * 10))
+      .join("");
     return {
-      numbers: [{ msisdn: getFormattedPhoneNumber(faker.phone.phoneNumber()) }]
+      numbers: [{ msisdn: getFormattedPhoneNumber(`+1212555${num}`) }]
     };
   }
   return new Promise((resolve, reject) => {

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -3,7 +3,6 @@ import { getFormattedPhoneNumber } from "../../../lib/phone-format";
 import { Log, Message, PendingMessagePart, r } from "../../models";
 import { log } from "../../../lib";
 import { getLastMessage, saveNewIncomingMessage } from "./message-sending";
-import faker from "faker";
 
 let twilio = null;
 const MAX_SEND_ATTEMPTS = 5;
@@ -79,7 +78,11 @@ async function findNewCell() {
 
 async function rentNewCell() {
   if (!twilio) {
-    return getFormattedPhoneNumber(faker.phone.phoneNumber());
+    const num = "1234"
+      .split("")
+      .map(() => parseInt(Math.random() * 10))
+      .join("");
+    return getFormattedPhoneNumber(`+1212555${num}`);
   }
   const newCell = await findNewCell();
 

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -1,5 +1,6 @@
 import { r } from "../server/models";
-import { sleep, getNextJob, log } from "./lib";
+import { sleep, getNextJob } from "./lib";
+import { log } from "../lib";
 import {
   exportCampaign,
   processSqsMessages,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5567,11 +5567,6 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-faker@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/faker/-/faker-3.1.0.tgz#0f908faf4e6ec02524e54a57e432c5c013e08c9f"
-  integrity sha1-D5CPr05uwCUk5UpX5DLFwBPgjJ8=
-
 fakeredis@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fakeredis/-/fakeredis-2.0.0.tgz#752fb832819ace31be88668cf1358d6f1438afc0"


### PR DESCRIPTION
# Fixes build failing on deploy to AWS Lambda

## Description

The instructions in DEPLOYING_AWS_LAMBDA.txt don't work with current dependencies which are too large.  I remove `faker` which was used only in old files to generate a phone number easily 'faked' manually.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [na] I have added tests that prove my fix is effective or that my feature works
- [na] My PR is labeled [WIP] if it is in progress
