### PR TITLE
Switch default passport_strategy on Heroku deploys to local for revie…

### DIFF
--- a/app.json
+++ b/app.json
@@ -14,7 +14,7 @@
     "PASSPORT_STRATEGY": {
       "description": "Either 'auth0' or 'local' -- We recommend auth0 for production systems",
       "required": true,
-      "value": "auth0"
+      "value": "local"
     },
 
     "AUTH0_DOMAIN": {


### PR DESCRIPTION
…wapps to work
## Description
Change the `app.json` PASSPORT_STRATEGY env variable in order to make the [heroku reviewapps](https://devcenter.heroku.com/articles/github-integration-review-apps) feature possible for us to use to QA our PRs.

reviewapps allows the creation of 1 time Heroku instances to be spun up and linked to PRs so that you can click around and test the functionality of the proposed change. From what I can tell, our current `app.json` default is causing all of my tests at creating reviewapps to set the env to the current default of `auth0`. We need them to be set to `local` in the reviewapps context. This will also default the one-click heroku button to `local` but there's a hint under the env var label saying you should use auth0 in production anyway.

## Testing Plan
I can't actually test this locally because it needs to be wired up. My plan is to create this pull request, and then try to manually create the heroku reviewapp on *this* PR to see if it uses the default in this branch's `app.json` file. ~If it does and it goes smoothly, I will then tick the box in the checklist saying that I tested it. Otherwise, I'll need a new plan.~ This worked!

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- n/a The test suite passes locally with my changes
- n/a If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- n/a I have made any necessary changes to the documentation
- n/a I have added tests that prove my fix is effective or that my feature works
- n/a My PR is labeled [WIP] if it is in progress
