### PR TITLE
Integrate Citizen Code of Conduct with more explicit expected/unacceptable behavior

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -3,33 +3,62 @@
 ## Our Pledge
 
 In the interest of fostering an open and welcoming environment, we as
-contributors and maintainers pledge to making participation in our project and
-our community a harassment-free experience for everyone, regardless of age, body
+contributors and maintainers pledge to make participation in our project and
+our community a safe, welcoming, harassment-free experience for everyone, regardless of age, body
 size, disability, ethnicity, sex characteristics, gender identity and expression,
 level of experience, education, socio-economic status, nationality, personal
 appearance, race, religion, or sexual identity and orientation.
 
+This code of conduct outlines our expectations for all those who participate
+in our community, as well as the consequences for unacceptable behavior.
+
+We invite all those who participate in Spoke to help us create safe
+and positive experiences for everyone.
+
+
 ## Our Standards
 
-Examples of behavior that contributes to creating a positive environment
-include:
+### Open Source Citizenship
 
-* Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
+A supplemental goal of this Code of Conduct is to increase open source citizenship by encouraging participants to recognize and strengthen the relationships between our actions and their effects on our community.
+Communities mirror the societies in which they exist and positive action is essential to counteract the many forms of inequality and abuses of power that exist in society.
+If you see someone who is making an extra effort to ensure our community is welcoming, friendly, and encourages all participants to contribute to the fullest extent, we want to know.
 
-Examples of unacceptable behavior by participants include:
+### Expected Behavior
 
-* The use of sexualized language or imagery and unwelcome sexual attention or
- advances
+* Use welcoming and inclusive language
+* Be respectful of differing viewpoints and experiences
+* Exercise consideration and respect in your speech and actions.
+* Attempt collaboration before conflict.
+* Gracefully accept constructive criticism
+* Focus on what is best for the community
+* Show empathy towards other community members
+* Refrain from demeaning, discriminatory, or harassing behavior and speech, including threats to pursue legal action including litigation
+* Be mindful of your surroundings and of your fellow participants. Alert community leaders if you notice a dangerous situation, someone in distress, or violations of this Code of Conduct, even if they seem inconsequential.
+* Remember that community event venues may be shared with members of the public; please be respectful to all patrons of these locations.
+
+### Unacceptable Behavior
+
+* Sexist, racist, homophobic, transphobic, ableist or otherwise discriminatory jokes and language.
+* Personal insults, particularly those related to gender, sexual orientation, race, religion, or disability.
+* Posting or displaying sexually explicit or violent material.
 * Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or electronic
- address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
- professional setting
+* Public or private harassment, including threats to pursue legal action including litigation
+* Violence, threats of violence or violent language directed against another person.
+* Posting or threatening to post other people’s personally identifying information such as a physical or electronic address, without explicit permission ("doxing").
+* Inappropriate photography or recording.
+* Inappropriate physical contact. You should have someone’s consent before touching them.
+* Unwelcome sexual attention. This includes, sexualized language, imagery, comments or jokes; inappropriate touching, groping, and unwelcomed sexual advances.
+* Deliberate intimidation, stalking or following (online or in person).
+* Advocating for, or encouraging, any of the above behavior.
+* Sustained disruption of community events, including talks and presentations.
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+### Consequences of Unacceptable Behavior
+
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated.
+
+Any community member asked to stop unacceptable behavior is expected to comply immediately. If the member fails to comply immediately, the community organizers may take any action they deem appropriate, up to and including [blocking users from collaboration with MoveOn Github repositories](https://help.github.com/en/articles/blocking-a-user-from-your-organization) and/or temporarily banning or permanently expelling the non-complying member from the community without warning (and without refund in the case of a paid event).
 
 ## Our Responsibilities
 
@@ -67,10 +96,8 @@ members of the project's leadership.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
-available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
-
-[homepage]: https://www.contributor-covenant.org
+This Code of Conduct is adapted from the [Contributor Covenant, version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct.html) and the [Citizen Code of Conduct](http://citizencodeofconduct.org/)
 
 For answers to common questions about this code of conduct, see
 https://www.contributor-covenant.org/faq
+and http://citizencodeofconduct.org/about/


### PR DESCRIPTION
## Description

Updates Code of Conduct with more details based on the Citizen's Code of Conduct

MoveOn is committed to fostering an open and welcoming environment in the Spoke community, and this means doing what we can to ensure that participation in the Spoke project is a friendly, safe, welcoming, harassment-free experience for everyone. To make it clear what this means in the context of collaboration around Spoke, in this pull request we are updating our Code of Conduct to be more comprehensive and detailed on what is considered acceptable and unacceptable behavior. 