### PR TITLE
Address color contrast for user-selected primary color

### DIFF
--- a/__test__/lib/color-contrast-helper.test.js
+++ b/__test__/lib/color-contrast-helper.test.js
@@ -1,119 +1,23 @@
-import {
-  parseRgbValues,
-  convertHexToRgb,
-  convertHslToRgb,
-  calcBrightness,
-  setContrastingColor
-} from "../../src/lib/color-contrast-helper";
+import { setContrastingColor } from "../../src/lib/color-contrast-helper";
 
 import theme from "../../src/styles/theme";
 
-describe("test parseRgbValues", () => {
-  it("handles rgba string correctly", () => {
-    expect(parseRgbValues("rgba(100, 100, 100, 1)")).toEqual({
-      r: 100,
-      g: 100,
-      b: 100,
-      alpha: 100
-    });
-  });
-
-  it("handles rgb string correctly", () => {
-    expect(parseRgbValues("rgb(100, 100, 100)")).toEqual({
-      r: 100,
-      g: 100,
-      b: 100,
-      alpha: 100
-    });
-  });
-});
-
-describe("test convertHexToRgb", () => {
-  it("handles 6-digit hex string correctly", () => {
-    expect(convertHexToRgb("#ffffff")).toEqual({ r: 255, g: 255, b: 255 });
-  });
-
-  it("handles 3-digit hex string correctly", () => {
-    expect(convertHexToRgb("#fff")).toEqual({ r: 255, g: 255, b: 255 });
-  });
-});
-
-describe("test convertHslToRgb", () => {
-  it("handles hsla string correctly", () => {
-    expect(convertHslToRgb("hsla(0, 0%, 100%, 1)")).toEqual({
-      r: 255,
-      g: 255,
-      b: 255,
-      alpha: 100
-    });
-  });
-
-  it("handles hsl string correctly", () => {
-    expect(convertHslToRgb("hsl(0, 0%, 100%)")).toEqual({
-      r: 255,
-      g: 255,
-      b: 255,
-      alpha: 100
-    });
-  });
-});
-
-describe("test calcBrightness", () => {
-  it("handles rgb string correctly", () => {
-    expect(calcBrightness("rgb(255, 255, 255)")).toEqual({
-      brightness: 255,
-      alpha: 100
-    });
-  });
-
-  it("handles rgba string correctly", () => {
-    expect(calcBrightness("rgb(255, 255, 255, 1)")).toEqual({
-      brightness: 255,
-      alpha: 100
-    });
-  });
-
-  it("handles hsl string correctly", () => {
-    expect(calcBrightness("hsla(0, 0%, 100%)")).toEqual({
-      brightness: 255,
-      alpha: 100
-    });
-  });
-
-  it("handles hsla string correctly", () => {
-    expect(calcBrightness("hsla(0, 0%, 100%, 1)")).toEqual({
-      brightness: 255,
-      alpha: 100
-    });
-  });
-
-  it("handles hex string correctly", () => {
-    expect(calcBrightness("#fff")).toEqual({
-      brightness: 255,
-      alpha: undefined
-    });
-  });
-
-  it("handles incorrectly formatted string correctly", () => {
-    expect(calcBrightness("incorrect")).toEqual({
-      brightness: undefined,
-      alpha: undefined
-    });
-  });
-});
-
 describe("test setContrastingColor", () => {
-  it("returns theme.colors.darkGray when a light primary color is passed in", () => {
+  it("returns darkGray when a light color is passed in", () => {
     expect(setContrastingColor("#fff")).toEqual(theme.colors.darkGray);
   });
 
-  it("returns theme.colors.white when a dark primary color is passed in", () => {
+  it("returns white when a dark color is passed in", () => {
     expect(setContrastingColor("#000")).toEqual(theme.colors.white);
   });
 
-  it("returns theme.colors.darkGray when a color is passed in with an opacity of less than .5", () => {
-    expect(setContrastingColor("rgba(0, 0, 0, .4)")).toEqual(
+  it("returns darkGray when a color is passed in with an opacity of less than .4", () => {
+    expect(setContrastingColor("rgba(0, 0, 0, .39)")).toEqual(
       theme.colors.darkGray
     );
+  });
+
+  it("returns darkGray when an invalid color is passed in", () => {
+    expect(setContrastingColor("incorrect")).toEqual(theme.colors.darkGray);
   });
 });

--- a/__test__/lib/color-contrast-helper.test.js
+++ b/__test__/lib/color-contrast-helper.test.js
@@ -4,7 +4,7 @@ import {
   convertHslToRgb,
   calcBrightness,
   setContrastingColor
-} from "../../src/lib/color-eval";
+} from "../../src/lib/color-contrast-helper";
 
 import theme from "../../src/styles/theme";
 

--- a/__test__/lib/color-eval.test.js
+++ b/__test__/lib/color-eval.test.js
@@ -1,0 +1,119 @@
+import {
+  parseRgbValues,
+  convertHexToRgb,
+  convertHslToRgb,
+  calcBrightness,
+  setContrastingColor
+} from "../../src/lib/color-eval";
+
+import theme from "../../src/styles/theme";
+
+describe("test parseRgbValues", () => {
+  it("handles rgba string correctly", () => {
+    expect(parseRgbValues("rgba(100, 100, 100, 1)")).toEqual({
+      r: 100,
+      g: 100,
+      b: 100,
+      alpha: 100
+    });
+  });
+
+  it("handles rgb string correctly", () => {
+    expect(parseRgbValues("rgb(100, 100, 100)")).toEqual({
+      r: 100,
+      g: 100,
+      b: 100,
+      alpha: 100
+    });
+  });
+});
+
+describe("test convertHexToRgb", () => {
+  it("handles 6-digit hex string correctly", () => {
+    expect(convertHexToRgb("#ffffff")).toEqual({ r: 255, g: 255, b: 255 });
+  });
+
+  it("handles 3-digit hex string correctly", () => {
+    expect(convertHexToRgb("#fff")).toEqual({ r: 255, g: 255, b: 255 });
+  });
+});
+
+describe("test convertHslToRgb", () => {
+  it("handles hsla string correctly", () => {
+    expect(convertHslToRgb("hsla(0, 0%, 100%, 1)")).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+      alpha: 100
+    });
+  });
+
+  it("handles hsl string correctly", () => {
+    expect(convertHslToRgb("hsl(0, 0%, 100%)")).toEqual({
+      r: 255,
+      g: 255,
+      b: 255,
+      alpha: 100
+    });
+  });
+});
+
+describe("test calcBrightness", () => {
+  it("handles rgb string correctly", () => {
+    expect(calcBrightness("rgb(255, 255, 255)")).toEqual({
+      brightness: 255,
+      alpha: 100
+    });
+  });
+
+  it("handles rgba string correctly", () => {
+    expect(calcBrightness("rgb(255, 255, 255, 1)")).toEqual({
+      brightness: 255,
+      alpha: 100
+    });
+  });
+
+  it("handles hsl string correctly", () => {
+    expect(calcBrightness("hsla(0, 0%, 100%)")).toEqual({
+      brightness: 255,
+      alpha: 100
+    });
+  });
+
+  it("handles hsla string correctly", () => {
+    expect(calcBrightness("hsla(0, 0%, 100%, 1)")).toEqual({
+      brightness: 255,
+      alpha: 100
+    });
+  });
+
+  it("handles hex string correctly", () => {
+    expect(calcBrightness("#fff")).toEqual({
+      brightness: 255,
+      alpha: undefined
+    });
+  });
+
+  it("handles incorrectly formatted string correctly", () => {
+    expect(calcBrightness("incorrect")).toEqual({
+      brightness: undefined,
+      alpha: undefined
+    });
+  });
+});
+
+describe("test setContrastingColor", () => {
+  it("returns theme.colors.darkGray when a light primary color is passed in", () => {
+    expect(setContrastingColor("#fff")).toEqual(theme.colors.darkGray);
+  });
+
+  it("returns theme.colors.white when a dark primary color is passed in", () => {
+    expect(setContrastingColor("#000")).toEqual(theme.colors.white);
+  });
+
+  it("returns theme.colors.darkGray when a color is passed in with an opacity of less than .5", () => {
+    expect(setContrastingColor("rgba(0, 0, 0, .4)")).toEqual(
+      theme.colors.darkGray
+    );
+  });
+});

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -10,6 +10,7 @@ import moment from "moment";
 import Divider from "material-ui/Divider";
 import { withRouter } from "react-router";
 import { dataTest } from "../lib/attributes";
+import theme from "../styles/theme";
 
 const inlineStyles = {
   badge: {
@@ -106,7 +107,7 @@ export class AssignmentSummary extends Component {
     }
   }
 
-  detectHexBrightness(color) {
+  calcHexBrightness(color) {
     let hexcolor = color.replace("#", "");
     if (hexcolor.length === 3) {
       hexcolor = hexcolor.replace(/(.)/g, "$1$1");
@@ -118,10 +119,12 @@ export class AssignmentSummary extends Component {
     const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
     const threshhold = 130;
 
-    return brightness > threshhold ? "light" : "dark";
+    const contrastingColor =
+      brightness > threshhold ? theme.colors.darkGray : theme.colors.white;
+    return contrastingColor;
   }
 
-  detectRgbBrightness(color) {
+  calcRgbBrightness(color) {
     const colorValuesArray = color
       .slice(color.indexOf("(") + 1, color.indexOf(")"))
       .split(",");
@@ -136,10 +139,14 @@ export class AssignmentSummary extends Component {
     const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
     const threshhold = 130;
 
-    return brightness > threshhold || alpha < 50 ? "light" : "dark";
+    const contrastingColor =
+      brightness > threshhold || alpha < 50
+        ? theme.colors.darkGray
+        : theme.colors.white;
+    return contrastingColor;
   }
 
-  detectHslBrightness(color) {
+  calcHslBrightness(color) {
     let colorValuesArray = color
       .slice(color.indexOf("(") + 1, color.indexOf(")"))
       .replace(/(%)/g, "")
@@ -152,19 +159,23 @@ export class AssignmentSummary extends Component {
 
     const threshhold = 60;
 
-    return brightness > threshhold || alpha < 50 ? "light" : "dark";
+    const contrastingColor =
+      brightness > threshhold || alpha < 50
+        ? theme.colors.darkGray
+        : theme.colors.white;
+    return contrastingColor;
   }
 
-  setContrastingColor(color) {
-    let brightness;
+  setContrastingColor(primaryColor) {
+    let contrastingColor;
 
-    color[0] === "#"
-      ? (brightness = this.detectHexBrightness(color))
-      : color[0] === "h"
-      ? (brightness = this.detectHslBrightness(color))
-      : (brightness = this.detectRgbBrightness(color));
+    primaryColor[0] === "#"
+      ? (contrastingColor = this.calcHexBrightness(primaryColor))
+      : primaryColor[0] === "h"
+      ? (contrastingColor = this.calcHslBrightness(primaryColor))
+      : (contrastingColor = this.calcRgbBrightness(primaryColor));
 
-    return brightness === "dark" ? "rgb(255,255,255)" : "rgb(54, 67, 80)";
+    return contrastingColor;
   }
 
   render() {

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import { Card, CardActions, CardTitle } from "material-ui/Card";
 import { StyleSheet, css } from "aphrodite";
 import loadData from "../containers/hoc/load-data";
+import { setContrastingColor } from "../lib/color-contrast-helper";
 import gql from "graphql-tag";
 import RaisedButton from "material-ui/RaisedButton";
 import Badge from "material-ui/Badge";
@@ -10,7 +11,6 @@ import moment from "moment";
 import Divider from "material-ui/Divider";
 import { withRouter } from "react-router";
 import { dataTest } from "../lib/attributes";
-import theme from "../styles/theme";
 
 const inlineStyles = {
   badge: {
@@ -107,77 +107,6 @@ export class AssignmentSummary extends Component {
     }
   }
 
-  calcHexBrightness(color) {
-    let hexcolor = color.replace("#", "");
-    if (hexcolor.length === 3) {
-      hexcolor = hexcolor.replace(/(.)/g, "$1$1");
-    }
-    const r = parseInt(hexcolor.substr(0, 2), 16);
-    const g = parseInt(hexcolor.substr(2, 2), 16);
-    const b = parseInt(hexcolor.substr(4, 2), 16);
-
-    const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
-    const threshhold = 130;
-
-    const contrastingColor =
-      brightness > threshhold ? theme.colors.darkGray : theme.colors.white;
-    return contrastingColor;
-  }
-
-  calcRgbBrightness(color) {
-    const colorValuesArray = color
-      .slice(color.indexOf("(") + 1, color.indexOf(")"))
-      .split(",");
-
-    const r = parseInt(colorValuesArray[0]);
-    const g = parseInt(colorValuesArray[1]);
-    const b = parseInt(colorValuesArray[2]);
-    const alpha = colorValuesArray[3]
-      ? parseInt(colorValuesArray[3] * 100)
-      : 100;
-
-    const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
-    const threshhold = 130;
-
-    const contrastingColor =
-      brightness > threshhold || alpha < 50
-        ? theme.colors.darkGray
-        : theme.colors.white;
-    return contrastingColor;
-  }
-
-  calcHslBrightness(color) {
-    let colorValuesArray = color
-      .slice(color.indexOf("(") + 1, color.indexOf(")"))
-      .replace(/(%)/g, "")
-      .split(",");
-
-    const brightness = parseInt(colorValuesArray[2]);
-    const alpha = colorValuesArray[3]
-      ? parseInt(colorValuesArray[3] * 100)
-      : 100;
-
-    const threshhold = 60;
-
-    const contrastingColor =
-      brightness > threshhold || alpha < 50
-        ? theme.colors.darkGray
-        : theme.colors.white;
-    return contrastingColor;
-  }
-
-  setContrastingColor(primaryColor) {
-    let contrastingColor;
-
-    primaryColor[0] === "#"
-      ? (contrastingColor = this.calcHexBrightness(primaryColor))
-      : primaryColor[0] === "h"
-      ? (contrastingColor = this.calcHslBrightness(primaryColor))
-      : (contrastingColor = this.calcRgbBrightness(primaryColor));
-
-    return contrastingColor;
-  }
-
   render() {
     const {
       assignment,
@@ -200,7 +129,7 @@ export class AssignmentSummary extends Component {
     } = assignment.campaign;
     const maxContacts = assignment.maxContacts;
 
-    const cardTitleTextColor = this.setContrastingColor(primaryColor);
+    const cardTitleTextColor = setContrastingColor(primaryColor);
 
     return (
       <div className={css(styles.container)}>

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -106,7 +106,7 @@ export class AssignmentSummary extends Component {
     }
   }
 
-  calcHexBrightness(color) {
+  detectHexBrightness(color) {
     let hexcolor = color.replace("#", "");
     if (hexcolor.length === 3) {
       hexcolor = hexcolor.replace(/(.)/g, "$1$1");
@@ -121,7 +121,7 @@ export class AssignmentSummary extends Component {
     return brightness > threshhold ? "light" : "dark";
   }
 
-  calcRgbBrightness(color) {
+  detectRgbBrightness(color) {
     const colorValuesArray = color
       .slice(color.indexOf("(") + 1, color.indexOf(")"))
       .split(",");
@@ -139,7 +139,7 @@ export class AssignmentSummary extends Component {
     return brightness > threshhold || alpha < 50 ? "light" : "dark";
   }
 
-  calcHslBrightness(color) {
+  detectHslBrightness(color) {
     let colorValuesArray = color
       .slice(color.indexOf("(") + 1, color.indexOf(")"))
       .replace(/(%)/g, "")
@@ -155,16 +155,16 @@ export class AssignmentSummary extends Component {
     return brightness > threshhold || alpha < 50 ? "light" : "dark";
   }
 
-  checkColorContrast(color) {
+  setContrastingColor(color) {
     let brightness;
 
     color[0] === "#"
-      ? (brightness = this.calcHexBrightness(color))
+      ? (brightness = this.detectHexBrightness(color))
       : color[0] === "h"
-      ? (brightness = this.calcHslBrightness(color))
-      : (brightness = this.calcRgbBrightness(color));
+      ? (brightness = this.detectHslBrightness(color))
+      : (brightness = this.detectRgbBrightness(color));
 
-    return brightness;
+    return brightness === "dark" ? "rgb(255,255,255)" : "rgb(54, 67, 80)";
   }
 
   render() {
@@ -189,16 +189,19 @@ export class AssignmentSummary extends Component {
     } = assignment.campaign;
     const maxContacts = assignment.maxContacts;
 
-    const backgroundBrightness = this.checkColorContrast(primaryColor);
-    console.log(backgroundBrightness);
+    const cardTitleTextColor = this.setContrastingColor(primaryColor);
 
     return (
       <div className={css(styles.container)}>
         <Card key={assignment.id}>
           <CardTitle
             title={title}
+            titleStyle={{ color: cardTitleTextColor }}
             subtitle={`${description} - ${moment(dueBy).format("MMM D YYYY")}`}
-            style={{ backgroundColor: primaryColor }}
+            subtitleStyle={{ color: cardTitleTextColor }}
+            style={{
+              backgroundColor: primaryColor
+            }}
             children={
               logoImageUrl ? (
                 <img src={logoImageUrl} className={css(styles.image)} />

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -106,6 +106,67 @@ export class AssignmentSummary extends Component {
     }
   }
 
+  calcHexBrightness(color) {
+    let hexcolor = color.replace("#", "");
+    if (hexcolor.length === 3) {
+      hexcolor = hexcolor.replace(/(.)/g, "$1$1");
+    }
+    const r = parseInt(hexcolor.substr(0, 2), 16);
+    const g = parseInt(hexcolor.substr(2, 2), 16);
+    const b = parseInt(hexcolor.substr(4, 2), 16);
+
+    const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
+    const threshhold = 130;
+
+    return brightness > threshhold ? "light" : "dark";
+  }
+
+  calcRgbBrightness(color) {
+    const colorValuesArray = color
+      .slice(color.indexOf("(") + 1, color.indexOf(")"))
+      .split(",");
+
+    const r = parseInt(colorValuesArray[0]);
+    const g = parseInt(colorValuesArray[1]);
+    const b = parseInt(colorValuesArray[2]);
+    const alpha = colorValuesArray[3]
+      ? parseInt(colorValuesArray[3] * 100)
+      : 100;
+
+    const brightness = Math.floor((r * 299 + g * 587 + b * 114) / 1000);
+    const threshhold = 130;
+
+    return brightness > threshhold || alpha < 50 ? "light" : "dark";
+  }
+
+  calcHslBrightness(color) {
+    let colorValuesArray = color
+      .slice(color.indexOf("(") + 1, color.indexOf(")"))
+      .replace(/(%)/g, "")
+      .split(",");
+
+    const brightness = parseInt(colorValuesArray[2]);
+    const alpha = colorValuesArray[3]
+      ? parseInt(colorValuesArray[3] * 100)
+      : 100;
+
+    const threshhold = 60;
+
+    return brightness > threshhold || alpha < 50 ? "light" : "dark";
+  }
+
+  checkColorContrast(color) {
+    let brightness;
+
+    color[0] === "#"
+      ? (brightness = this.calcHexBrightness(color))
+      : color[0] === "h"
+      ? (brightness = this.calcHslBrightness(color))
+      : (brightness = this.calcRgbBrightness(color));
+
+    return brightness;
+  }
+
   render() {
     const {
       assignment,
@@ -127,6 +188,10 @@ export class AssignmentSummary extends Component {
       useDynamicAssignment
     } = assignment.campaign;
     const maxContacts = assignment.maxContacts;
+
+    const backgroundBrightness = this.checkColorContrast(primaryColor);
+    console.log(backgroundBrightness);
+
     return (
       <div className={css(styles.container)}>
         <Card key={assignment.id}>

--- a/src/lib/color-contrast-helper.js
+++ b/src/lib/color-contrast-helper.js
@@ -1,116 +1,20 @@
 import theme from "../styles/theme";
 
-export const parseRgbValues = color => {
-  let rgbColorValuesArray = color
-    .slice(color.indexOf("(") + 1, color.indexOf(")"))
-    .split(",");
+const tinycolor = require("tinycolor2");
 
-  const r = parseInt(rgbColorValuesArray[0]);
-  const g = parseInt(rgbColorValuesArray[1]);
-  const b = parseInt(rgbColorValuesArray[2]);
-  const alpha = rgbColorValuesArray[3]
-    ? parseInt(rgbColorValuesArray[3] * 100)
-    : 100;
-  return { r, g, b, alpha };
-};
+export const setContrastingColor = color => {
+  const colorIsValid = tinycolor(color).isValid();
+  const brightness = tinycolor(color).getBrightness();
+  const alpha = tinycolor(color).getAlpha();
 
-export const convertHexToRgb = color => {
-  let hexcolor = color.replace("#", "");
-  if (hexcolor.length === 3) {
-    hexcolor = hexcolor.replace(/(.)/g, "$1$1");
-  }
-  const r = parseInt(hexcolor.substr(0, 2), 16);
-  const g = parseInt(hexcolor.substr(2, 2), 16);
-  const b = parseInt(hexcolor.substr(4, 2), 16);
-  return { r, g, b };
-};
+  const brightnessThreshhold = 160;
+  const alphaThreshhold = 0.4;
 
-export const convertHslToRgb = color => {
-  let hslColorValuesArray = color
-    .slice(color.indexOf("(") + 1, color.indexOf(")"))
-    .replace(/(%)/g, "")
-    .split(",");
-
-  const h = hslColorValuesArray[0];
-  const s = hslColorValuesArray[1] / 100;
-  const l = hslColorValuesArray[2] / 100;
-  const alpha = hslColorValuesArray[3]
-    ? parseInt(hslColorValuesArray[3] * 100)
-    : 100;
-
-  const val1 = (1 - Math.abs(2 * l - 1)) * s;
-  const val2 = val1 * (1 - Math.abs(((h / 60) % 2) - 1));
-  const val3 = l - val1 / 2;
-
-  let r, g, b;
-
-  if (h >= 0 && h < 60) {
-    r = val1;
-    g = val2;
-    b = 0;
-  } else if (h >= 60 && h < 120) {
-    r = val2;
-    g = val1;
-    b = 0;
-  } else if (h >= 120 && h < 180) {
-    r = 0;
-    g = val1;
-    b = val2;
-  } else if (h >= 180 && h < 240) {
-    r = 0;
-    g = val2;
-    b = val1;
-  } else if (h >= 240 && h < 300) {
-    r = val2;
-    g = 0;
-    b = val1;
-  } else if (h >= 300 && h < 360) {
-    r = val1;
-    g = 0;
-    b = val2;
-  }
-
-  r = Math.round((r + val3) * 255);
-  g = Math.round((g + val3) * 255);
-  b = Math.round((b + val3) * 255);
-  return { r, g, b, alpha };
-};
-
-export const calcBrightness = primaryColor => {
-  const W3CBrightnessFormula = (red, green, blue) =>
-    Math.floor((red * 299 + green * 587 + blue * 114) / 1000);
-
-  switch (primaryColor[0]) {
-    case "r": {
-      const { r, g, b, alpha } = parseRgbValues(primaryColor);
-      const brightness = W3CBrightnessFormula(r, g, b);
-      return { brightness, alpha };
-    }
-    case "#": {
-      const { r, g, b, alpha } = convertHexToRgb(primaryColor);
-      const brightness = W3CBrightnessFormula(r, g, b);
-      return { brightness, alpha };
-    }
-    case "h": {
-      const { r, g, b, alpha } = convertHslToRgb(primaryColor);
-      const brightness = W3CBrightnessFormula(r, g, b);
-      return { brightness, alpha };
-    }
-
-    default:
-      return { brightness: undefined, alpha: undefined };
-  }
-};
-
-export const setContrastingColor = primaryColor => {
-  const { brightness, alpha } = calcBrightness(primaryColor);
-  const threshhold = 160;
-  const color =
-    brightness > threshhold ||
-    (alpha && alpha < 50) ||
-    brightness === undefined ||
-    isNaN(brightness)
+  const contrastingColor =
+    brightness > brightnessThreshhold ||
+    alpha < alphaThreshhold ||
+    !colorIsValid
       ? theme.colors.darkGray
       : theme.colors.white;
-  return color;
+  return contrastingColor;
 };

--- a/src/lib/color-contrast-helper.js
+++ b/src/lib/color-contrast-helper.js
@@ -1,0 +1,116 @@
+import theme from "../styles/theme";
+
+export const parseRgbValues = color => {
+  let rgbColorValuesArray = color
+    .slice(color.indexOf("(") + 1, color.indexOf(")"))
+    .split(",");
+
+  const r = parseInt(rgbColorValuesArray[0]);
+  const g = parseInt(rgbColorValuesArray[1]);
+  const b = parseInt(rgbColorValuesArray[2]);
+  const alpha = rgbColorValuesArray[3]
+    ? parseInt(rgbColorValuesArray[3] * 100)
+    : 100;
+  return { r, g, b, alpha };
+};
+
+export const convertHexToRgb = color => {
+  let hexcolor = color.replace("#", "");
+  if (hexcolor.length === 3) {
+    hexcolor = hexcolor.replace(/(.)/g, "$1$1");
+  }
+  const r = parseInt(hexcolor.substr(0, 2), 16);
+  const g = parseInt(hexcolor.substr(2, 2), 16);
+  const b = parseInt(hexcolor.substr(4, 2), 16);
+  return { r, g, b };
+};
+
+export const convertHslToRgb = color => {
+  let hslColorValuesArray = color
+    .slice(color.indexOf("(") + 1, color.indexOf(")"))
+    .replace(/(%)/g, "")
+    .split(",");
+
+  const h = hslColorValuesArray[0];
+  const s = hslColorValuesArray[1] / 100;
+  const l = hslColorValuesArray[2] / 100;
+  const alpha = hslColorValuesArray[3]
+    ? parseInt(hslColorValuesArray[3] * 100)
+    : 100;
+
+  const val1 = (1 - Math.abs(2 * l - 1)) * s;
+  const val2 = val1 * (1 - Math.abs(((h / 60) % 2) - 1));
+  const val3 = l - val1 / 2;
+
+  let r, g, b;
+
+  if (h >= 0 && h < 60) {
+    r = val1;
+    g = val2;
+    b = 0;
+  } else if (h >= 60 && h < 120) {
+    r = val2;
+    g = val1;
+    b = 0;
+  } else if (h >= 120 && h < 180) {
+    r = 0;
+    g = val1;
+    b = val2;
+  } else if (h >= 180 && h < 240) {
+    r = 0;
+    g = val2;
+    b = val1;
+  } else if (h >= 240 && h < 300) {
+    r = val2;
+    g = 0;
+    b = val1;
+  } else if (h >= 300 && h < 360) {
+    r = val1;
+    g = 0;
+    b = val2;
+  }
+
+  r = Math.round((r + val3) * 255);
+  g = Math.round((g + val3) * 255);
+  b = Math.round((b + val3) * 255);
+  return { r, g, b, alpha };
+};
+
+export const calcBrightness = primaryColor => {
+  const W3CBrightnessFormula = (red, green, blue) =>
+    Math.floor((red * 299 + green * 587 + blue * 114) / 1000);
+
+  switch (primaryColor[0]) {
+    case "r": {
+      const { r, g, b, alpha } = parseRgbValues(primaryColor);
+      const brightness = W3CBrightnessFormula(r, g, b);
+      return { brightness, alpha };
+    }
+    case "#": {
+      const { r, g, b, alpha } = convertHexToRgb(primaryColor);
+      const brightness = W3CBrightnessFormula(r, g, b);
+      return { brightness, alpha };
+    }
+    case "h": {
+      const { r, g, b, alpha } = convertHslToRgb(primaryColor);
+      const brightness = W3CBrightnessFormula(r, g, b);
+      return { brightness, alpha };
+    }
+
+    default:
+      return { brightness: undefined, alpha: undefined };
+  }
+};
+
+export const setContrastingColor = primaryColor => {
+  const { brightness, alpha } = calcBrightness(primaryColor);
+  const threshhold = 160;
+  const color =
+    brightness > threshhold ||
+    (alpha && alpha < 50) ||
+    brightness === undefined ||
+    isNaN(brightness)
+      ? theme.colors.darkGray
+      : theme.colors.white;
+  return color;
+};


### PR DESCRIPTION
Fixes issue #448 

Added code to detect the brightness of the user-selected background color, then render the text in either white or dark gray, to provide enough contrast so the text is legible and for improved accessibility.

Before: 
![Screen Shot 2019-11-11 at 10 33 33 PM](https://user-images.githubusercontent.com/23403170/68641010-7378d580-04d7-11ea-99ba-107aa500d2cb.png)
 
After: 
![Screen Shot 2019-11-11 at 10 35 37 PM](https://user-images.githubusercontent.com/23403170/68641037-91ded100-04d7-11ea-8734-b4f0a0c786ca.png)


- [ ] I have manually tested my changes on desktop and mobile
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less]