### PR TITLE
Canceling a new Canned Response

### DIFF
--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -26,7 +26,7 @@ class CannedResponseForm extends React.Component {
       text: yup.string().required()
     });
 
-    const { customFields } = this.props;
+    const { customFields, handleCloseAddForm } = this.props;
     return (
       <div>
         <GSForm ref="form" schema={modelSchema} onSubmit={this.handleSave}>
@@ -57,7 +57,7 @@ class CannedResponseForm extends React.Component {
             />
             <FlatButton
               label="Cancel"
-              onTouchTap={() => this.setState({ showForm: false })}
+              onTouchTap={handleCloseAddForm}
               style={{
                 marginLeft: 5,
                 display: "inline-block"
@@ -72,6 +72,7 @@ class CannedResponseForm extends React.Component {
 
 CannedResponseForm.propTypes = {
   onSaveCannedResponse: type.func,
+  handleCloseAddForm: type.func,
   customFields: type.array
 };
 

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -47,11 +47,16 @@ export default class CampaignCannedResponsesForm extends React.Component {
   });
 
   showAddForm() {
+    const handleCloseAddForm = () => {
+      this.setState({ showForm: false });
+    };
+
     if (this.state.showForm) {
       return (
         <div className={css(styles.formContainer)}>
           <div className={css(styles.form)}>
             <CampaignCannedResponseForm
+              handleCloseAddForm={handleCloseAddForm}
               onSaveCannedResponse={ele => {
                 const newVals = this.props.formValues.cannedResponses.slice(0);
                 const newEle = {


### PR DESCRIPTION
# Fixes #226

## Description

The Cancel button on the "Add New Canned Response" form wasn't functioning properly.  Added method to the CampaignCannedResponsesForm component so it works as expected.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- n/a If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- n/a I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- n/a My PR is labeled [WIP] if it is in progress
