### PR TITLE
Update google-libphonenumber

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "draft-js": "^0.7.0",
     "express": "^4.14.0",
     "fs": "^0.0.2",
-    "google-libphonenumber": "^1.0.25",
+    "google-libphonenumber": "^3.0.0",
     "googleapis": "^39.2.0",
     "graphql": "^0.13.2",
     "graphql-date": "^1.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6344,10 +6344,10 @@ google-auth-library@^3.0.0:
     lru-cache "^5.0.0"
     semver "^5.5.0"
 
-google-libphonenumber@^1.0.25:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-1.1.2.tgz#bf058975c31f7e3638333b0d630ef38dd3263b48"
-  integrity sha1-vwWJdcMffjY4MzsNYw7zjdMmO0g=
+google-libphonenumber@^3.0.0:
+  version "3.2.6"
+  resolved "https://registry.yarnpkg.com/google-libphonenumber/-/google-libphonenumber-3.2.6.tgz#3d725b48ff44706b80246e77f95f2c2fdc6fd729"
+  integrity sha512-6QCQAaKJlSd/1dUqvdQf7zzfb3uiZHsG8yhCfOdCVRfMuPZ/VDIEB47y5SYwjPQJPs7ebfW5jj6PeobB9JJ4JA==
 
 google-p12-pem@^1.0.0:
   version "1.0.4"


### PR DESCRIPTION
# Fixes #1271 

## Description

Update the google-libphonenumber library from 1.1.2 to 3.2.6. This allows phone numbers using newer area codes (e.g. 463) to be validated. I don't believe there are any relevant API changes in the library and my manual testing did not show any problems.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
