### PR TITLE
HOWTO-run_tests - added link to tips in getting postgres installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ At this point, you should be ready to start your app in development mode.
 4. You should then be prompted to create an organization. Create it.
 5. See the [Admin and Texter demos](https://opensource.moveon.org/spoke-p2p#block-yui_3_17_2_25_1509554076500_36334) to learn about how Spoke works.
 6. See [Getting Started with Development](#more-documentation) below.
+7. See [How to Run Tests](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-run_tests.md)
 
 ### SMS
 

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -11,7 +11,6 @@ GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 ```
 3) Run `npm test`
 
-
 ## SQLite Testing (simpler)
 
 1) Run `npm run test-sqlite`

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -2,7 +2,7 @@ There are current two ways to run tests, using either PostgreSQL or SQLite.
 
 ## PostgreSQL Testing (default, closer to most prod environments)
 
-1) Install PostgreSQL - [Tips to installing Postgre](https://www.codementor.io/engineerapart/getting-started-with-postgresql-on-mac-osx-are8jcopb)
+1) Install PostgreSQL - [Tips to installing Postgres](https://www.codementor.io/engineerapart/getting-started-with-postgresql-on-mac-osx-are8jcopb)
 2) In PostgreSQL, create a database and user named "spoke_test":
 ```
 CREATE DATABASE spoke_test;

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -2,7 +2,7 @@ There are current two ways to run tests, using either PostgreSQL or SQLite.
 
 ## PostgreSQL Testing (default, closer to most prod environments)
 
-1) Install PostgreSQL
+1) Install PostgreSQL - [Tips to installing Postgre](https://www.codementor.io/engineerapart/getting-started-with-postgresql-on-mac-osx-are8jcopb)
 2) In PostgreSQL, create a database and user named "spoke_test":
 ```
 CREATE DATABASE spoke_test;
@@ -10,6 +10,7 @@ CREATE USER spoke_test WITH PASSWORD 'spoke_test';
 GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 ```
 3) Run `npm test`
+
 
 ## SQLite Testing (simpler)
 

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -9,16 +9,20 @@ CREATE DATABASE spoke_test;
 CREATE USER spoke_test WITH PASSWORD 'spoke_test';
 GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
 ```
-3) Run `npm test`
+3) Run `yarn test`
 
 ## SQLite Testing (simpler)
 
-1) Run `npm run test-sqlite`
+1) Run `yarn run test-sqlite`
+  
+## Test Redis Cache
+
+1) Run `yarn test-rediscache`
 
 ## End-To-End (Interactive Browser) Testing
 
 1. Remember to set `NODE_ENV=dev` 
-1. **Start DB** and **Start Spoke Server** as described in the [Getting Started](
+2. **Start DB** and **Start Spoke Server** as described in the [Getting Started](
 https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section. 
 1. Install browser driver(s)
     
@@ -33,11 +37,11 @@ https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section.
 1. Running tests...
     * ... using your local browser
       ```
-      npm run test-e2e
+      yarn run test-e2e
       ```
     * ... individually
       ```
-      npm run test-e2e <test name>
+      yarn run test-e2e <test name>
       ```
     * ... using Sauce Labs browser with your local host
       
@@ -45,5 +49,5 @@ https://github.com/MoveOnOrg/Spoke/blob/main/README.md#getting-started) section.
       ```
       export SAUCE_USERNAME=<Sauce Labs user name>
       export SAUCE_ACCESS_KEY=<Sauce Labs access key>
-      npm run test-e2e <optional test name> --saucelabs
+      yarn run test-e2e <optional test name> --saucelabs
       ```

--- a/docs/HOWTO-run_tests.md
+++ b/docs/HOWTO-run_tests.md
@@ -17,6 +17,8 @@ GRANT ALL PRIVILEGES ON DATABASE spoke_test TO spoke_test;
   
 ## Test Redis Cache
 
+Redis is used for caching and is separate from the backend DB so can be used with sqlite *or* postgres. Redis cache testing defaults to postgres and functions like an 'addon' to the DB for improved speed/scalability.
+
 1) Run `yarn test-rediscache`
 
 ## End-To-End (Interactive Browser) Testing


### PR DESCRIPTION
# Fixes [#1208 ](https://github.com/MoveOnOrg/Spoke/issues/1208)

## Description

README: Links to the testing documentation more prominently. 
How to run tests: 
* Adds documentation for troubleshooting Prostgres installation. 
* Changes references from 'npm' to 'yarn'  e.g. yarn test-sqlite
* Added section for `yarn test-rediscache`

README:
<img width="1107" alt="Screen Shot 2019-11-17 at 9 07 57 PM" src="https://user-images.githubusercontent.com/23281077/69019398-816aa280-097e-11ea-983e-8ca42dca55da.png">

How to Run tests:
<img width="963" alt="Screen Shot 2019-11-24 at 4 02 15 PM" src="https://user-images.githubusercontent.com/23281077/69501530-cdb06800-0ed3-11ea-95b0-34ca010be473.png">

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
