### PR TITLE
Improve documentation for bulk sending outside the USA.

### DIFF
--- a/docs/HOWTO-use_bulk_sending_outside_the_USA.md
+++ b/docs/HOWTO-use_bulk_sending_outside_the_USA.md
@@ -1,0 +1,28 @@
+# How to configure Spoke for bulk sending outside the USA
+
+#### We assume that bulk sending -- sending a text to more than one contact with a single click -- is not legal in the USA.  Please consult with an attorney before you do that.
+
+## About bulk sending
+
+If Spoke is configured to do bulk sending, a `Send Bulk` button will appear on the texter's view for the first contact.  When the texter clicks that button, the next chunk of contacts will receive the initial message.  After Spoke queues up messages for those contacts, if there are any contacts left in the texter's assignment, the next chunk of contacts will receive messages the next time the texter clicks `Send Bulk`.
+
+Only contacts needing the initial message will receive a message.
+
+## After confirming that you can legally use the feature
+
+Refer to [REFERENCE-environment_variables.md](REFERENCE-environment_variables.md) for more information about the environment variables mentioned below.
+
+1. Set the environment variable `ALLOW_SEND_ALL` to `true`.
+2. Set the environment variable `BULK_SEND_CHUNK_SIZE` to a number greater than 0. 
+3. Set the environment variable `NOT_IN_USA` to `true`. 
+4. Restart Spoke.
+
+## Example: `.env` file
+
+If you use a `.env` file to configure Spoke, the changes above would appear as follows.  If you're using some other method to configure Spoke (such as Heroku settings) please follow the procedures and instructions for that method.
+
+```
+ALLOW_SEND_ALL=true
+BULK_SEND_CHUNK_SIZE=30
+NOT_IN_USA=true
+```

--- a/docs/REFERENCE-environment_variables.md
+++ b/docs/REFERENCE-environment_variables.md
@@ -1,5 +1,6 @@
 Variable                          | Purpose
 ----------------------------------|----------------------------------
+ALLOW_SEND_ALL                    | A flag to affirmatively indicate the ability to use the bulk send feature, which is not legally usable in the United States. Consult with an attorney about the implications for doing so.  Refer to [HOWTO-use_bulk_sending_outside_the_USA.md](HOWTO-use_bulk_sending_outside_the_USA.md) for full instructions on configuring Spoke for bulk sending. _Default_: false (i.e. default assumes a USA legal context)
 APOLLO_OPTICS_KEY                 | A key for Apollo tracer.
 ASSETS_DIR                        | Directory path where front-end packaged JavaScript is saved and loaded. _Required_.
 ASSETS_MAP_FILE                   | File name of map file, within ASSETS_DIR, containing map of general file names to unique build-specific file names.
@@ -11,6 +12,7 @@ AWS_ACCESS_KEY_ID                 | AWS access key ID with access to S3 bucket, 
 AWS_SECRET_ACCESS_KEY             | AWS access key secret with access to S3 bucket, required for campaign exports outside Amazon Lambda.
 AWS_S3_BUCKET_NAME                | Name of S3 bucket for saving campaign exports.
 BASE_URL                          | The base URL of the website, without trailing slack, e.g. `https://example.org`, used to construct various URLs.
+BULK_SEND_CHUNK_SIZE              | The number of contacts to whom to send the initial text for a campaign when a volunteer uses the `Send Bulk` button.  Applies only when Spoke is configured for use outside the USA.  Refer to [HOWTO-use_bulk_sending_outside_the_USA.md](HOWTO-use_bulk_sending_outside_the_USA.md) for full instructions on configuring Spoke for bulk sending.
 CACHE_PREFIX                      | If REDIS_URL is set, then this will prefix keys CACHE_PREFIX, which might be useful if multiple applications use the same redis server. _Default_: "".
 CAMPAIGN_ID                       | Campaign ID used by `dev-tools/export-query.js` to identify which campaign should be exported.
 DB_HOST                           | Domain or IP address of database host.
@@ -47,7 +49,7 @@ NEXMO_API_KEY                     | Nexmo API key. Required if using Nexmo.
 NEXMO_API_SECRET                  | Nexmo API secret. Required if using Nexmo.
 NO_EXTERNAL_LINKS                 | Removes google fonts and auth0 login script -- good for development offline when you already have an auth0 session
 NODE_ENV                          | Node environment type. _Options_: development, production.
-NOT_IN_USA                        | A flag to affirmatively indicate the ability to use features that are discouraged or not legally usable in the United States. Consult with an attorney about the implications for doing so. _Default_: false (i.e. default assumes a USA legal context)
+NOT_IN_USA                        | A flag to affirmatively indicate the ability to use features that are discouraged or not legally usable in the United States. Consult with an attorney about the implications for doing so.  Refer to [HOWTO-use_bulk_sending_outside_the_USA.md](HOWTO-use_bulk_sending_outside_the_USA.md) for full instructions on configuring Spoke for bulk sending. _Default_: false (i.e. default assumes a USA legal context)
 OPT_OUT_MESSAGE                   | Spoke instance-wide default for opt out message.
 OPTOUTS_SHARE_ALL_ORGS            | Can be set to true if opt outs should be respected per instance and across organizations
 OUTPUT_DIR                        | Directory path for packaged files should be saved to. _Required_.


### PR DESCRIPTION
# Fixes #1282 

## Description

Added documentation for the environment variables `BULK_SEND_CHUNK_SIZE` and `ALLOW_SEND_ALL` and added a new readme to explain bulk sending, with some emphasis on not using it in the USA.

# Checklist:

This is a documentation change.  No code was touched.