### PR TITLE
Allow alternate schema for postgres db

### DIFF
--- a/docs/REFERENCE-environment_variables.md
+++ b/docs/REFERENCE-environment_variables.md
@@ -18,6 +18,7 @@ DB_MAX_POOL                       | Database connection pool maximum size. _Defa
 DB_MIN_POOL                       | Database connection pool minumum size. _Default_: 2.
 DB_NAME                           | Database connection name. _Required_.
 DB_PORT                           | Database connection port. _Required_.
+DB_SCHEMA                         | Optional postgres database schema to use instead of public. Useful for running multiple instances on a shared DB server. _Default_: ""
 DB_TYPE                           | Database connection type for [Knex](http://knexjs.org/#Installation-client). _Options_: mysql, pg, sqlite3. _Default_: sqlite3.
 DB_USE_SSL                        | Boolean value to determine whether database connections should use SSL. _Default_: false.
 DEBUG_SCALING                     | Emit console.log on events related to scaling issues. _Default_: false.
@@ -41,7 +42,7 @@ MAILGUN_SMTP_PASSWORD             | 'Default Password' in Mailgun. _Required for
 MAILGUN_SMTP_PORT                 | _Default_: 587. Do not modify. _Required for Mailgun usage._
 MAILGUN_SMTP_SERVER               | _Default_: smtp.mailgun.org. Do not modify. _Required for Mailgun usage._
 MAX_CONTACTS                      | If set each campaign can only have a maximum of the value (an integer). This is good for staging/QA/evaluation instances.  _Default_: false (i.e. there is no maximum)
-MAX_CONTACTS_PER_TEXTER           | Maximum contacts that a texter can send to, per campaign. This is particularly useful for dynamic assignment. This must not be blank/empty and must be a number greater than 0. 
+MAX_CONTACTS_PER_TEXTER           | Maximum contacts that a texter can send to, per campaign. This is particularly useful for dynamic assignment. This must not be blank/empty and must be a number greater than 0.
 MAX_MESSAGE_LENGTH                | The maximum size for a message that a texter can send. When you send a SMS message over 160 characters the message will be split, so you might want to set this as 160 or less if you have a high SMS-only target demographic. _Default_: 99999
 NEXMO_API_KEY                     | Nexmo API key. Required if using Nexmo.
 NEXMO_API_SECRET                  | Nexmo API secret. Required if using Nexmo.

--- a/src/server/knex-connect.js
+++ b/src/server/knex-connect.js
@@ -13,6 +13,7 @@ const {
   DB_NAME,
   DB_PASSWORD,
   DB_USER,
+  DB_SCHEMA,
   DATABASE_URL,
   NODE_ENV
 } = process.env;
@@ -50,6 +51,7 @@ if (DB_JSON) {
   config = {
     client: /postgres/.test(dbType) ? "pg" : dbType,
     connection: DATABASE_URL,
+    searchPath: DB_SCHEMA || "",
     migrations: {
       directory: process.env.KNEX_MIGRATION_DIR || "./migrations/"
     },


### PR DESCRIPTION
## Description

This is a very simple change that allow you to specify a `searchPath` in the knex config. See: http://knexjs.org/#Installation-client

This allows you to share a single postgres database across multiple Spoke instances, but keep data separate, e.g. using `heroku addons:attach`. It's probably mostly useful on Heroku, because Heroku allows you to [attach a database addon to multiple apps](https://devcenter.heroku.com/articles/heroku-postgresql#sharing-heroku-postgres-between-applications), but doesn't allow you to create multiple databases.

If the searchPath is left blank, than knex will just ignore it, see: https://github.com/knex/knex/blob/master/lib/dialects/postgres/index.js#L21

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
