### PR TITLE
guard against passport auth switch

### DIFF
--- a/__test__/server/auth-passport.test.js
+++ b/__test__/server/auth-passport.test.js
@@ -1,0 +1,61 @@
+import passport from "passport";
+import passportSetup from "../../src/server/auth-passport";
+
+import {
+  setupTest,
+  cleanupTest,
+  createUser,
+  createOrganization
+} from "../test_helpers";
+
+beforeEach(async () => {
+  await setupTest();
+}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+afterEach(async () => {
+  await cleanupTest();
+}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+describe("Local Auth Passport tests", () => {
+  it("should deserialize false on non-existent user", async () => {
+    const localAuth = passportSetup.local();
+    passport.initialize();
+    const session = passport.session();
+    const deserialize = passport._deserializers[0];
+
+    let results = [];
+    await deserialize(1, function(err, val) {
+      results.push(err, val);
+    });
+    expect(results[0]).toBe(null);
+    expect(results[1]).toBe(false);
+  });
+  it("should deserialize user on existing user", async () => {
+    const localAuth = passportSetup.local();
+    passport.initialize();
+    const session = passport.session();
+    const deserialize = passport._deserializers[0];
+
+    const testAdminUser = await createUser();
+
+    let results = [];
+    await deserialize(testAdminUser.id, function(err, val) {
+      results.push(err, val);
+    });
+    expect(results[0]).toBe(null);
+    expect(results[1].id).toBe(testAdminUser.id);
+  });
+  it("should return falsey on invalid id", async () => {
+    const localAuth = passportSetup.local();
+    passport.initialize();
+    const session = passport.session();
+    const deserialize = passport._deserializers[0];
+
+    let results = [];
+    await deserialize("JUNKjklsdf", function(err, val) {
+      results.push(err, val);
+    });
+    expect(results[0]).toBe(null);
+    expect(results[1]).toBeFalsy();
+  });
+});

--- a/src/server/auth-passport.js
+++ b/src/server/auth-passport.js
@@ -115,10 +115,9 @@ export function setupLocalAuthPassport() {
 
   passport.deserializeUser(
     wrap(async (id, done) => {
-      const user = await cacheableData.user.userLoggedIn(
-        "id",
-        parseInt(id, 10)
-      );
+      const userId = parseInt(id, 10);
+      const user =
+        userId && (await cacheableData.user.userLoggedIn("id", userId));
       done(null, user || false);
     })
   );


### PR DESCRIPTION
# Fixes switching from auth0 => local auth with a local cookie
guard against NaN content, which e.g. could be from previous auth0 auth, but could also be used for testing guesses of decrypted values (security issue)

## Description

When a server was originally using auth0 and then switches to `PASSPORT_STRATEGY=local` people who have visited and logged in to the site would visit, the server would respond with 'Error on server' -- and the backend would complain that "NaN" is an invalid SQL value.  This is from the changed lines in the PR, where `id` was something like `auth0|1234abcdef678` -- parseInt would fail and then NaN would be passed as an integer arg to the database.

This PR

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [na] My PR is labeled [WIP] if it is in progress
