### PR TITLE
Move gzip helpers & csv parsing to separate files

### DIFF
--- a/src/lib/gzip.js
+++ b/src/lib/gzip.js
@@ -1,0 +1,23 @@
+import zlib from "zlib";
+
+export const gzip = str =>
+  new Promise((resolve, reject) => {
+    zlib.gzip(str, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+export const gunzip = buf =>
+  new Promise((resolve, reject) => {
+    zlib.gunzip(buf, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,3 @@
-import zlib from "zlib";
 export { getFormattedPhoneNumber, getDisplayPhoneNumber } from "./phone-format";
 export {
   getFormattedZip,
@@ -22,9 +21,6 @@ export { DstHelper } from "./dst-helper";
 export { isClient } from "./is-client";
 import { log } from "./log";
 export { log };
-import Papa from "papaparse";
-import _ from "lodash";
-import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
 export {
   findParent,
   getInteractionPath,
@@ -35,14 +31,6 @@ export {
   getChildren,
   makeTree
 } from "./interaction-step-helpers";
-const requiredUploadFields = ["firstName", "lastName", "cell"];
-const topLevelUploadFields = [
-  "firstName",
-  "lastName",
-  "cell",
-  "zip",
-  "external_id"
-];
 
 export {
   ROLE_HIERARCHY,
@@ -51,126 +39,5 @@ export {
   isRoleGreater
 } from "./permissions";
 
-const getValidatedData = (data, optOuts) => {
-  const optOutCells = optOuts.map(optOut => optOut.cell);
-  let validatedData;
-  let result;
-  // For some reason destructuring is not working here
-  result = _.partition(data, row => !!row.cell);
-  validatedData = result[0];
-  const missingCellRows = result[1];
-
-  validatedData = _.map(validatedData, row =>
-    _.extend(row, {
-      cell: getFormattedPhoneNumber(
-        row.cell,
-        process.env.PHONE_NUMBER_COUNTRY || "US"
-      )
-    })
-  );
-  result = _.partition(validatedData, row => !!row.cell);
-  validatedData = result[0];
-  const invalidCellRows = result[1];
-
-  const count = validatedData.length;
-  validatedData = _.uniqBy(validatedData, row => row.cell);
-  const dupeCount = count - validatedData.length;
-
-  result = _.partition(
-    validatedData,
-    row => optOutCells.indexOf(row.cell) === -1
-  );
-  validatedData = result[0];
-  const optOutRows = result[1];
-
-  validatedData = _.map(validatedData, row =>
-    _.extend(row, {
-      zip: row.zip ? getFormattedZip(row.zip) : null
-    })
-  );
-  const zipCount = validatedData.filter(row => !!row.zip).length;
-
-  return {
-    validatedData,
-    validationStats: {
-      dupeCount,
-      optOutCount: optOutRows.length,
-      invalidCellCount: invalidCellRows.length,
-      missingCellCount: missingCellRows.length,
-      zipCount
-    }
-  };
-};
-
-export const gzip = str =>
-  new Promise((resolve, reject) => {
-    zlib.gzip(str, (err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-
-export const gunzip = buf =>
-  new Promise((resolve, reject) => {
-    zlib.gunzip(buf, (err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-
-export const parseCSV = (file, optOuts, callback) => {
-  Papa.parse(file, {
-    header: true,
-    // eslint-disable-next-line no-shadow, no-unused-vars
-    complete: ({ data, meta, errors }, file) => {
-      const fields = meta.fields;
-
-      const missingFields = [];
-
-      for (const field of requiredUploadFields) {
-        if (fields.indexOf(field) === -1) {
-          missingFields.push(field);
-        }
-      }
-
-      if (missingFields.length > 0) {
-        const error = `Missing fields: ${missingFields.join(", ")}`;
-        callback({ error });
-      } else {
-        const { validationStats, validatedData } = getValidatedData(
-          data,
-          optOuts
-        );
-
-        const customFields = fields.filter(
-          field => topLevelUploadFields.indexOf(field) === -1
-        );
-
-        callback({
-          customFields,
-          validationStats,
-          contacts: validatedData
-        });
-      }
-    }
-  });
-};
-
-export const convertRowToContact = row => {
-  const customFields = row;
-  const contact = {};
-  for (const field of topLevelUploadFields) {
-    if (_.has(row, field)) {
-      contact[field] = row[field];
-    }
-  }
-
-  contact.customFields = customFields;
-  return contact;
-};
+export { gzip, gunzip } from "./gzip";
+export { parseCSV } from "./parse_csv.js";

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -1,0 +1,101 @@
+import Papa from "papaparse";
+import _ from "lodash";
+import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
+
+const requiredUploadFields = ["firstName", "lastName", "cell"];
+const topLevelUploadFields = [
+  "firstName",
+  "lastName",
+  "cell",
+  "zip",
+  "external_id"
+];
+
+const getValidatedData = (data, optOuts) => {
+  const optOutCells = optOuts.map(optOut => optOut.cell);
+  let validatedData;
+  let result;
+  // For some reason destructuring is not working here
+  result = _.partition(data, row => !!row.cell);
+  validatedData = result[0];
+  const missingCellRows = result[1];
+
+  validatedData = _.map(validatedData, row =>
+    _.extend(row, {
+      cell: getFormattedPhoneNumber(
+        row.cell,
+        process.env.PHONE_NUMBER_COUNTRY || "US"
+      )
+    })
+  );
+  result = _.partition(validatedData, row => !!row.cell);
+  validatedData = result[0];
+  const invalidCellRows = result[1];
+
+  const count = validatedData.length;
+  validatedData = _.uniqBy(validatedData, row => row.cell);
+  const dupeCount = count - validatedData.length;
+
+  result = _.partition(
+    validatedData,
+    row => optOutCells.indexOf(row.cell) === -1
+  );
+  validatedData = result[0];
+  const optOutRows = result[1];
+
+  validatedData = _.map(validatedData, row =>
+    _.extend(row, {
+      zip: row.zip ? getFormattedZip(row.zip) : null
+    })
+  );
+  const zipCount = validatedData.filter(row => !!row.zip).length;
+
+  return {
+    validatedData,
+    validationStats: {
+      dupeCount,
+      optOutCount: optOutRows.length,
+      invalidCellCount: invalidCellRows.length,
+      missingCellCount: missingCellRows.length,
+      zipCount
+    }
+  };
+};
+
+export const parseCSV = (file, optOuts, callback) => {
+  Papa.parse(file, {
+    header: true,
+    // eslint-disable-next-line no-shadow, no-unused-vars
+    complete: ({ data, meta, errors }, file) => {
+      const fields = meta.fields;
+
+      const missingFields = [];
+
+      for (const field of requiredUploadFields) {
+        if (fields.indexOf(field) === -1) {
+          missingFields.push(field);
+        }
+      }
+
+      if (missingFields.length > 0) {
+        const error = `Missing fields: ${missingFields.join(", ")}`;
+        callback({ error });
+      } else {
+        const { validationStats, validatedData } = getValidatedData(
+          data,
+          optOuts
+        );
+
+        const customFields = fields.filter(
+          field => topLevelUploadFields.indexOf(field) === -1
+        );
+
+        callback({
+          customFields,
+          validationStats,
+          contacts: validatedData
+        });
+      }
+    }
+  });
+};


### PR DESCRIPTION
# Fixes #1312 

## Description

No functional changes.  This PR moves some functions out of `lib/index.js` into specific files with descriptive names and removes some dead code.  This is in advance of the changes I'm about to make for #1272.

* move gzip functions to `gzip.js`
* move csv parsing functions to `parse_csv.js`
* delete dead code (`convertRowToContact`)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- N/A ~[ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- N/A ~[ ] I have made any necessary changes to the documentation~
- N/A -- **existing tests pass** ~[ ] I have added tests that prove my fix is effective or that my feature works~
- N/A ~[ ] My PR is labeled [WIP] if it is in progress~