### PR TITLE
Allow required headers to be snake_case in the contacts csv

### DIFF
--- a/__test__/lib/parse-csv.test.js
+++ b/__test__/lib/parse-csv.test.js
@@ -7,14 +7,28 @@ describe("parseCSV", () => {
 
     it("should consider phone numbers from that country as valid", () => {
       const csv = "firstName,lastName,cell\ntest,test,61468511000";
-      parseCSV(
-        csv,
-        [],
-        ({ contacts, customFields, validationStats, error }) => {
-          expect(error).toBeFalsy();
-          expect(contacts.length).toEqual(1);
-        }
-      );
+      parseCSV(csv, [], ({ contacts, error }) => {
+        expect(error).toBeFalsy();
+        expect(contacts.length).toEqual(1);
+      });
+    });
+  });
+
+  describe("When required headers are snake case", () => {
+    const mockCallback = jest.fn();
+    const csv =
+      "first_name,last_name,cell,zip\r\nJerome,Garcia,14155551212,94970\r\n";
+
+    it("should call the callback with a contact with camel case fields", () => {
+      parseCSV(csv, [], mockCallback);
+
+      expect(mockCallback).toHaveBeenCalledTimes(1);
+      expect(mockCallback.mock.calls[0][0].contacts[0]).toEqual({
+        cell: "+14155551212",
+        firstName: "Jerome",
+        lastName: "Garcia",
+        zip: "94970"
+      });
     });
   });
 });

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "moment-timezone": "^0.5.14",
     "nexmo": "^1.0.0-beta-7",
     "nodemailer": "^4.3.1",
-    "papaparse": "^4.3.6",
+    "papaparse": "^5.1.0",
     "passport": "^0.3.2",
     "passport-auth0": "^0.6.1",
     "passport-local": "^1.0.0",

--- a/src/components/CampaignContactsForm.jsx
+++ b/src/components/CampaignContactsForm.jsx
@@ -322,8 +322,10 @@ export default class CampaignContactsForm extends React.Component {
       <span>
         Your upload file should be in CSV format with column headings in the
         first row. You must include{" "}
-        <span className={css(styles.csvHeader)}>firstName</span>,
-        <span className={css(styles.csvHeader)}>lastName</span>, and
+        <span className={css(styles.csvHeader)}>firstName</span>, (or{" "}
+        <span className={css(styles.csvHeader)}>first_name</span>),
+        <span className={css(styles.csvHeader)}>lastName</span>
+        (or <span className={css(styles.csvHeader)}>last_name</span>), and
         <span className={css(styles.csvHeader)}>cell</span> columns. If you
         include a <span className={css(styles.csvHeader)}>zip</span> column,
         we'll use the zip to guess the contact's timezone for enforcing texting

--- a/src/lib/gzip.js
+++ b/src/lib/gzip.js
@@ -1,0 +1,23 @@
+import zlib from "zlib";
+
+export const gzip = str =>
+  new Promise((resolve, reject) => {
+    zlib.gzip(str, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });
+
+export const gunzip = buf =>
+  new Promise((resolve, reject) => {
+    zlib.gunzip(buf, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res);
+      }
+    });
+  });

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,4 +1,3 @@
-import zlib from "zlib";
 export { getFormattedPhoneNumber, getDisplayPhoneNumber } from "./phone-format";
 export {
   getFormattedZip,
@@ -22,9 +21,6 @@ export { DstHelper } from "./dst-helper";
 export { isClient } from "./is-client";
 import { log } from "./log";
 export { log };
-import Papa from "papaparse";
-import _ from "lodash";
-import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
 export {
   findParent,
   getInteractionPath,
@@ -35,14 +31,6 @@ export {
   getChildren,
   makeTree
 } from "./interaction-step-helpers";
-const requiredUploadFields = ["firstName", "lastName", "cell"];
-const topLevelUploadFields = [
-  "firstName",
-  "lastName",
-  "cell",
-  "zip",
-  "external_id"
-];
 
 export {
   ROLE_HIERARCHY,
@@ -51,126 +39,5 @@ export {
   isRoleGreater
 } from "./permissions";
 
-const getValidatedData = (data, optOuts) => {
-  const optOutCells = optOuts.map(optOut => optOut.cell);
-  let validatedData;
-  let result;
-  // For some reason destructuring is not working here
-  result = _.partition(data, row => !!row.cell);
-  validatedData = result[0];
-  const missingCellRows = result[1];
-
-  validatedData = _.map(validatedData, row =>
-    _.extend(row, {
-      cell: getFormattedPhoneNumber(
-        row.cell,
-        process.env.PHONE_NUMBER_COUNTRY || "US"
-      )
-    })
-  );
-  result = _.partition(validatedData, row => !!row.cell);
-  validatedData = result[0];
-  const invalidCellRows = result[1];
-
-  const count = validatedData.length;
-  validatedData = _.uniqBy(validatedData, row => row.cell);
-  const dupeCount = count - validatedData.length;
-
-  result = _.partition(
-    validatedData,
-    row => optOutCells.indexOf(row.cell) === -1
-  );
-  validatedData = result[0];
-  const optOutRows = result[1];
-
-  validatedData = _.map(validatedData, row =>
-    _.extend(row, {
-      zip: row.zip ? getFormattedZip(row.zip) : null
-    })
-  );
-  const zipCount = validatedData.filter(row => !!row.zip).length;
-
-  return {
-    validatedData,
-    validationStats: {
-      dupeCount,
-      optOutCount: optOutRows.length,
-      invalidCellCount: invalidCellRows.length,
-      missingCellCount: missingCellRows.length,
-      zipCount
-    }
-  };
-};
-
-export const gzip = str =>
-  new Promise((resolve, reject) => {
-    zlib.gzip(str, (err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-
-export const gunzip = buf =>
-  new Promise((resolve, reject) => {
-    zlib.gunzip(buf, (err, res) => {
-      if (err) {
-        reject(err);
-      } else {
-        resolve(res);
-      }
-    });
-  });
-
-export const parseCSV = (file, optOuts, callback) => {
-  Papa.parse(file, {
-    header: true,
-    // eslint-disable-next-line no-shadow, no-unused-vars
-    complete: ({ data, meta, errors }, file) => {
-      const fields = meta.fields;
-
-      const missingFields = [];
-
-      for (const field of requiredUploadFields) {
-        if (fields.indexOf(field) === -1) {
-          missingFields.push(field);
-        }
-      }
-
-      if (missingFields.length > 0) {
-        const error = `Missing fields: ${missingFields.join(", ")}`;
-        callback({ error });
-      } else {
-        const { validationStats, validatedData } = getValidatedData(
-          data,
-          optOuts
-        );
-
-        const customFields = fields.filter(
-          field => topLevelUploadFields.indexOf(field) === -1
-        );
-
-        callback({
-          customFields,
-          validationStats,
-          contacts: validatedData
-        });
-      }
-    }
-  });
-};
-
-export const convertRowToContact = row => {
-  const customFields = row;
-  const contact = {};
-  for (const field of topLevelUploadFields) {
-    if (_.has(row, field)) {
-      contact[field] = row[field];
-    }
-  }
-
-  contact.customFields = customFields;
-  return contact;
-};
+export { gzip, gunzip } from "./gzip";
+export { parseCSV } from "./parse_csv.js";

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -1,0 +1,101 @@
+import Papa from "papaparse";
+import _ from "lodash";
+import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
+
+const requiredUploadFields = ["firstName", "lastName", "cell"];
+const topLevelUploadFields = [
+  "firstName",
+  "lastName",
+  "cell",
+  "zip",
+  "external_id"
+];
+
+const getValidatedData = (data, optOuts) => {
+  const optOutCells = optOuts.map(optOut => optOut.cell);
+  let validatedData;
+  let result;
+  // For some reason destructuring is not working here
+  result = _.partition(data, row => !!row.cell);
+  validatedData = result[0];
+  const missingCellRows = result[1];
+
+  validatedData = _.map(validatedData, row =>
+    _.extend(row, {
+      cell: getFormattedPhoneNumber(
+        row.cell,
+        process.env.PHONE_NUMBER_COUNTRY || "US"
+      )
+    })
+  );
+  result = _.partition(validatedData, row => !!row.cell);
+  validatedData = result[0];
+  const invalidCellRows = result[1];
+
+  const count = validatedData.length;
+  validatedData = _.uniqBy(validatedData, row => row.cell);
+  const dupeCount = count - validatedData.length;
+
+  result = _.partition(
+    validatedData,
+    row => optOutCells.indexOf(row.cell) === -1
+  );
+  validatedData = result[0];
+  const optOutRows = result[1];
+
+  validatedData = _.map(validatedData, row =>
+    _.extend(row, {
+      zip: row.zip ? getFormattedZip(row.zip) : null
+    })
+  );
+  const zipCount = validatedData.filter(row => !!row.zip).length;
+
+  return {
+    validatedData,
+    validationStats: {
+      dupeCount,
+      optOutCount: optOutRows.length,
+      invalidCellCount: invalidCellRows.length,
+      missingCellCount: missingCellRows.length,
+      zipCount
+    }
+  };
+};
+
+export const parseCSV = (file, optOuts, callback) => {
+  Papa.parse(file, {
+    header: true,
+    // eslint-disable-next-line no-shadow, no-unused-vars
+    complete: ({ data, meta, errors }, file) => {
+      const fields = meta.fields;
+
+      const missingFields = [];
+
+      for (const field of requiredUploadFields) {
+        if (fields.indexOf(field) === -1) {
+          missingFields.push(field);
+        }
+      }
+
+      if (missingFields.length > 0) {
+        const error = `Missing fields: ${missingFields.join(", ")}`;
+        callback({ error });
+      } else {
+        const { validationStats, validatedData } = getValidatedData(
+          data,
+          optOuts
+        );
+
+        const customFields = fields.filter(
+          field => topLevelUploadFields.indexOf(field) === -1
+        );
+
+        callback({
+          customFields,
+          validationStats,
+          contacts: validatedData
+        });
+      }
+    }
+  });
+};

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -1,6 +1,7 @@
 import Papa from "papaparse";
 import _ from "lodash";
 import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
+import humps from "humps";
 
 const requiredUploadFields = ["firstName", "lastName", "cell"];
 const topLevelUploadFields = [
@@ -62,13 +63,26 @@ const getValidatedData = (data, optOuts) => {
   };
 };
 
+const ensureCamelCaseRequiredHeaders = columnHeader => {
+  const camelizedColumnHeader = humps.camelize(columnHeader);
+
+  if (
+    requiredUploadFields.includes(camelizedColumnHeader) &&
+    camelizedColumnHeader !== columnHeader
+  ) {
+    return camelizedColumnHeader;
+  }
+
+  return columnHeader;
+};
+
 export const parseCSV = (file, optOuts, callback) => {
   Papa.parse(file, {
     header: true,
+    transformHeader: ensureCamelCaseRequiredHeaders,
     // eslint-disable-next-line no-shadow, no-unused-vars
     complete: ({ data, meta, errors }, file) => {
       const fields = meta.fields;
-
       const missingFields = [];
 
       for (const field of requiredUploadFields) {

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -64,6 +64,16 @@ const getValidatedData = (data, optOuts) => {
 };
 
 const ensureCamelCaseRequiredHeaders = columnHeader => {
+  /*
+   * This function changes:
+   *  first_name to firstName
+   *  last_name to lastName
+   *
+   * It changes no other fields.
+   *
+   * If other fields that could be either snake_case or camelCase
+   * are added to `requiredUploadFields` it will do the same for them.
+   * */
   const camelizedColumnHeader = humps.camelize(columnHeader);
 
   if (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10475,10 +10475,10 @@ pako@~1.0.2, pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.8.tgz#6844890aab9c635af868ad5fecc62e8acbba3ea4"
   integrity sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA==
 
-papaparse@^4.3.6:
-  version "4.6.3"
-  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-4.6.3.tgz#742e5eaaa97fa6c7e1358d2934d8f18f44aee781"
-  integrity sha512-LRq7BrHC2kHPBYSD50aKuw/B/dGcg29omyJbKWY3KsYUZU69RKwaBHu13jGmCYBtOc4odsLCrFyk6imfyNubJQ==
+papaparse@^5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/papaparse/-/papaparse-5.1.1.tgz#1da66a039f80e2db43a1226b0bf44106451e9a2d"
+  integrity sha512-KPkW4GNQxunmYTeJIjHFrvilcNuHBWrfgbyvmagEmfGOA4hnP1WIkPbv4yABhj1Nam3as4w+7MBiI27BntwqVg==
 
 parallel-transform@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
# Fixes #1272 

## Description

Accept and correctly handle contacts csv files with `first_name` instead of `firstName` and `last_name` instead of `lastName` for their respective column headers.

Updated instructions in contact upload:

<img width="904" alt="Screen Shot 2019-12-21 at 2 17 23 PM" src="https://user-images.githubusercontent.com/1637288/71312760-d7f35280-23fc-11ea-8edc-7c12bbc1087f.png">

What changed: upgraded papa-parse to version 5 and provided a `transformHeaders` method to implement this.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- N/A ~[ ] I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- N/A ~[ ] My PR is labeled [WIP] if it is in progress~
