### PR TITLE
Fix: user edit dialog fields not populated

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -14,8 +14,19 @@ import {
   UserOrganization
 } from "../src/server/models/";
 import { resolvers as campaignResolvers } from "../src/server/api/campaign";
-import { getContext, setupTest, cleanupTest } from "./test_helpers";
+import {
+  setupTest,
+  cleanupTest,
+  getContext,
+  createUser as helperCreateUser,
+  createTexter as helperCreateTexter,
+  createOrganization as helperCreateOrganization,
+  createInvite as helperCreateInvite,
+  runGql
+} from "./test_helpers";
 import { makeExecutableSchema } from "graphql-tools";
+
+import { editUserMutation } from "../src/containers/UserEdit.jsx";
 
 const mySchema = makeExecutableSchema({
   typeDefs: schema,
@@ -694,6 +705,83 @@ describe("Campaign", () => {
       originalIntFiltered.forEach(interaction => {
         expect(copiedIntFiltered).toContainEqual(interaction);
       });
+    });
+  });
+});
+
+describe.only("editUser mutation", () => {
+  let testAdminUser;
+  let testTexter;
+  let testOrganization;
+  let organizationId;
+  let variables;
+
+  beforeEach(async () => {
+    await setupTest();
+    testAdminUser = await helperCreateUser();
+    testOrganization = await helperCreateOrganization(
+      testAdminUser,
+      await helperCreateInvite()
+    );
+    organizationId = testOrganization.data.createOrganization.id;
+    testTexter = await helperCreateTexter(testOrganization);
+
+    variables = {
+      organizationId,
+      userId: testTexter.id,
+      userData: null
+    };
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  it("returns the user if it is called with a userId by no userData", async () => {
+    const result = await runGql(editUserMutation, variables, testAdminUser);
+    expect(result).toEqual({
+      data: {
+        editUser: {
+          id: "2",
+          firstName: "TestTexterFirst",
+          lastName: "TestTexterLast",
+          cell: "555-555-6666",
+          email: "testtexter@example.com"
+        }
+      }
+    });
+  });
+
+  it("updates the user if it is called with a userId and userData", async () => {
+    const userData = {
+      firstName: "Jerry",
+      lastName: "Garcia",
+      email: "jerry@heaven.org",
+      cell: "4151111111"
+    };
+
+    variables.userData = userData;
+
+    // the mutation returns the right thing
+    const result = await runGql(editUserMutation, variables, testAdminUser);
+    expect(result).toEqual({
+      data: {
+        editUser: {
+          ...userData,
+          id: testTexter.id.toString()
+        }
+      }
+    });
+
+    // it gets updated in the database
+    const updatedUser = await r.knex("user").where("id", testTexter.id);
+    expect(updatedUser[0]).toMatchObject({
+      first_name: userData.firstName,
+      last_name: userData.lastName,
+      email: userData.email,
+      cell: userData.cell,
+      id: testTexter.id
     });
   });
 });

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -271,28 +271,31 @@ const mapQueriesToProps = ({ ownProps }) => {
   }
 };
 
+export const editUserMutation = `
+  mutation editUser(
+    $organizationId: String!
+    $userId: Int!
+    $userData: UserInput
+  ) {
+    editUser(
+      organizationId: $organizationId
+      userId: $userId
+      userData: $userData
+    ) {
+      id
+      firstName
+      lastName
+      cell
+      email
+    }
+  }`;
+
 const mapMutationsToProps = ({ ownProps }) => {
   if (ownProps.userId) {
     return {
       editUser: userData => ({
         mutation: gql`
-          mutation editUser(
-            $organizationId: String!
-            $userId: Int!
-            $userData: UserInput
-          ) {
-            editUser(
-              organizationId: $organizationId
-              userId: $userId
-              userData: $userData
-            ) {
-              id
-              firstName
-              lastName
-              cell
-              email
-            }
-          }
+          ${editUserMutation}
         `,
         variables: {
           userId: ownProps.userId,

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -421,14 +421,14 @@ const rootMutations = {
       } else {
         const member = userRes[0];
 
-        const newUserData = {
-          first_name: capitalizeWord(userData.firstName),
-          last_name: capitalizeWord(userData.lastName),
-          email: userData.email,
-          cell: userData.cell
-        };
-
         if (userData) {
+          const newUserData = {
+            first_name: capitalizeWord(userData.firstName),
+            last_name: capitalizeWord(userData.lastName),
+            email: userData.email,
+            cell: userData.cell
+          };
+
           const userRes = await r
             .knex("user")
             .where("id", userId)


### PR DESCRIPTION
# Fixes #1343 

## Description

The `editUser` mutation is used to retrieve user information, and in that use case it was referencing a null variable, causing it to fail.  This PR adds a guard against referencing that variable when it's null, and it adds a test.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [N/A] ~If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [N/A] ~I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A] ~My PR is labeled [WIP] if it is in progress~
