### PR TITLE
add job to load messages in from a csv and fix some crucial bugs in twilio.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "knex": "knex --knexfile ./knexfile.env.js",
     "clean": "rm -rf $OUTPUT_DIR",
     "lint": "eslint --fix --ext js --ext jsx src",
+    "process-message-csv": "./dev-tools/babel-run-with-env.js ./src/workers/process-message-csv.js",
     "prod-build-client": "webpack --config ./webpack/config.js",
     "prod-build-server": "babel ./src  -d ./build/server --source-maps --copy-files; babel ./migrations -d ./build/server/migrations/ --source-maps --copy-files",
     "prod-build": "npm run clean && npm run prod-build-client && npm run prod-build-server",

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -18,15 +18,15 @@ export async function getLastMessage({ contactNumber, service }) {
 
 export async function saveNewIncomingMessage(messageInstance) {
   if (messageInstance.service_id) {
-    const [countResult] = await r
+    const [duplicateMessage] = await r
       .knex("message")
       .where("service_id", messageInstance.service_id)
       .select("id")
       .limit(1);
-    if (countResult) {
-      console.error("DUPLICATE MESSAGE", countResult, messageInstance);
+    if (duplicateMessage) {
+      console.error("DUPLICATE MESSAGE", duplicateMessage, messageInstance);
+      return;
     }
-    return;
   }
   await messageInstance.save();
 

--- a/src/server/api/lib/message-sending.js
+++ b/src/server/api/lib/message-sending.js
@@ -18,16 +18,15 @@ export async function getLastMessage({ contactNumber, service }) {
 
 export async function saveNewIncomingMessage(messageInstance) {
   if (messageInstance.service_id) {
-    const countResult = await r.getCount(
-      r.knex("message").where("service_id", messageInstance.service_id)
-    );
+    const [countResult] = await r
+      .knex("message")
+      .where("service_id", messageInstance.service_id)
+      .select("id")
+      .limit(1);
     if (countResult) {
-      console.error(
-        "DUPLICATE MESSAGE SAVED",
-        countResult.count,
-        messageInstance
-      );
+      console.error("DUPLICATE MESSAGE", countResult, messageInstance);
     }
+    return;
   }
   await messageInstance.save();
 

--- a/src/workers/process-message-csv.js
+++ b/src/workers/process-message-csv.js
@@ -1,0 +1,20 @@
+import { loadMessages } from "./jobs";
+import fs from "fs";
+
+const csvFilename = process.argv.filter(f => /\.csv/.test(f))[0];
+
+new Promise((resolve, reject) => {
+  fs.readFile(csvFilename, "utf8", function(err, contents) {
+    loadMessages(contents)
+      .then(msgs => {
+        resolve(msgs);
+        process.exit();
+      })
+      .catch(err => {
+        console.log(err);
+        reject(err);
+        console.log("Error", err);
+        process.exit();
+      });
+  });
+});


### PR DESCRIPTION
# Fixes # (issue)

## Description
This adds a method to run `yarn process-message-csv SOMEMESSAGEFILE.csv` on a file and load them message responses into the database all at once -- this is a useful tool when processing messages from outside the twilio api and/or for testing.

In writing this, some critical bugs were found in the current twilio processing that may be causing deadlocks on indexes and other problems.  This fixes those minimally, awaiting more fixes in e.g. 

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
