### PR TITLE
Remove large query so that optouts can be scrubbed

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -49,22 +49,6 @@ const defensivelyDeleteJob = async job => {
 
 const zipMemoization = {};
 let warehouseConnection = null;
-function optOutsByOrgId(orgId) {
-  return r.knex
-    .select("cell")
-    .from("opt_out")
-    .where("organization_id", orgId);
-}
-
-function optOutsByInstance() {
-  return r.knex.select("cell").from("opt_out");
-}
-
-function getOptOutSubQuery(orgId) {
-  return !!process.env.OPTOUTS_SHARE_ALL_ORGS
-    ? optOutsByInstance()
-    : optOutsByOrgId(orgId);
-}
 
 function optOutsByOrgId(orgId) {
   return r.knex

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -227,34 +227,50 @@ export async function uploadContacts(job) {
   }
 
   for (let index = 0; index < numChunks; index++) {
-    await updateJob(job, Math.round((maxPercentage / numChunks) * index));
+    await updateJob(job, Math.round((maxPercentage / numChunks) * index))
+      .catch(err => {
+        console.log(
+          "Error updating job:",
+          campaignId,
+          job.id,
+          err
+        );
+      });
     const savePortion = contacts.slice(
       index * chunkSize,
       (index + 1) * chunkSize
     );
-    await CampaignContact.save(savePortion);
+    await CampaignContact.save(savePortion)
+      .catch(err => {
+        console.log(
+          "Error saving campaign contacts:",
+          campaignId,
+          err
+        );
+      });
   }
 
-  const optOutCellCount = await r
-    .knex("campaign_contact")
-    .whereIn("cell", function optouts() {
-      this.select("cell")
-        .from("opt_out")
-        .where("organization_id", campaign.organization_id);
-    });
-
-  const deleteOptOutCells = await r
+  let deleteOptOutCells;
+  const knexOptOutDeleteResult = await r
     .knex("campaign_contact")
     .whereIn("cell", getOptOutSubQuery(campaign.organization_id))
     .where("campaign_id", campaignId)
     .delete()
     .then(result => {
-      console.log("deleted result: " + result);
+      deleteOptOutCells = result;
+      console.log("Deleted opt-outs: " + deleteOptOutCells);
+    })
+    .catch(err => {
+      console.log(
+        "Error deleting opt-outs:",
+        campaignId,
+        err
+      );
     });
 
   if (deleteOptOutCells) {
     jobMessages.push(
-      `Number of contacts excluded due to their opt-out status: ${optOutCellCount}`
+      `Number of contacts excluded due to their opt-out status: ${deleteOptOutCells}`
     );
   }
 


### PR DESCRIPTION
# Fixes #1198 (Bug: Spoke Not Scrubbing Opt Outs From Larger Organizations)

## Description

Removes duplicated code, adds some error handling, and removes the query to count all optouts (uses the result of the delete query instead), which allows the optouts to finish being scrubbed.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
