### PR TITLE
Suspend texters

### DIFF
--- a/migrations/20200104185303_add_suspended_user_status.js
+++ b/migrations/20200104185303_add_suspended_user_status.js
@@ -1,0 +1,33 @@
+exports.up = function(knex, Promise) {
+  return Promise.all([
+    knex.schema
+      .alterTable("user_organization", table => {
+        table.enu("temp_role", [
+          "OWNER",
+          "ADMIN",
+          "SUPERVOLUNTEER",
+          "TEXTER",
+          "SUSPENDED"
+        ]);
+      })
+      .then(() =>
+        knex("user_organization")
+          .update({
+            temp_role: knex.raw("??", ["user_organization.role"])
+          })
+          .then(() =>
+            knex.schema
+              .table("user_organization", table => table.dropColumn("role"))
+              .then(() =>
+                knex.schema.table("user_organization", table =>
+                  table.renameColumn("temp_role", "role")
+                )
+              )
+          )
+      )
+  ]);
+};
+
+exports.down = function(knex, Promise) {
+  return Promise.resolve();
+};

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -202,6 +202,7 @@ const rootSchema = gql`
 
   type RootQuery {
     currentUser: User
+    currentUserWithAccess(organizationId: String!, role: String!): User
     organization(id: String!, utc: String): Organization
     campaign(id: String!): Campaign
     inviteByHash(hash: String!): [Invite]
@@ -293,6 +294,7 @@ const rootSchema = gql`
     unarchiveCampaign(id: String!): Campaign
     sendReply(id: String!, message: String!): CampaignContact
     getAssignmentContacts(
+      organizationId: String!
       assignmentId: String!
       contactIds: [String]
       findNew: Boolean

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -9,8 +9,10 @@ import LoadingIndicator from "./LoadingIndicator";
 import { StyleSheet, css } from "aphrodite";
 import { withRouter } from "react-router";
 import Check from "material-ui/svg-icons/action/check-circle";
+import Lock from "material-ui/svg-icons/action/lock-outline";
 import Empty from "../components/Empty";
 import RaisedButton from "material-ui/RaisedButton";
+import { get } from "lodash";
 
 const styles = StyleSheet.create({
   container: {
@@ -163,10 +165,10 @@ export class AssignmentTexter extends React.Component {
         .slice(newIndex + BATCH_FORWARD, newIndex + BATCH_FORWARD + BATCH_GET)
         .map(c => c.id)
         .filter(cId => !force || !this.state.contactCache[cId]);
-      // console.log('getContactData batch forward ', getIds)
+      console.log("getContactData batch forward ", getIds);
     } else if (
       !getIds.length &&
-      this.props.assignment.campaign.useDynamicAssignment &&
+      get(this.props, "assignment.campaign.useDynamicAssignment") &&
       // If we have just crossed the threshold of contact data we have, get more
       contacts[newIndex + BATCH_FORWARD - 1] &&
       !contacts[newIndex + BATCH_FORWARD]
@@ -174,9 +176,13 @@ export class AssignmentTexter extends React.Component {
       this.props.getNewContacts();
     }
     if (getIds.length) {
-      // console.log('getContactData length', newIndex, getIds.length)
+      console.log("getContactData length", newIndex, getIds.length);
       this.setState({ loading: true });
       const contactData = await this.props.loadContacts(getIds);
+      if (contactData.errors && this.props.organizationId) {
+        this.props.router.push(`/app/${this.props.organizationId}/suspended`);
+      }
+
       const {
         data: { getAssignmentContacts }
       } = contactData;

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -407,7 +407,15 @@ export class AssignmentTexterContact extends React.Component {
       }
       this.setState({ disabled: true });
       console.log("sendMessage", contact.id);
-      await this.props.mutations.sendMessage(message, contact.id);
+      const sendMessageResult = await this.props.mutations.sendMessage(
+        message,
+        contact.id
+      );
+      if (sendMessageResult.errors && this.props.campaign.organization.id) {
+        this.props.router.push(
+          `/app/${this.props.campaign.organization.id}/suspended`
+        );
+      }
 
       await this.handleSubmitSurveys();
       this.props.onFinishContact(contact.id);
@@ -478,7 +486,15 @@ export class AssignmentTexterContact extends React.Component {
     this.setState({ disabled: true });
     try {
       if (optOutMessageText.length) {
-        await this.props.mutations.sendMessage(message, contact.id);
+        const sendMessageResult = await this.props.mutations.sendMessage(
+          message,
+          contact.id
+        );
+        if (sendMessageResult.errors && this.props.campaign.organization.id) {
+          this.props.router.push(
+            `/app/${this.props.campaign.organization.id}/suspended`
+          );
+        }
       }
 
       const optOut = {

--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -51,6 +51,8 @@ class Home extends React.Component {
         this.props.router.push(`/admin/${user.ownerOrganizations[0].id}`);
       } else if (user.texterOrganizations.length > 0) {
         this.props.router.push(`/app/${user.texterOrganizations[0].id}`);
+      } else if (user.suspendedOrganizations.length > 0) {
+        this.props.router.push(`/app/${user.suspendedOrganizations[0].id}`);
       } else {
         this.setState({ orgLessUser: true });
       }
@@ -147,6 +149,9 @@ const mapQueriesToProps = () => ({
             id
           }
           texterOrganizations: organizations(role: "TEXTER") {
+            id
+          }
+          suspendedOrganizations: organizations(role: "SUSPENDED") {
             id
           }
         }

--- a/src/containers/SuspendedTexter.jsx
+++ b/src/containers/SuspendedTexter.jsx
@@ -1,0 +1,53 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import { withRouter } from "react-router";
+
+import ErrorOutline from "material-ui/svg-icons/alert/error-outline";
+
+import Empty from "../components/Empty";
+import loadData from "./hoc/load-data";
+
+import gql from "graphql-tag";
+
+const SuspendedTexter = props => {
+  if (!props.currentUser.errors) {
+    console.log(props.currentUser);
+    props.router.push(`/app/${props.organizationId}/todos`);
+    return null;
+  }
+
+  return (
+    <div>
+      <Empty
+        title="Your account is suspended. Contact the moderator in Slack."
+        icon={<ErrorOutline />}
+      />
+    </div>
+  );
+};
+
+SuspendedTexter.propTypes = {
+  organizationId: PropTypes.string.isRequired,
+  currentUser: PropTypes.object,
+  router: PropTypes.object
+};
+
+const mapQueriesToProps = ({ ownProps }) => ({
+  currentUser: {
+    query: gql`
+      query Q($organizationId: String!, $role: String!) {
+        currentUserWithAccess(organizationId: $organizationId, role: $role) {
+          id
+        }
+      }
+    `,
+    variables: {
+      organizationId: ownProps.organizationId,
+      role: "TEXTER"
+    },
+    forceFetch: true
+  }
+});
+
+export default loadData(withRouter(SuspendedTexter), { mapQueriesToProps });

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import AssignmentTexter from "../components/AssignmentTexter";
+import Empty from "../components/Empty";
 import { withRouter } from "react-router";
 import loadData from "./hoc/load-data";
 import gql from "graphql-tag";
@@ -115,6 +116,15 @@ export class TexterTodo extends React.Component {
     }
   }
 
+  shouldComponentUpdate = nextProps => {
+    if (nextProps.data.errors && this.props.params.organizationId) {
+      this.props.router.push(
+        `/app/${this.props.params.organizationId}/suspended`
+      );
+    }
+    return true;
+  };
+
   assignContactsIfNeeded = async (checkServer = false, currentIndex) => {
     const { assignment } = this.props.data;
     // TODO: should we assign a single contact at first, and then afterwards assign 10
@@ -178,6 +188,16 @@ export class TexterTodo extends React.Component {
 
   render() {
     const { assignment } = this.props.data;
+
+    if (
+      !assignment ||
+      (this.props.data.errors && this.props.params.organizationId)
+    ) {
+      this.props.router.push(
+        `/app/${this.props.params.organizationId}/suspended`
+      );
+    }
+
     const contacts = assignment ? assignment.contacts : [];
     const allContactsCount = assignment ? assignment.allContactsCount : 0;
     return (
@@ -242,13 +262,14 @@ const mapMutationsToProps = ({ ownProps }) => ({
   }),
   getAssignmentContacts: (contactIds, findNew) => ({
     mutation: gql`
-      mutation getAssignmentContacts($assignmentId: String!, $contactIds: [String]!, $findNew: Boolean) {
-        getAssignmentContacts(assignmentId: $assignmentId, contactIds: $contactIds, findNew: $findNew) {
+      mutation getAssignmentContacts($organizationId: String!, $assignmentId: String!, $contactIds: [String]!, $findNew: Boolean) {
+        getAssignmentContacts(organizationId: $organizationId, assignmentId: $assignmentId, contactIds: $contactIds, findNew: $findNew) {
           ${contactDataFragment}
         }
       }
     `,
     variables: {
+      organizationId: ownProps.params.organizationId,
       assignmentId: ownProps.params.assignmentId,
       contactIds,
       findNew: !!findNew

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -80,6 +80,14 @@ class TexterTodoList extends React.Component {
 
   render() {
     this.termsAgreed();
+
+    if (this.props.data.errors && this.props.params.organizationId) {
+      this.props.router.push(
+        `/app/${this.props.params.organizationId}/suspended`
+      );
+      return null;
+    }
+
     const todos = this.props.data.currentUser.todos;
     const renderedTodos = this.renderTodoList(todos);
 

--- a/src/lib/permissions.js
+++ b/src/lib/permissions.js
@@ -1,4 +1,10 @@
-export const ROLE_HIERARCHY = ["TEXTER", "SUPERVOLUNTEER", "ADMIN", "OWNER"];
+export const ROLE_HIERARCHY = [
+  "SUSPENDED",
+  "TEXTER",
+  "SUPERVOLUNTEER",
+  "ADMIN",
+  "OWNER"
+];
 
 export const isRoleGreater = (role1, role2) =>
   ROLE_HIERARCHY.indexOf(role1) > ROLE_HIERARCHY.indexOf(role2);

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -13,6 +13,7 @@ import TopNav from "./components/TopNav";
 import DashboardLoader from "./containers/DashboardLoader";
 import TexterTodoList from "./containers/TexterTodoList";
 import TexterTodo from "./containers/TexterTodo";
+import SuspendedTexter from "./containers/SuspendedTexter";
 import Login from "./components/Login";
 import Terms from "./containers/Terms";
 import React from "react";
@@ -77,6 +78,17 @@ export default function makeRoutes(requireAuth = () => {}) {
               ),
               topNav: p => (
                 <TopNav title="Account" orgId={p.params.organizationId} />
+              )
+            }}
+          />
+          <Route
+            path="suspended"
+            components={{
+              main: p => (
+                <SuspendedTexter organizationId={p.params.organizationId} />
+              ),
+              topNav: p => (
+                <TopNav title="Spoke Texting" orgId={p.params.organizationId} />
               )
             }}
           />

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -235,14 +235,14 @@ export const resolvers = {
       return query;
     },
     interactionSteps: async (campaign, _, { user }) => {
-      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
+      await accessRequired(user, campaign.organization_id, "TEXTER", true);
       return (
         campaign.interactionSteps ||
         cacheableData.campaign.dbInteractionSteps(campaign.id)
       );
     },
     cannedResponses: async (campaign, { userId }, { user }) => {
-      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
+      await accessRequired(user, campaign.organization_id, "TEXTER", true);
       return await cacheableData.cannedResponse.query({
         userId: userId || "",
         campaignId: campaign.id
@@ -268,7 +268,7 @@ export const resolvers = {
       // This is the same as hasUnassignedContacts, but the access control
       // is different because for TEXTERs it's just for dynamic campaigns
       // but hasUnassignedContacts for admins is for the campaigns list
-      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
+      await accessRequired(user, campaign.organization_id, "TEXTER", true);
       if (!campaign.use_dynamic_assignment || campaign.is_archived) {
         return false;
       }

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -235,14 +235,14 @@ export const resolvers = {
       return query;
     },
     interactionSteps: async (campaign, _, { user }) => {
-      await accessRequired(user, campaign.organization_id, "TEXTER", true);
+      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
       return (
         campaign.interactionSteps ||
         cacheableData.campaign.dbInteractionSteps(campaign.id)
       );
     },
     cannedResponses: async (campaign, { userId }, { user }) => {
-      await accessRequired(user, campaign.organization_id, "TEXTER", true);
+      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
       return await cacheableData.cannedResponse.query({
         userId: userId || "",
         campaignId: campaign.id
@@ -268,7 +268,7 @@ export const resolvers = {
       // This is the same as hasUnassignedContacts, but the access control
       // is different because for TEXTERs it's just for dynamic campaigns
       // but hasUnassignedContacts for admins is for the campaigns list
-      await accessRequired(user, campaign.organization_id, "TEXTER", true);
+      await accessRequired(user, campaign.organization_id, "SUSPENDED", true);
       if (!campaign.use_dynamic_assignment || campaign.is_archived) {
         return false;
       }

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -56,6 +56,28 @@ export async function assignmentRequired(user, assignmentId, assignment) {
   return true;
 }
 
+export async function assignmentAndNotSuspended(
+  organizationId,
+  user,
+  assignmentId,
+  assignment,
+  allowSupervolunteer = true
+) {
+  try {
+    await accessRequired(user, organizationId, "TEXTER");
+    await assignmentRequired(user, assignmentId, assignment);
+  } catch (e) {
+    console.log(typeof e);
+    if (e instanceof GraphQLError && allowSupervolunteer) {
+      await accessRequired(user, organizationId, "SUPERVOLUNTEER", true);
+    } else {
+      throw e;
+    }
+  }
+
+  return true;
+}
+
 export function superAdminRequired(user) {
   authRequired(user);
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1127,7 +1127,7 @@ const rootResolvers = {
         await accessRequired(
           user,
           campaign.organization_id,
-          "TEXTER",
+          "SUSPENDED",
           /* allowSuperadmin=*/ true
         );
       } else {
@@ -1141,7 +1141,7 @@ const rootResolvers = {
       return assignment;
     },
     organization: async (_, { id }, { user, loaders }) => {
-      await accessRequired(user, id, "TEXTER");
+      await accessRequired(user, id, "SUSPENDED");
       return await loaders.organization.load(id);
     },
     inviteByHash: async (_, { hash }, { loaders, user }) => {
@@ -1159,7 +1159,7 @@ const rootResolvers = {
       if (user.is_superadmin) {
         return r.table("organization");
       } else {
-        return await cacheableData.user.userOrgs(user.id, "TEXTER");
+        return await cacheableData.user.userOrgs(user.id, "SUSPENDED");
       }
     },
     availableActions: (_, { organizationId }, { user }) => {

--- a/src/server/models/cacheable_queries/user.js
+++ b/src/server/models/cacheable_queries/user.js
@@ -1,6 +1,6 @@
 import DataLoader from "dataloader";
 import { r } from "../../models";
-import { isRoleGreater } from "../../../lib/permissions";
+import { ROLE_HIERARCHY, isRoleGreater } from "../../../lib/permissions";
 
 /*
 KEY: texterauth-${authId}
@@ -30,8 +30,6 @@ const userRoleKey = userId =>
   `${process.env.CACHE_PREFIX || ""}texterroles-${userId}`;
 const userAuthKey = authId =>
   `${process.env.CACHE_PREFIX || ""}texterauth-${authId}`;
-
-export const accessHierarchy = ["TEXTER", "SUPERVOLUNTEER", "ADMIN", "OWNER"];
 
 const getHighestRolesPerOrg = userOrgs => {
   const highestRolesPerOrg = {};
@@ -128,8 +126,8 @@ const dbLoadUserAuth = async (field, val) => {
 
 const userOrgs = async (userId, role) => {
   const acceptableRoles = role
-    ? accessHierarchy.slice(accessHierarchy.indexOf(role))
-    : [...accessHierarchy];
+    ? ROLE_HIERARCHY.slice(ROLE_HIERARCHY.indexOf(role))
+    : [...ROLE_HIERARCHY];
   const orgRoles = await loadUserRoles(userId);
   const matchedOrgs = Object.keys(orgRoles).filter(
     orgId => acceptableRoles.indexOf(orgRoles[orgId].role) !== -1
@@ -140,9 +138,9 @@ const userOrgs = async (userId, role) => {
 const orgRoles = async (userId, orgId) => {
   const orgRolesDict = await loadUserRoles(userId);
   if (orgId in orgRolesDict) {
-    return accessHierarchy.slice(
+    return ROLE_HIERARCHY.slice(
       0,
-      1 + accessHierarchy.indexOf(orgRolesDict[orgId].role)
+      1 + ROLE_HIERARCHY.indexOf(orgRolesDict[orgId].role)
     );
   }
   return [];
@@ -172,7 +170,7 @@ const userOrgHighestRole = async (userId, orgId) => {
       highestRole = roles
         .map(ri => ri.role)
         .sort(
-          (a, b) => accessHierarchy.indexOf(b) - accessHierarchy.indexOf(a)
+          (a, b) => ROLE_HIERARCHY.indexOf(b) - ROLE_HIERARCHY.indexOf(a)
         )[0];
     }
   }
@@ -180,7 +178,7 @@ const userOrgHighestRole = async (userId, orgId) => {
 };
 
 const userHasRole = async (user, orgId, role) => {
-  const acceptableRoles = accessHierarchy.slice(accessHierarchy.indexOf(role));
+  const acceptableRoles = ROLE_HIERARCHY.slice(ROLE_HIERARCHY.indexOf(role));
   let highestRole = "";
   if (user.orgRoleCache) {
     highestRole = await user.orgRoleCache.load(`${user.id}:${orgId}`);

--- a/src/server/models/user-organization.js
+++ b/src/server/models/user-organization.js
@@ -13,7 +13,13 @@ const UserOrganization = thinky.createModel(
       id: type.string(),
       user_id: requiredString(),
       organization_id: requiredString(),
-      role: requiredString().enum("OWNER", "ADMIN", "SUPERVOLUNTEER", "TEXTER")
+      role: requiredString().enum(
+        "OWNER",
+        "ADMIN",
+        "SUPERVOLUNTEER",
+        "TEXTER",
+        "SUSPENDED"
+      )
     })
     .allowExtra(false),
   { noAutoCreation: true, dependencies: [User, Organization] }


### PR DESCRIPTION
# Fixes #1323 

## Description

### Motivation
WFP asked for a way to quickly stop testers from texting.  This may be necessary if they're not following instructions, ignoring responses, going off script, sending offensive messages, etc.  This may be something useful to other organizations as well, so I'm doing this PR to merge it into the MoveOn repository.

### What's in this PR
* Add `SUSPENDED` texter status.
* Admins can change a use's status to `SUSPENDED` on the people page.
* Testers with `SUSPENDED` status cannot send messages or opt out contacts.
  * When they log in they will land on `/app/<organizationId>/suspended`
  * If they become suspended while they are logged in they will be redirected to `/app/<organizationId>/suspended` (this will happen either when the UI tries to retrieve more contacts or when the user hits `send` before the UI had a chance to retrieve more contacts)

### This is `WIP` because 
- [ ] Tests are failing 😭 
- [ ] It needs lots of new tests.
- [ ] The way we determine that a user is suspended if they become suspended while they are logged in is too broad.  Right now we're assuming any GraphQL error means suspended.  We need to use a specific GraphQL error and only redirect to `/app/<organizationId>/suspended` if the error is happening because they're suspended.
- [ ] The suspended message should be customizable.  Organizations that don't have slack in their workflow will want a different message.

---

<img width="944" alt="Screen Shot 2020-01-06 at 7 42 56 PM" src="https://user-images.githubusercontent.com/1637288/71859431-d2646080-30bc-11ea-98cc-d6650fb1917a.png">

---

### Possible enhancements
- Suspended texters should not be eligible for assignment.
- Indicate in message review that a texter is suspended when their name appears in filter by texter?
- Indicate in the message review grid that a texter is suspended?
- Indicate in texter assignment that a texter is suspended? (if we don't make them ineligible for assignment as noted above)
- When a texter is suspended, unassign them from all contacts? Or should that remain a manual step in message review?

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress