### PR TITLE
Fix supervolunteer access to campaign data

### DIFF
--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -68,10 +68,19 @@ export async function createUser(
     last_name: "TestUserLast",
     cell: "555-555-5555",
     email: "testuser@example.com"
-  }
+  },
+  organization_id = null,
+  role = null
 ) {
   const user = new User(userInfo);
   await user.save();
+  if (organization_id && role) {
+    await r.knex("user_organization").insert({
+      user_id: user.id,
+      organization_id,
+      role
+    });
+  }
   return user;
 }
 

--- a/docs/HOWTO-use-contact-loaders.md
+++ b/docs/HOWTO-use-contact-loaders.md
@@ -21,7 +21,7 @@ Just enabling a contact loader is the first step, but contact loaders often
 have additional context required for them to be visible (e.g. for datawarehouse, many `WAREHOUSE_DB_*`
 environment variables need to be present (along with the user being a super-admin).
 
-The server admin can look at the ingest loader index.js file in the appropriate directory TKTK
+The server admin can look at the ingest loader index.js file in `src/integrations/contact-loaders/<CONTACT LOADER NAME>`
 inside the function `serverAdministratorInstructions`
 (this data might sometime be visible to superadmins on a documentation page)
 

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -208,7 +208,11 @@ export const resolvers = {
         .orderBy("updated_at", "desc");
     },
     ingestMethodsAvailable: async (campaign, _, { user, loaders }) => {
-      await accessRequired(user, campaign.organization_id, "ADMIN", true);
+      try {
+        await accessRequired(user, campaign.organization_id, "ADMIN", true);
+      } catch (err) {
+        return []; // for SUPERVOLUNTEERS
+      }
       const organization = await loaders.organization.load(
         campaign.organization_id
       );
@@ -231,7 +235,9 @@ export const resolvers = {
       );
     },
     ingestMethod: async (campaign, _, { user, loaders }) => {
-      await accessRequired(user, campaign.organization_id, "ADMIN", true);
+      // FUTURE: which ingestMethod was used and status
+      // try { ... for SUPERVOLUNTEER
+      // await accessRequired(user, campaign.organization_id, "ADMIN", true);
       return null;
     },
     texters: async (campaign, _, { user }) => {


### PR DESCRIPTION
This fixed an issue that came up in production when testing stage-main.
Supervolunteers don't have access to ingestMethods, but they should still be able to load campaign data.