### PR TITLE
fix optout from message review

### DIFF
--- a/__test__/components/IncomingMessageList/ConversationPreviewModal.test.js
+++ b/__test__/components/IncomingMessageList/ConversationPreviewModal.test.js
@@ -1,0 +1,143 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { mount } from "enzyme";
+import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
+import ConversationPreviewModal, {
+  InnerConversationPreviewModal
+} from "../../../src/components/IncomingMessageList/ConversationPreviewModal";
+import { prepareDataTableData } from "../../../src/components/IncomingMessageList";
+
+import ReactTestUtils from "react-dom/test-utils";
+import Store from "../../../src/store";
+import { createMemoryHistory } from "react-router";
+import ApolloClientSingleton from "../../../src/network/apollo-client-singleton";
+import { ApolloProvider } from "react-apollo";
+import Dialog from "material-ui/Dialog";
+
+import { r } from "../../../src/server/models";
+
+import {
+  setupTest,
+  cleanupTest,
+  sendMessage,
+  getConversations,
+  createStartedCampaign
+} from "../../test_helpers";
+
+describe("ConversationPreviewModal", async () => {
+  let startedCampaign;
+  let optOutContact;
+  let optOut;
+  let conversations;
+  let conversation;
+  let onRequestCloseMock;
+
+  let component;
+  let store;
+
+  beforeAll(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+    jest.restoreAllMocks();
+    startedCampaign = await createStartedCampaign();
+
+    optOutContact = startedCampaign.testContacts[0];
+
+    const message = {
+      assignmentId: startedCampaign.assignmentId,
+      contactNumber: optOutContact.cell,
+      text: "hey now"
+    };
+
+    await sendMessage(
+      optOutContact.id,
+      startedCampaign.assignmentId,
+      startedCampaign.testTexterUser,
+      message
+    );
+
+    optOut = {
+      cell: optOutContact.cell,
+      assignmentId: startedCampaign.assignmentId.toString()
+    };
+
+    const campaignsFilter = {
+      campaignId: startedCampaign.dbCampaignContact.campaign_id
+    };
+
+    conversations = await getConversations(
+      startedCampaign.testAdminUser,
+      startedCampaign.organizationId,
+      { isOptedOut: false },
+      campaignsFilter,
+      {}
+    );
+
+    console.log(conversations);
+
+    store = new Store(createMemoryHistory("/")).data;
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterAll(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  describe("when a message review user opts out a user", async () => {
+    beforeAll(async () => {
+      const root = document.createElement("div");
+      document.body.appendChild(root);
+
+      conversation = prepareDataTableData(
+        conversations.data.conversations.conversations
+      )[0];
+
+      onRequestCloseMock = jest.fn();
+
+      component = mount(
+        <ApolloProvider store={store} client={ApolloClientSingleton}>
+          <MuiThemeProvider>
+            <ConversationPreviewModal
+              organizationId={startedCampaign.organizationId}
+              conversation={conversation}
+              onForceRefresh={() => {}}
+              onRequestClose={onRequestCloseMock}
+            />
+          </MuiThemeProvider>
+        </ApolloProvider>,
+        {
+          attachTo: root
+        }
+      );
+    });
+
+    it("calls the createOptOut mutation", async () => {
+      const createOptOutMock = jest.fn((_optOut, _campaignContactId) =>
+        Promise.resolve({ campaignContactId: _campaignContactId })
+      );
+      const conversationPreviewModal = component.find(
+        InnerConversationPreviewModal
+      );
+      conversationPreviewModal
+        .first()
+        .instance().props.mutations.createOptOut = createOptOutMock;
+
+      const dialog = conversationPreviewModal.find(Dialog);
+      expect(dialog.first().instance().props.open).toBe(true);
+
+      const optOutButton = document.querySelector(
+        "[data-test=conversationPreviewModalOptOutButton]"
+      );
+
+      await ReactTestUtils.Simulate.click(optOutButton);
+
+      expect(createOptOutMock).toBeCalledTimes(1);
+      expect(createOptOutMock).toBeCalledWith(
+        optOut,
+        optOutContact.id.toString()
+      );
+    });
+  });
+});

--- a/__test__/server/api/createOptOut.test.js
+++ b/__test__/server/api/createOptOut.test.js
@@ -1,0 +1,96 @@
+/* eslint-disable no-unused-expressions, consistent-return */
+import { r } from "../../../src/server/models/";
+
+import {
+  setupTest,
+  cleanupTest,
+  runGql,
+  createStartedCampaign,
+  getOptOut
+} from "../../test_helpers";
+
+import { createOptOutGqlString as createOptOutGql } from "../../../src/components/IncomingMessageList/ConversationPreviewModal";
+
+describe("createOptOut", () => {
+  let startedCampaign;
+  let optOutContact;
+  let optOut;
+  let variables;
+
+  beforeEach(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+
+    startedCampaign = await createStartedCampaign();
+
+    optOutContact = startedCampaign.testContacts[20];
+    optOut = {
+      cell: optOutContact.cell,
+      assignmentId: startedCampaign.assignmentId,
+      reason: "they were snotty"
+    };
+
+    variables = {
+      optOut,
+      campaignContactId: optOutContact.id
+    };
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  it("creates an opt out when the contact is assigned to the current user", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testTexterUser
+    );
+
+    expect(optOutResult.data.createOptOut.id).toEqual(
+      optOutContact.id.toString()
+    );
+    expect(optOutResult.errors).toBeUndefined();
+
+    const dbOptOut = await getOptOut(
+      parseInt(startedCampaign.assignmentId, 10),
+      optOutContact.cell
+    );
+    expect(dbOptOut.cell).toEqual(optOutContact.cell);
+  });
+
+  it("creates an opt out when the current user is an admin user and the contact is assigned to a different user", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testAdminUser
+    );
+
+    console.log("optOutResult", optOutResult);
+
+    expect(optOutResult.data.createOptOut.id).toEqual(
+      optOutContact.id.toString()
+    );
+    expect(optOutResult.errors).toBeUndefined();
+
+    const dbOptOut = await getOptOut(
+      parseInt(startedCampaign.assignmentId, 10),
+      optOutContact.cell
+    );
+    expect(dbOptOut.cell).toEqual(optOutContact.cell);
+  });
+
+  it("returns an error when the user attempting the optout is neither an admin nor assigned to the contact", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testTexterUser2
+    );
+
+    expect(optOutResult.createOptOut).toBeUndefined();
+    expect(optOutResult.errors[0].message).toEqual(
+      "You are not authorized to access that resource."
+    );
+  });
+});

--- a/__test__/server/api/errors.test.js
+++ b/__test__/server/api/errors.test.js
@@ -1,0 +1,174 @@
+import { r } from "../../../src/server/models/";
+import {
+  authRequired,
+  assignmentRequired,
+  assignmentOrAdminRoleRequired
+} from "../../../src/server/api/errors";
+
+const errors = require("../../../src/server/api/errors.js");
+
+import {
+  setupTest,
+  cleanupTest,
+  createStartedCampaign
+} from "../../test_helpers";
+
+describe("errors.js", () => {
+  let startedCampaign;
+
+  beforeEach(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+    startedCampaign = await createStartedCampaign();
+  });
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  describe("#authRequired", () => {
+    it("does not throw an exception if a user is passed to it", async () => {
+      authRequired(startedCampaign.testTexterUser);
+    });
+
+    it("throws an exception if nothing is passed to it", async () => {
+      let error;
+      try {
+        authRequired(undefined);
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeDefined();
+      expect(error.message).toEqual({
+        message: "You must login to access that resource.",
+        status: 401
+      });
+    });
+  });
+
+  describe("#assignmentRequired", () => {
+    it("returns true when a texter user has the assignment", async () => {
+      expect(
+        await assignmentRequired(
+          startedCampaign.testTexterUser,
+          startedCampaign.assignmentId
+        )
+      ).toBe(true);
+    });
+
+    describe("when the user does not have the assignment", () => {
+      it("throws an exception", async () => {
+        let error;
+        try {
+          await assignmentRequired(
+            startedCampaign.testTexterUser2,
+            startedCampaign.assignmentId
+          );
+        } catch (caught) {
+          error = caught;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toEqual(
+          "You are not authorized to access that resource."
+        );
+      });
+    });
+
+    describe("when a user is superadmin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentRequired(
+            startedCampaign.testSuperAdminUser,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+      });
+    });
+
+    describe("when an assignment is passed", () => {
+      it("returns true if the user has the assignment", async () => {
+        expect(
+          await assignmentRequired(
+            startedCampaign.testTexterUser,
+            startedCampaign.assignmentId,
+            startedCampaign.assignment
+          )
+        ).toBe(true);
+      });
+
+      describe("when the user does not have the assignment", () => {
+        it("throws an exception", async () => {
+          let error;
+          try {
+            await assignmentRequired(
+              startedCampaign.testTexterUser2,
+              startedCampaign.assignmentId,
+              startedCampaign.assignment
+            );
+          } catch (caught) {
+            error = caught;
+          }
+
+          expect(error).toBeDefined();
+          expect(error.message).toEqual(
+            "You are not authorized to access that resource."
+          );
+        });
+      });
+    });
+  });
+
+  describe("#assignmentOrAdminRoleRequired", () => {
+    let spy;
+
+    beforeEach(async () => {
+      spy = jest.spyOn(errors, "assignmentRequired").mockResolvedValue(true);
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+    });
+
+    it("calls assignmentRequired", async () => {
+      await assignmentOrAdminRoleRequired(
+        startedCampaign.testTexterUser,
+        startedCampaign.organizationId,
+        startedCampaign.assignmentId
+      );
+      expect(spy).toHaveBeenCalledWith(
+        startedCampaign.testTexterUser,
+        startedCampaign.assignmentId,
+        undefined
+      );
+    });
+
+    describe("when the user is an admin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentOrAdminRoleRequired(
+            startedCampaign.testAdminUser,
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the user is a superadmin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentOrAdminRoleRequired(
+            startedCampaign.testSuperAdminUser,
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -494,6 +494,82 @@ export async function createStartedCampaign() {
     assignmentId,
     assignment,
     testSuperAdminUser,
-    organizationId
+    organizationId,
+    dbCampaignContact
   };
 }
+
+export const getConversations = async (
+  user,
+  organizationId,
+  contactsFilter,
+  campaignsFilter,
+  assignmentsFilter
+) => {
+  const cursor = {
+    offset: 0,
+    limit: 1000
+  };
+  const variables = {
+    cursor,
+    organizationId,
+    contactsFilter,
+    campaignsFilter,
+    assignmentsFilter
+  };
+
+  const conversationsQuery = `
+    query Q(
+          $organizationId: String!
+          $cursor: OffsetLimitCursor!
+          $contactsFilter: ContactsFilter
+          $campaignsFilter: CampaignsFilter
+          $assignmentsFilter: AssignmentsFilter
+          $utc: String
+        ) {
+          conversations(
+            cursor: $cursor
+            organizationId: $organizationId
+            campaignsFilter: $campaignsFilter
+            contactsFilter: $contactsFilter
+            assignmentsFilter: $assignmentsFilter
+            utc: $utc
+          ) {
+            pageInfo {
+              limit
+              offset
+              total
+            }
+            conversations {
+              texter {
+                id
+                displayName
+              }
+              contact {
+                id
+                assignmentId
+                firstName
+                lastName
+                cell
+                messageStatus
+                messages {
+                  id
+                  text
+                  isFromContact
+                }
+                optOut {
+                  cell
+                }
+              }
+              campaign {
+                id
+                title
+              }
+            }
+          }
+        }
+      `;
+
+  const result = await runGql(conversationsQuery, variables, user);
+  return result;
+};

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -167,22 +167,25 @@ ConversationPreviewModal.propTypes = {
   onForceRefresh: PropTypes.func
 };
 
+export const createOptOutGqlString = `mutation createOptOut(
+  $optOut: OptOutInput!
+  $campaignContactId: String!
+) {
+  createOptOut(
+   optOut: $optOut
+   campaignContactId: $campaignContactId
+  ) {
+   id
+  }
+}`;
+
+export const createOptOutGql = gql`
+  ${createOptOutGqlString}
+`;
+
 const mapMutationsToProps = () => ({
   createOptOut: (optOut, campaignContactId) => ({
-    mutation: gql`
-      mutation createOptOut(
-        $optOut: OptOutInput!
-        $campaignContactId: String!
-      ) {
-        createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
-          id
-          optOut {
-            id
-            createdAt
-          }
-        }
-      }
-    `,
+    mutation: createOptOutGql,
     variables: {
       optOut,
       campaignContactId

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -9,6 +9,8 @@ import loadData from "../../containers//hoc/load-data";
 import wrapMutations from "../../containers/hoc/wrap-mutations";
 import MessageResponse from "./MessageResponse";
 
+import { dataTest } from "../../lib/attributes";
+
 const styles = StyleSheet.create({
   conversationRow: {
     color: "white",
@@ -20,10 +22,16 @@ const styles = StyleSheet.create({
 
 class MessageList extends Component {
   componentDidMount() {
+    if (typeof this.refs.messageWindow.scrollTo !== "function") {
+      return;
+    }
     this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
   }
 
   componentDidUpdate() {
+    if (typeof this.refs.messageWindow.scrollTo !== "function") {
+      return;
+    }
     this.refs.messageWindow.scrollTo(0, this.refs.messageWindow.scrollHeight);
   }
 
@@ -92,7 +100,7 @@ ConversationPreviewBody.propTypes = {
   conversation: PropTypes.object
 };
 
-class ConversationPreviewModal extends Component {
+export class InnerConversationPreviewModal extends Component {
   constructor(props) {
     super(props);
 
@@ -134,8 +142,17 @@ class ConversationPreviewModal extends Component {
       isOpen = conversation !== undefined;
 
     const primaryActions = [
-      <FlatButton label="Opt-Out" secondary onClick={this.handleClickOptOut} />,
-      <FlatButton label="Close" primary onClick={this.props.onRequestClose} />
+      <FlatButton
+        {...dataTest("conversationPreviewModalOptOutButton")}
+        label="Opt-Out"
+        secondary={true}
+        onClick={this.handleClickOptOut}
+      />,
+      <FlatButton
+        label="Close"
+        primary={true}
+        onClick={this.props.onRequestClose}
+      />
     ];
 
     return (
@@ -161,9 +178,10 @@ class ConversationPreviewModal extends Component {
   }
 }
 
-ConversationPreviewModal.propTypes = {
+InnerConversationPreviewModal.propTypes = {
   conversation: PropTypes.object,
   onRequestClose: PropTypes.func,
+  mutations: PropTypes.object,
   onForceRefresh: PropTypes.func
 };
 
@@ -193,6 +211,6 @@ const mapMutationsToProps = () => ({
   })
 });
 
-export default loadData(wrapMutations(ConversationPreviewModal), {
+export default loadData(wrapMutations(InnerConversationPreviewModal), {
   mapMutationsToProps
 });

--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -102,20 +102,28 @@ class ConversationPreviewModal extends Component {
   }
 
   handleClickOptOut = async () => {
-    const { contact } = this.props.conversation;
+    const { assignmentId, cell, campaignContactId } = this.props.conversation;
+
     const optOut = {
-      cell: contact.cell,
-      assignmentId: contact.assignmentId
+      cell,
+      assignmentId
     };
+
     try {
       const response = await this.props.mutations.createOptOut(
         optOut,
         campaignContactId
       );
       if (response.errors) {
-        const errorText = response.errors.join("\n");
+        let errorText = "Error processing opt-out.";
+        if ("message" in response.errors) {
+          errorText = response.errors.message;
+        }
+        console.log(errorText);
         throw new Error(errorText);
       }
+      this.props.onForceRefresh();
+      this.props.onRequestClose();
     } catch (error) {
       this.setState({ optOutError: error.message });
     }
@@ -126,16 +134,8 @@ class ConversationPreviewModal extends Component {
       isOpen = conversation !== undefined;
 
     const primaryActions = [
-      <FlatButton
-        label="Opt-Out"
-        secondary={true}
-        onClick={this.handleClickOptOut}
-      />,
-      <FlatButton
-        label="Close"
-        primary={true}
-        onClick={this.props.onRequestClose}
-      />
+      <FlatButton label="Opt-Out" secondary onClick={this.handleClickOptOut} />,
+      <FlatButton label="Close" primary onClick={this.props.onRequestClose} />
     ];
 
     return (
@@ -163,7 +163,8 @@ class ConversationPreviewModal extends Component {
 
 ConversationPreviewModal.propTypes = {
   conversation: PropTypes.object,
-  onRequestClose: PropTypes.func
+  onRequestClose: PropTypes.func,
+  onForceRefresh: PropTypes.func
 };
 
 const mapMutationsToProps = () => ({

--- a/src/components/IncomingMessageList/MessageResponse.jsx
+++ b/src/components/IncomingMessageList/MessageResponse.jsx
@@ -32,12 +32,11 @@ class MessageResponse extends Component {
   }
 
   createMessageToContact(text) {
-    const { contact, texter } = this.props.conversation;
+    const { cell, assignmentId } = this.props.conversation;
 
     return {
-      assignmentId: contact.assignmentId,
-      contactNumber: contact.cell,
-      userId: texter.id,
+      assignmentId: assignmentId,
+      contactNumber: cell,
       text
     };
   }
@@ -45,7 +44,7 @@ class MessageResponse extends Component {
   handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
 
   handleMessageFormSubmit = async ({ messageText }) => {
-    const { contact } = this.props.conversation;
+    const { campaignContactId } = this.props.conversation;
     const message = this.createMessageToContact(messageText);
     if (this.state.isSending) {
       return; // stops from multi-send
@@ -56,7 +55,7 @@ class MessageResponse extends Component {
     try {
       const response = await this.props.mutations.sendMessage(
         message,
-        contact.id
+        campaignContactId
       );
       const { messages } = response.data.sendMessage;
       this.props.messagesChanged(messages);

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -11,7 +11,7 @@ import ConversationPreviewModal from "./ConversationPreviewModal";
 
 import { MESSAGE_STATUSES } from "../../components/IncomingMessageFilter";
 
-const prepareDataTableData = conversations =>
+export const prepareDataTableData = conversations =>
   conversations.map(conversation => ({
     campaignTitle: conversation.campaign.title,
     texter: conversation.texter.displayName,

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -22,6 +22,9 @@ const prepareDataTableData = conversations =>
       // \u26d4 is the No Entry symbol: http://unicode.org/cldr/utility/character.jsp?a=26D4
       // including it directly breaks some text editors
       (conversation.contact.optOut.cell ? "\u26d4" : ""),
+    cell: conversation.contact.cell,
+    campaignContactId: conversation.contact.id,
+    assignmentId: conversation.contact.assignmentId,
     status: conversation.contact.messageStatus,
     messages: conversation.contact.messages
   }));
@@ -251,6 +254,7 @@ export class IncomingMessageList extends Component {
         <ConversationPreviewModal
           conversation={this.state.activeConversation}
           onRequestClose={this.handleCloseConversation}
+          onForceRefresh={this.props.onForceRefresh}
         />
       </div>
     );
@@ -269,7 +273,8 @@ IncomingMessageList.propTypes = {
   onConversationCountChanged: type.func,
   utc: type.string,
   conversations: type.object,
-  clearSelectedMessages: type.bool
+  clearSelectedMessages: type.bool,
+  onForceRefresh: type.func
 };
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/AdminIncomingMessageList.jsx
+++ b/src/containers/AdminIncomingMessageList.jsx
@@ -291,6 +291,14 @@ export class AdminIncomingMessageList extends Component {
     });
   };
 
+  handleForceRefresh = (clearSelectedMessages = false) => {
+    this.setState({
+      utc: Date.now().toString(),
+      needsRender: true,
+      clearSelectedMessages
+    });
+  };
+
   render() {
     const cursor = {
       offset: this.state.page * this.state.pageSize,
@@ -366,6 +374,7 @@ export class AdminIncomingMessageList extends Component {
               onConversationSelected={this.handleRowSelection}
               onConversationCountChanged={this.conversationCountChanged}
               clearSelectedMessages={this.state.clearSelectedMessages}
+              onForceRefresh={this.handleForceRefresh}
             />
           </div>
         )}

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -68,7 +68,9 @@ export async function assignmentOrAdminRoleRequired(
     return true;
   }
 
-  return await assignmentRequired(user, assignmentId, assignment);
+  // calling exports.assignmentRequired instead of just assignmentRequired
+  // is functionally identical but it allos us to mock assignmentRequired
+  return await exports.assignmentRequired(user, assignmentId, assignment);
 }
 
 export function superAdminRequired(user) {

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -56,6 +56,21 @@ export async function assignmentRequired(user, assignmentId, assignment) {
   return true;
 }
 
+export async function assignmentOrAdminRoleRequired(
+  user,
+  orgId,
+  assignmentId,
+  assignment
+) {
+  authRequired(user);
+  const isAdmin = await cacheableData.user.userHasRole(user, orgId, "ADMIN");
+  if (isAdmin || user.is_superadmin) {
+    return true;
+  }
+
+  return await assignmentRequired(user, assignmentId, assignment);
+}
+
 export function superAdminRequired(user) {
   authRequired(user);
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -284,22 +284,23 @@ const rootMutations = {
 
       await accessRequired(user, campaign.organization_id, "ADMIN");
 
-      const lastMessage = await r
-        .table("message")
-        .getAll(contact.assignment_id, { index: "assignment_id" })
-        .filter({ contact_number: contact.cell })
-        .limit(1)(0)
-        .default(null);
+      const lastMessages = await r.knex
+        .select()
+        .from("message")
+        .where({ contact_number: contact.cell })
+        .orderBy("id", "desc")
+        .limit(1);
 
-      if (!lastMessage) {
-        throw new GraphQLError({
+      if (!lastMessages.length) {
+        const errorStatusAndMessage = {
           status: 400,
           message:
             "Cannot fake a reply to a contact that has no existing thread yet"
-        });
+        };
+        throw new GraphQLError(errorStatusAndMessage);
       }
 
-      const userNumber = lastMessage.user_number;
+      const userNumber = lastMessages[0].user_number;
       const contactNumber = contact.cell;
       const mockId = `mocked_${Math.random()
         .toString(36)
@@ -313,8 +314,8 @@ const rootMutations = {
           error_code: null,
           service_id: mockId,
           campaign_contact_id: contact.id,
-          messageservice_sid: lastMessage.messageservice_sid,
-          service: lastMessage.service,
+          messageservice_sid: lastMessages[0].messageservice_sid,
+          service: lastMessages[0].service,
           send_status: "DELIVERED"
         })
       );

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -39,7 +39,12 @@ import {
   reassignConversations,
   resolvers as conversationsResolver
 } from "./conversations";
-import { accessRequired, assignmentRequired, authRequired } from "./errors";
+import {
+  accessRequired,
+  assignmentOrAdminRoleRequired,
+  assignmentRequired,
+  authRequired
+} from "./errors";
 import { resolvers as interactionStepResolvers } from "./interaction-step";
 import { resolvers as inviteResolvers } from "./invite";
 import { saveNewIncomingMessage } from "./lib/message-sending";
@@ -886,11 +891,15 @@ const rootMutations = {
       { loaders, user }
     ) => {
       const contact = await loaders.campaignContact.load(campaignContactId);
-      await assignmentRequired(user, contact.assignment_id);
-
-      const { assignmentId, cell, reason } = optOut;
       const campaign = await loaders.campaign.load(contact.campaign_id);
 
+      await assignmentOrAdminRoleRequired(
+        user,
+        campaign.organization_id,
+        contact.assignment_id
+      );
+
+      const { assignmentId, cell, reason } = optOut;
       await cacheableData.optOut.save({
         cell,
         campaignContactId,


### PR DESCRIPTION
# Fixes #1291 
# Fixes #1337 

## Description

This PR provides the ability for message-review users to opt out a contact from message review. 

This PR replaces #1293.  It changes a lot less code.

I fixed ConversationPreviewModal to pull attributes from the correct shape of the data, I broke out the graphQL query so we can use it in tests, and I created InnerConversationPreviewModal so we can wrap it and instantiate it separately from the wrapped component exported from conversationPreviewModal.jsx.

I updated the server to allow admins to opt out contacts assigned to a different user.  That's necessary for this function to work.

It's more than 300 lines because I added a lot of test code.


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] **No UI changes** ~If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] **N/A** ~I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ]  **N/A** ~My PR is labeled [WIP] if it is in progress~
