### PR TITLE
Admin can optout a contact not assigned to them

### DIFF
--- a/__test__/server/api/createOptOut.test.js
+++ b/__test__/server/api/createOptOut.test.js
@@ -1,0 +1,105 @@
+/* eslint-disable no-unused-expressions, consistent-return */
+import { r } from "../../../src/server/models/";
+
+import {
+  setupTest,
+  cleanupTest,
+  runGql,
+  createStartedCampaign,
+  getOptOut
+} from "../../test_helpers";
+
+describe("createOptOut", () => {
+  let startedCampaign;
+  let optOutContact;
+  let optOut;
+  let variables;
+  const createOptOutGql = `mutation createOptOut(
+      $optOut: OptOutInput!
+      $campaignContactId: String!
+    ) {
+      createOptOut(
+       optOut: $optOut
+       campaignContactId: $campaignContactId
+      ) {
+       id
+      }
+    }`;
+
+  beforeEach(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+
+    startedCampaign = await createStartedCampaign();
+
+    optOutContact = startedCampaign.testContacts[20];
+    optOut = {
+      cell: optOutContact.cell,
+      assignmentId: startedCampaign.assignmentId,
+      reason: "they were snotty"
+    };
+
+    variables = {
+      optOut,
+      campaignContactId: optOutContact.id
+    };
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  it("creates an opt out when the contact is assigned to the current user", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testTexterUser
+    );
+
+    expect(optOutResult.data.createOptOut.id).toEqual(
+      optOutContact.id.toString()
+    );
+    expect(optOutResult.errors).toBeUndefined();
+
+    const dbOptOut = await getOptOut(
+      parseInt(startedCampaign.assignmentId, 10),
+      optOutContact.cell
+    );
+    expect(dbOptOut.cell).toEqual(optOutContact.cell);
+  });
+
+  it("creates an opt out when the current user is an admin user and the contact is assigned to a different user", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testAdminUser
+    );
+
+    console.log("optOutResult", optOutResult);
+
+    expect(optOutResult.data.createOptOut.id).toEqual(
+      optOutContact.id.toString()
+    );
+    expect(optOutResult.errors).toBeUndefined();
+
+    const dbOptOut = await getOptOut(
+      parseInt(startedCampaign.assignmentId, 10),
+      optOutContact.cell
+    );
+    expect(dbOptOut.cell).toEqual(optOutContact.cell);
+  });
+
+  it("returns an error when the user attempting the optout is neither an admin nor assigned to the contact", async () => {
+    const optOutResult = await runGql(
+      createOptOutGql,
+      variables,
+      startedCampaign.testTexterUser2
+    );
+
+    expect(optOutResult.createOptOut).toBeUndefined();
+    expect(optOutResult.errors[0].message).toEqual(
+      "You are not authorized to access that resource."
+    );
+  });
+});

--- a/__test__/server/api/errors.test.js
+++ b/__test__/server/api/errors.test.js
@@ -1,0 +1,174 @@
+import { r } from "../../../src/server/models/";
+import {
+  authRequired,
+  assignmentRequired,
+  assignmentOrAdminRoleRequired
+} from "../../../src/server/api/errors";
+
+const errors = require("../../../src/server/api/errors.js");
+
+import {
+  setupTest,
+  cleanupTest,
+  createStartedCampaign
+} from "../../test_helpers";
+
+describe("errors.js", () => {
+  let startedCampaign;
+
+  beforeEach(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+    startedCampaign = await createStartedCampaign();
+  });
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  describe("#authRequired", () => {
+    it("does not throw an exception if a user is passed to it", async () => {
+      authRequired(startedCampaign.testTexterUser);
+    });
+
+    it("throws an exception if nothing is passed to it", async () => {
+      let error;
+      try {
+        authRequired(undefined);
+      } catch (caught) {
+        error = caught;
+      }
+
+      expect(error).toBeDefined();
+      expect(error.message).toEqual({
+        message: "You must login to access that resource.",
+        status: 401
+      });
+    });
+  });
+
+  describe("#assignmentRequired", () => {
+    it("returns true when a texter user has the assignment", async () => {
+      expect(
+        await assignmentRequired(
+          startedCampaign.testTexterUser,
+          startedCampaign.assignmentId
+        )
+      ).toBe(true);
+    });
+
+    describe("when the user does not have the assignment", () => {
+      it("throws an exception", async () => {
+        let error;
+        try {
+          await assignmentRequired(
+            startedCampaign.testTexterUser2,
+            startedCampaign.assignmentId
+          );
+        } catch (caught) {
+          error = caught;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toEqual(
+          "You are not authorized to access that resource."
+        );
+      });
+    });
+
+    describe("when a user is superadmin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentRequired(
+            startedCampaign.testSuperAdminUser,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+      });
+    });
+
+    describe("when an assignment is passed", () => {
+      it("returns true if the user has the assignment", async () => {
+        expect(
+          await assignmentRequired(
+            startedCampaign.testTexterUser,
+            startedCampaign.assignmentId,
+            startedCampaign.assignment
+          )
+        ).toBe(true);
+      });
+
+      describe("when the user does not have the assignment", () => {
+        it("throws an exception", async () => {
+          let error;
+          try {
+            await assignmentRequired(
+              startedCampaign.testTexterUser2,
+              startedCampaign.assignmentId,
+              startedCampaign.assignment
+            );
+          } catch (caught) {
+            error = caught;
+          }
+
+          expect(error).toBeDefined();
+          expect(error.message).toEqual(
+            "You are not authorized to access that resource."
+          );
+        });
+      });
+    });
+  });
+
+  describe("#assignmentOrAdminRoleRequired", () => {
+    let spy;
+
+    beforeEach(async () => {
+      spy = jest.spyOn(errors, "assignmentRequired").mockResolvedValue(true);
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+    });
+
+    it("calls assignmentRequired", async () => {
+      await assignmentOrAdminRoleRequired(
+        startedCampaign.testTexterUser,
+        startedCampaign.organizationId,
+        startedCampaign.assignmentId
+      );
+      expect(spy).toHaveBeenCalledWith(
+        startedCampaign.testTexterUser,
+        startedCampaign.assignmentId,
+        undefined
+      );
+    });
+
+    describe("when the user is an admin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentOrAdminRoleRequired(
+            startedCampaign.testAdminUser,
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("when the user is a superadmin", () => {
+      it("returns true", async () => {
+        expect(
+          await assignmentOrAdminRoleRequired(
+            startedCampaign.testSuperAdminUser,
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId
+          )
+        ).toBe(true);
+        expect(spy).not.toHaveBeenCalled();
+      });
+    });
+  });
+});

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -443,3 +443,133 @@ export async function getCampaignContact(id) {
     .where({ id })
     .first();
 }
+
+export async function getOptOut(assignmentId, cell) {
+  return await r
+    .knex("opt_out")
+    .where({
+      cell,
+      assignment_id: assignmentId
+    })
+    .first();
+}
+
+export async function createStartedCampaign() {
+  const testAdminUser = await createUser();
+  const testInvite = await createInvite();
+  const testOrganization = await createOrganization(testAdminUser, testInvite);
+  const organizationId = testOrganization.data.createOrganization.id;
+  const testCampaign = await createCampaign(testAdminUser, testOrganization);
+  const testContacts = await createContacts(testCampaign, 100);
+  const testTexterUser = await createTexter(testOrganization);
+  const testTexterUser2 = await createTexter(testOrganization);
+  await startCampaign(testAdminUser, testCampaign);
+
+  await assignTexter(testAdminUser, testTexterUser, testCampaign);
+  const dbCampaignContact = await getCampaignContact(testContacts[0].id);
+  const assignmentId = dbCampaignContact.assignment_id;
+  const assignment = (await r.knex("assignment").where("id", assignmentId))[0];
+
+  const testSuperAdminUser = await createUser(
+    {
+      auth0_id: "2024561111",
+      first_name: "super",
+      last_name: "admin",
+      cell: "202-456-1111",
+      email: "superadmin@example.com",
+      is_superadmin: true
+    },
+    organizationId,
+    "ADMIN"
+  );
+
+  return {
+    testAdminUser,
+    testInvite,
+    testOrganization,
+    testCampaign,
+    testTexterUser,
+    testTexterUser2,
+    testContacts,
+    assignmentId,
+    assignment,
+    testSuperAdminUser,
+    organizationId,
+    dbCampaignContact
+  };
+}
+
+export const getConversations = async (
+  user,
+  organizationId,
+  contactsFilter,
+  campaignsFilter,
+  assignmentsFilter
+) => {
+  const cursor = {
+    offset: 0,
+    limit: 1000
+  };
+  const variables = {
+    cursor,
+    organizationId,
+    contactsFilter,
+    campaignsFilter,
+    assignmentsFilter
+  };
+
+  const conversationsQuery = `
+    query Q(
+          $organizationId: String!
+          $cursor: OffsetLimitCursor!
+          $contactsFilter: ContactsFilter
+          $campaignsFilter: CampaignsFilter
+          $assignmentsFilter: AssignmentsFilter
+          $utc: String
+        ) {
+          conversations(
+            cursor: $cursor
+            organizationId: $organizationId
+            campaignsFilter: $campaignsFilter
+            contactsFilter: $contactsFilter
+            assignmentsFilter: $assignmentsFilter
+            utc: $utc
+          ) {
+            pageInfo {
+              limit
+              offset
+              total
+            }
+            conversations {
+              texter {
+                id
+                displayName
+              }
+              contact {
+                id
+                assignmentId
+                firstName
+                lastName
+                cell
+                messageStatus
+                messages {
+                  id
+                  text
+                  isFromContact
+                }
+                optOut {
+                  cell
+                }
+              }
+              campaign {
+                id
+                title
+              }
+            }
+          }
+        }
+      `;
+
+  const result = await runGql(conversationsQuery, variables, user);
+  return result;
+};

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -56,6 +56,23 @@ export async function assignmentRequired(user, assignmentId, assignment) {
   return true;
 }
 
+export async function assignmentOrAdminRoleRequired(
+  user,
+  orgId,
+  assignmentId,
+  assignment
+) {
+  authRequired(user);
+  const isAdmin = await cacheableData.user.userHasRole(user, orgId, "ADMIN");
+  if (isAdmin || user.is_superadmin) {
+    return true;
+  }
+
+  // calling exports.assignmentRequired instead of just assignmentRequired
+  // is functionally identical but it allows us to mock assignmentRequired
+  return await exports.assignmentRequired(user, assignmentId, assignment);
+}
+
 export function superAdminRequired(user) {
   authRequired(user);
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -39,7 +39,12 @@ import {
   reassignConversations,
   resolvers as conversationsResolver
 } from "./conversations";
-import { accessRequired, assignmentRequired, authRequired } from "./errors";
+import {
+  accessRequired,
+  assignmentOrAdminRoleRequired,
+  assignmentRequired,
+  authRequired
+} from "./errors";
 import { resolvers as interactionStepResolvers } from "./interaction-step";
 import { resolvers as inviteResolvers } from "./invite";
 import { saveNewIncomingMessage } from "./lib/message-sending";
@@ -885,10 +890,15 @@ const rootMutations = {
       { loaders, user }
     ) => {
       const contact = await loaders.campaignContact.load(campaignContactId);
-      await assignmentRequired(user, contact.assignment_id);
+      const campaign = await loaders.campaign.load(contact.campaign_id);
+
+      await assignmentOrAdminRoleRequired(
+        user,
+        campaign.organization_id,
+        contact.assignment_id
+      );
 
       const { assignmentId, cell, reason } = optOut;
-      const campaign = await loaders.campaign.load(contact.campaign_id);
 
       await cacheableData.optOut.save({
         cell,


### PR DESCRIPTION
# Related to #1291

#1412 

## Description

Server change to allow admins to opt out any contact, even those not assigned to them.

This is intended to "burn in" for a while without being exposed in the UI.  #1412 exists as a fix for #1291 (includes these changes as well as fixes in the front end) but when it was deployed there were problems in production that might have been related, as described in #1293.  When we rolled back this change, the errors stopped, so maybe _post hoc ergo propter hoc_ is a thing here.

Specifically what we're "burning in" is an [`await` where we didn't have one before](https://github.com/MoveOnOrg/Spoke/pull/1420/files#diff-c4c31a616e66e00a288dc20948d5de88R73).  

# Checklist:

- [N/A] ~I have manually tested my changes on desktop and mobile~
- [x] The test suite passes locally with my changes
- [N/A] ~If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x]  **This PR has a lot of lines of tests.  The actual change is like 25 lines.**  ~[My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer~
- [N/A] ~I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A] ~My PR is labeled [WIP] if it is in progress~
