### PR TITLE
add organization as an argument to getConfig

### DIFF
--- a/src/server/api/lib/config.js
+++ b/src/server/api/lib/config.js
@@ -8,7 +8,16 @@ import fs from "fs";
 
 let CONFIG = null;
 
-export function getConfig(key) {
+export function getConfig(key, organization) {
+  if (organization) {
+    let features =
+      organization.feature ||
+      (organization.features && JSON.parse(organization.features)) ||
+      {};
+    if (features[key]) {
+      return features[key];
+    }
+  }
   if (key in global) {
     return global[key];
   } else if (key in process.env) {


### PR DESCRIPTION
So config can come from organization.features json column OR global context

## Description

This allows us to start using a single pattern for feature-flag-type settings from environment variables and organization features.  After this, we can standardize customizations that can also be per-organization.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
