### PR TITLE
Refactor AssignmentTexterContact

### DIFF
--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -455,7 +455,7 @@ AssignmentTexter.propTypes = {
   getNewContacts: PropTypes.func,
   assignContactsIfNeeded: PropTypes.func,
   organizationId: PropTypes.string,
-  ChildComponent: PropTypes.object,
+  ChildComponent: PropTypes.func,
   messageStatusFilter: PropTypes.string
 };
 

--- a/src/components/AssignmentTexter.jsx
+++ b/src/components/AssignmentTexter.jsx
@@ -1,10 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
-import { ToolbarTitle } from "material-ui/Toolbar";
 import IconButton from "material-ui/IconButton/IconButton";
-import NavigateBeforeIcon from "material-ui/svg-icons/image/navigate-before";
-import NavigateNextIcon from "material-ui/svg-icons/image/navigate-next";
-import AssignmentTexterContact from "../containers/AssignmentTexterContact";
 import LoadingIndicator from "./LoadingIndicator";
 import { StyleSheet, css } from "aphrodite";
 import { withRouter } from "react-router";
@@ -24,9 +20,6 @@ const styles = StyleSheet.create({
     zIndex: 1002,
     backgroundColor: "white",
     overflow: "hidden"
-  },
-  navigationToolbarTitle: {
-    fontSize: "12px"
   }
 });
 
@@ -327,45 +320,34 @@ export class AssignmentTexter extends React.Component {
     return this.getContact(contacts, 0);
   }
 
-  renderNavigationToolbarChildren() {
+  getNavigationToolbarChildren() {
     const { allContactsCount } = this.props;
     const remainingContacts = this.contactCount();
     const messagedContacts = allContactsCount - remainingContacts;
 
     const currentIndex = this.state.currentContactIndex + 1 + messagedContacts;
-    let ofHowMany = allContactsCount;
+    let total = allContactsCount;
     if (
-      ofHowMany === currentIndex &&
+      total === currentIndex &&
       this.props.assignment.campaign.useDynamicAssignment
     ) {
-      ofHowMany = "?";
+      total = "?";
     }
-    const title = `${currentIndex} of ${ofHowMany}`;
-    return [
-      <ToolbarTitle
-        className={css(styles.navigationToolbarTitle)}
-        text={title}
-      />,
-      <IconButton
-        onTouchTap={this.handleNavigatePrevious}
-        disabled={!this.hasPrevious()}
-      >
-        <NavigateBeforeIcon />
-      </IconButton>,
-      <IconButton
-        onTouchTap={this.handleNavigateNext}
-        disabled={!this.hasNext()}
-      >
-        <NavigateNextIcon />
-      </IconButton>
-    ];
+    const title = `${currentIndex} of ${total}`;
+    return {
+      onPrevious: this.hasPrevious() ? this.handleNavigatePrevious : null,
+      onNext: this.hasNext() ? this.handleNavigateNext : null,
+      currentIndex,
+      total,
+      title
+    };
   }
 
   renderTexter() {
-    const { assignment } = this.props;
+    const { assignment, ChildComponent } = this.props;
     const { campaign, texter } = assignment;
     const contact = this.currentContact();
-    const navigationToolbarChildren = this.renderNavigationToolbarChildren();
+    const navigationToolbarChildren = this.getNavigationToolbarChildren();
     if (!contact || !contact.id) {
       console.log("NO CONTACT", contact, this.props);
       return <LoadingIndicator />;
@@ -420,8 +402,9 @@ export class AssignmentTexter extends React.Component {
       }, self.state.reloadDelay);
       return <LoadingIndicator />;
     }
+    // ChildComponent is AssignmentTexterContact except for demo/testing
     return (
-      <AssignmentTexterContact
+      <ChildComponent
         key={contact.id}
         assignment={assignment}
         campaignContactId={contact.id}
@@ -432,6 +415,7 @@ export class AssignmentTexter extends React.Component {
         onFinishContact={this.handleFinishContact}
         refreshData={this.props.refreshData}
         onExitTexter={this.handleExitTexter}
+        messageStatusFilter={this.props.messageStatusFilter}
       />
     );
   }
@@ -470,7 +454,9 @@ AssignmentTexter.propTypes = {
   loadContacts: PropTypes.func,
   getNewContacts: PropTypes.func,
   assignContactsIfNeeded: PropTypes.func,
-  organizationId: PropTypes.string
+  organizationId: PropTypes.string,
+  ChildComponent: PropTypes.object,
+  messageStatusFilter: PropTypes.string
 };
 
 export default withRouter(AssignmentTexter);

--- a/src/components/AssignmentTexterContactControls.jsx
+++ b/src/components/AssignmentTexterContactControls.jsx
@@ -502,9 +502,8 @@ export class AssignmentTexterContactControls extends React.Component {
         campaignCannedResponses={campaignCannedResponses}
         userCannedResponses={userCannedResponses}
         customFields={campaign.customFields}
-        campaignId={campaign.id}
-        texterId={texter.id}
         onSelectCannedResponse={this.handleCannedResponseChange}
+        onCreateCannedResponse={this.props.onCreateCannedResponse}
       />
     );
   }
@@ -652,30 +651,23 @@ AssignmentTexterContactControls.propTypes = {
   // data
   contact: PropTypes.object,
   campaign: PropTypes.object,
-  messageStatusFilter: PropTypes.string,
+  assignment: PropTypes.object,
+  texter: PropTypes.object,
 
   // parent state
   disabled: PropTypes.bool,
+  navigationToolbarChildren: PropTypes.object,
+  messageStatusFilter: PropTypes.string,
 
   // parent config/callbacks
   startingMessage: PropTypes.string,
   onMessageFormSubmit: PropTypes.func,
   onOptOut: PropTypes.func,
   onQuestionResponseChange: PropTypes.func,
+  onCreateCannedResponse: PropTypes.func,
   onExitTexter: PropTypes.func,
   onEditStatus: PropTypes.func,
-  getMessageTextFromScript: PropTypes.func,
-  //--both in contact: availableInteractionSteps + questionResponses
-  //
-  // assignment=
-  // for cannedresponses list:
-  // maybe also needs handleNewCannedReponse
-  assignment: PropTypes.object,
-  texter: PropTypes.object,
-  // navigationToolbarChildren=
-  // next/prev buttons with figured out of
-  // replace with: first/middle/last, handleNavigatePrevious/Next
-  navigationToolbarChildren: PropTypes.object
+  getMessageTextFromScript: PropTypes.func
 };
 
 export default AssignmentTexterContactControls;

--- a/src/components/AssignmentTexterContactControls.jsx
+++ b/src/components/AssignmentTexterContactControls.jsx
@@ -1,0 +1,678 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { StyleSheet, css } from "aphrodite";
+import ContactToolbar from "../components/ContactToolbar";
+import MessageList from "../components/MessageList";
+import CannedResponseMenu from "../components/CannedResponseMenu";
+import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";
+import RaisedButton from "material-ui/RaisedButton";
+import FlatButton from "material-ui/FlatButton";
+import NavigateHomeIcon from "material-ui/svg-icons/action/home";
+import NavigateBeforeIcon from "material-ui/svg-icons/image/navigate-before";
+import NavigateNextIcon from "material-ui/svg-icons/image/navigate-next";
+import { grey100 } from "material-ui/styles/colors";
+import IconButton from "material-ui/IconButton/IconButton";
+import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
+import { Card, CardActions, CardTitle } from "material-ui/Card";
+import Divider from "material-ui/Divider";
+import gql from "graphql-tag";
+import yup from "yup";
+import GSForm from "../components/forms/GSForm";
+import Form from "react-formal";
+import GSSubmitButton from "../components/forms/GSSubmitButton";
+import SendButton from "../components/SendButton";
+import SendButtonArrow from "../components/SendButtonArrow";
+import CircularProgress from "material-ui/CircularProgress";
+import Snackbar from "material-ui/Snackbar";
+import {
+  getChildren,
+  getAvailableInteractionSteps,
+  getTopMostParent,
+  interactionStepForId,
+  log,
+  isBetweenTextingHours
+} from "../lib";
+import Empty from "../components/Empty";
+import CreateIcon from "material-ui/svg-icons/content/create";
+import { dataTest } from "../lib/attributes";
+import { getContactTimezone } from "../lib/timezones";
+
+const styles = StyleSheet.create({
+  mobile: {
+    "@media(min-width: 425px)": {
+      display: "none !important"
+    }
+  },
+  desktop: {
+    "@media(max-width: 450px)": {
+      display: "none !important"
+    }
+  },
+  container: {
+    margin: 0,
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: "flex",
+    flexDirection: "column",
+    height: "100%"
+  },
+  optOutCard: {
+    "@media(max-width: 320px)": {
+      padding: "2px 10px !important"
+    },
+    zIndex: 2000,
+    backgroundColor: "white"
+  },
+  messageForm: {
+    backgroundColor: "red"
+  },
+  loadingIndicator: {
+    maxWidth: "50%"
+  },
+  navigationToolbarTitle: {
+    fontSize: "12px"
+  },
+  topFixedSection: {
+    flex: "0 0 auto"
+  },
+  middleScrollingSection: {
+    flex: "1 1 auto",
+    overflowY: "scroll",
+    overflow: "-moz-scrollbars-vertical"
+  },
+  bottomFixedSection: {
+    borderTop: `1px solid ${grey100}`,
+    flex: "0 0 auto",
+    marginBottom: "none"
+  },
+  messageField: {
+    padding: "0px 8px",
+    "@media(max-width: 450px)": {
+      marginBottom: "8%"
+    }
+  },
+  textField: {
+    "@media(max-width: 350px)": {
+      overflowY: "scroll !important"
+    }
+  },
+  dialogActions: {
+    marginTop: 20,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  lgMobileToolBar: {
+    "@media(max-width: 449px) and (min-width: 300px)": {
+      display: "inline-block"
+    },
+    "@media(max-width: 320px) and (min-width: 300px)": {
+      marginLeft: "-30px !important"
+    }
+  }
+});
+
+const inlineStyles = {
+  mobileToolBar: {
+    position: "absolute",
+    bottom: "-5"
+  },
+  mobileCannedReplies: {
+    "@media(max-width: 450px)": {
+      marginBottom: "1"
+    }
+  },
+  dialogButton: {
+    display: "inline-block"
+  },
+  exitTexterIconButton: {
+    float: "right",
+    height: "50px",
+    zIndex: 100,
+    position: "absolute",
+    top: 0,
+    right: "-30"
+  },
+  toolbarIconButton: {
+    position: "absolute",
+    top: 0
+    // without this the toolbar icons are not centered vertically
+  },
+  actionToolbar: {
+    backgroundColor: "white",
+    "@media(min-width: 450px)": {
+      marginBottom: 5
+    },
+    "@media(max-width: 450px)": {
+      marginBottom: 50
+    }
+  },
+  actionToolbarFirst: {
+    backgroundColor: "white"
+  }
+};
+
+export class AssignmentTexterContactControls extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const questionResponses = {};
+    // initial values
+    props.contact.questionResponseValues.forEach(questionResponse => {
+      questionResponses[questionResponse.interactionStepId] =
+        questionResponse.value;
+    });
+    const availableSteps = getAvailableInteractionSteps(
+      questionResponses,
+      props.campaign.interactionSteps
+    );
+    this.state = {
+      questionResponses,
+      optOutMessageText: props.campaign.organization.optOutMessage,
+      responsePopoverOpen: false,
+      messageText: this.getStartingMessageText(),
+      optOutDialogOpen: false,
+      currentInteractionStep:
+        availableSteps.length > 0
+          ? availableSteps[availableSteps.length - 1]
+          : null
+    };
+    this.onEnter = this.onEnter.bind(this);
+  }
+
+  componentDidMount() {
+    const node = this.refs.messageScrollContainer;
+    // Does not work without this setTimeout
+    setTimeout(() => {
+      node.scrollTop = Math.floor(node.scrollHeight);
+    }, 0);
+
+    // note: key*down* is necessary to stop propagation of keyup for the textarea element
+    document.body.addEventListener("keydown", this.onEnter);
+  }
+
+  componentWillUnmount() {
+    document.body.removeEventListener("keydown", this.onEnter);
+  }
+
+  getStartingMessageText() {
+    const { campaign, messageStatusFilter } = this.props;
+    return messageStatusFilter === "needsMessage"
+      ? this.props.getMessageTextFromScript(
+          getTopMostParent(campaign.interactionSteps).script
+        )
+      : "";
+  }
+
+  onEnter(evt) {
+    // FUTURE: consider disabling except in needsMessage
+    if (evt.keyCode === 13) {
+      evt.preventDefault();
+      // pressing the Enter key submits
+      if (!this.state.optOutDialogOpen) {
+        this.handleClickSendMessageButton();
+      }
+    }
+  }
+
+  optOutSchema = yup.object({
+    optOutMessageText: yup.string()
+  });
+
+  messageSchema = yup.object({
+    messageText: yup
+      .string()
+      .required("Can't send empty message")
+      .max(window.MAX_MESSAGE_LENGTH)
+  });
+
+  handleClickSendMessageButton = () => {
+    this.refs.form.submit();
+  };
+
+  handleCannedResponseChange = cannedResponseScript => {
+    this.handleChangeScript(cannedResponseScript);
+  };
+
+  handleOpenDialog = () => {
+    this.setState({ optOutDialogOpen: true });
+  };
+
+  handleCloseDialog = () => {
+    this.setState({ optOutDialogOpen: false });
+  };
+
+  handleQuestionResponseChange = ({
+    interactionStep,
+    questionResponseValue,
+    nextScript
+  }) => {
+    const { questionResponses } = this.state;
+    const { interactionSteps } = this.props.campaign;
+    questionResponses[interactionStep.id] = questionResponseValue;
+
+    const children = getChildren(interactionStep, interactionSteps);
+    for (const childStep of children) {
+      if (childStep.id in questionResponses) {
+        questionResponses[childStep.id] = null;
+      }
+    }
+
+    this.setState(
+      {
+        questionResponses
+      },
+      () => {
+        this.handleChangeScript(nextScript);
+        // a bit odd, but we need to update the parent context's state as well
+        // this is because responses are sent to the server on many other actions
+        // so any of those can trigger a question response update
+        this.props.onQuestionResponseChange({ questionResponses });
+      }
+    );
+  };
+
+  handleChangeScript = newScript => {
+    const messageText = this.props.getMessageTextFromScript(newScript);
+
+    this.setState({
+      messageText
+    });
+  };
+
+  handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
+
+  handleOpenPopover = event => {
+    event.preventDefault();
+    this.setState({
+      responsePopoverAnchorEl: event.currentTarget,
+      responsePopoverOpen: true
+    });
+  };
+
+  handleClosePopover = () => {
+    this.setState({
+      responsePopoverOpen: false
+    });
+  };
+
+  renderMiddleScrollingSection() {
+    const { contact } = this.props;
+    return <MessageList contact={contact} messages={contact.messages} />;
+  }
+
+  renderSurveySection() {
+    const { campaign, contact } = this.props;
+    const { questionResponses } = this.state;
+    const { messages } = contact;
+
+    const availableInteractionSteps = getAvailableInteractionSteps(
+      questionResponses,
+      campaign.interactionSteps
+    );
+
+    return messages.length === 0 ? (
+      <Empty
+        title={"This is your first message to " + contact.firstName}
+        icon={<CreateIcon color="rgb(83, 180, 119)" />}
+        hideMobile
+      />
+    ) : (
+      <div>
+        <AssignmentTexterSurveys
+          contact={contact}
+          interactionSteps={availableInteractionSteps}
+          onQuestionResponseChange={this.handleQuestionResponseChange}
+          currentInteractionStep={this.state.currentInteractionStep}
+          questionResponses={questionResponses}
+        />
+      </div>
+    );
+  }
+
+  renderNeedsResponseToggleButton(contact) {
+    const { messageStatus } = contact;
+    let button = null;
+    if (messageStatus === "closed") {
+      button = (
+        <RaisedButton
+          onTouchTap={() => this.props.onEditStatus("needsResponse")}
+          label="Reopen"
+        />
+      );
+    } else if (messageStatus === "needsResponse") {
+      button = (
+        <RaisedButton
+          onTouchTap={() => this.props.onEditStatus("closed", true)}
+          label="Skip Reply"
+        />
+      );
+    }
+
+    return button;
+  }
+
+  renderActionToolbar() {
+    const {
+      contact,
+      campaign,
+      assignment,
+      navigationToolbarChildren,
+      onFinishContact,
+      messageStatusFilter
+    } = this.props;
+    const { messageStatus } = contact;
+    const size = document.documentElement.clientWidth;
+
+    const { onNext, onPrevious, title } = navigationToolbarChildren;
+
+    const navigationToolbar = [
+      <ToolbarTitle
+        className={css(styles.navigationToolbarTitle)}
+        text={title}
+      />,
+      <IconButton onTouchTap={onPrevious} disabled={!onPrevious}>
+        <NavigateBeforeIcon />
+      </IconButton>,
+      <IconButton onTouchTap={onNext} disabled={!onNext}>
+        <NavigateNextIcon />
+      </IconButton>
+    ];
+
+    if (messageStatusFilter === "needsMessage") {
+      return (
+        <div>
+          <Toolbar style={inlineStyles.actionToolbarFirst}>
+            <ToolbarGroup firstChild>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.props.disabled}
+              />
+              <div style={{ float: "right", marginLeft: 20 }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    } else if (size < 450) {
+      // for needsResponse or messaged or convo
+      return (
+        <div>
+          <Toolbar
+            className={css(styles.mobile)}
+            style={inlineStyles.actionToolbar}
+          >
+            <ToolbarGroup
+              style={inlineStyles.mobileToolBar}
+              className={css(styles.lgMobileToolBar)}
+              firstChild
+            >
+              <RaisedButton
+                {...dataTest("optOut")}
+                secondary
+                label="Opt out"
+                onTouchTap={this.handleOpenDialog}
+                tooltip="Opt out this contact"
+              />
+              <RaisedButton
+                style={inlineStyles.mobileCannedReplies}
+                label="Canned replies"
+                onTouchTap={this.handleOpenPopover}
+              />
+              {this.renderNeedsResponseToggleButton(contact)}
+              <div style={{ float: "right", marginLeft: "-30px" }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    } else if (size >= 768) {
+      // for needsResponse or messaged
+      return (
+        <div>
+          <Toolbar style={inlineStyles.actionToolbarFirst}>
+            <ToolbarGroup firstChild>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.props.disabled}
+              />
+              {this.renderNeedsResponseToggleButton(contact)}
+              <RaisedButton
+                label="Other responses"
+                onTouchTap={this.handleOpenPopover}
+              />
+              <RaisedButton
+                {...dataTest("optOut")}
+                secondary
+                label="Opt out"
+                onTouchTap={this.handleOpenDialog}
+                tooltip="Opt out this contact"
+                tooltipPosition="top-center"
+              />
+              <div style={{ float: "right", marginLeft: 20 }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    }
+    return "";
+  }
+
+  renderTopFixedSection() {
+    const { contact } = this.props;
+    return (
+      <ContactToolbar
+        campaign={this.props.campaign}
+        campaignContact={contact}
+        rightToolbarIcon={
+          <IconButton
+            onTouchTap={this.props.onExitTexter}
+            style={inlineStyles.exitTexterIconButton}
+            tooltip="Return Home"
+            tooltipPosition="bottom-center"
+          >
+            <NavigateHomeIcon />
+          </IconButton>
+        }
+      />
+    );
+  }
+
+  renderCannedResponsePopover() {
+    const { campaign, assignment, texter } = this.props;
+    const { userCannedResponses, campaignCannedResponses } = assignment;
+
+    return (
+      <CannedResponseMenu
+        onRequestClose={this.handleClosePopover}
+        open={this.state.responsePopoverOpen}
+        anchorEl={this.state.responsePopoverAnchorEl}
+        campaignCannedResponses={campaignCannedResponses}
+        userCannedResponses={userCannedResponses}
+        customFields={campaign.customFields}
+        campaignId={campaign.id}
+        texterId={texter.id}
+        onSelectCannedResponse={this.handleCannedResponseChange}
+      />
+    );
+  }
+
+  renderOptOutDialog() {
+    if (!this.state.optOutDialogOpen) {
+      return "";
+    }
+    return (
+      <Card>
+        <CardTitle className={css(styles.optOutCard)} title="Opt out user" />
+        <Divider />
+        <CardActions className={css(styles.optOutCard)}>
+          <GSForm
+            className={css(styles.optOutCard)}
+            schema={this.optOutSchema}
+            onChange={({ optOutMessageText }) =>
+              this.setState({ optOutMessageText })
+            }
+            value={{ optOutMessageText: this.state.optOutMessageText }}
+            onSubmit={this.props.onOptOut}
+          >
+            <Form.Field
+              name="optOutMessageText"
+              fullWidth
+              autoFocus
+              multiLine
+            />
+            <div className={css(styles.dialogActions)}>
+              <FlatButton
+                style={inlineStyles.dialogButton}
+                label="Cancel"
+                onTouchTap={this.handleCloseDialog}
+              />
+              <Form.Button
+                type="submit"
+                style={inlineStyles.dialogButton}
+                component={GSSubmitButton}
+                label={
+                  this.state.optOutMessageText.length
+                    ? "Send"
+                    : "Opt Out without Text"
+                }
+              />
+            </div>
+          </GSForm>
+        </CardActions>
+      </Card>
+    );
+  }
+
+  renderCorrectSendButton() {
+    const { campaign } = this.props;
+    const { contact } = this.props;
+    if (
+      contact.messageStatus === "messaged" ||
+      contact.messageStatus === "convo" ||
+      contact.messageStatus === "needsResponse"
+    ) {
+      return (
+        <SendButtonArrow
+          threeClickEnabled={false}
+          onFinalTouchTap={this.handleClickSendMessageButton}
+          disabled={this.props.disabled}
+        />
+      );
+    }
+    return null;
+  }
+
+  renderBottomFixedSection() {
+    const { optOutDialogOpen } = this.state;
+    const { messageStatusFilter } = this.props;
+
+    const message = optOutDialogOpen ? (
+      ""
+    ) : (
+      <div className={css(styles.messageField)}>
+        <GSForm
+          ref="form"
+          schema={this.messageSchema}
+          value={{ messageText: this.state.messageText }}
+          onSubmit={this.props.onMessageFormSubmit}
+          onChange={
+            messageStatusFilter === "needsMessage"
+              ? ""
+              : this.handleMessageFormChange
+          }
+        >
+          <Form.Field
+            className={css(styles.textField)}
+            name="messageText"
+            label="Your message"
+            multiLine
+            fullWidth
+            rowsMax={6}
+          />
+          {this.renderCorrectSendButton()}
+        </GSForm>
+      </div>
+    );
+
+    return (
+      <div>
+        {this.renderSurveySection()}
+        <div>
+          {message}
+          {optOutDialogOpen ? "" : this.renderActionToolbar()}
+        </div>
+        {this.renderOptOutDialog()}
+        {this.renderCannedResponsePopover()}
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div
+        className={css(styles.container)}
+        style={
+          this.props.contact.messageStatus === "needsResponse"
+            ? { backgroundColor: "rgba(83, 180, 119, 0.25)" }
+            : {}
+        }
+      >
+        <div className={css(styles.topFixedSection)}>
+          {this.renderTopFixedSection()}
+        </div>
+        <div
+          {...dataTest("messageList")}
+          ref="messageScrollContainer"
+          className={css(styles.middleScrollingSection)}
+        >
+          {this.renderMiddleScrollingSection()}
+        </div>
+        <div className={css(styles.bottomFixedSection)}>
+          {this.renderBottomFixedSection()}
+        </div>
+      </div>
+    );
+  }
+}
+
+AssignmentTexterContactControls.propTypes = {
+  // data
+  contact: PropTypes.object,
+  campaign: PropTypes.object,
+  messageStatusFilter: PropTypes.string,
+
+  // parent state
+  disabled: PropTypes.bool,
+
+  // parent config/callbacks
+  startingMessage: PropTypes.string,
+  onMessageFormSubmit: PropTypes.func,
+  onOptOut: PropTypes.func,
+  onQuestionResponseChange: PropTypes.func,
+  onExitTexter: PropTypes.func,
+  onEditStatus: PropTypes.func,
+  getMessageTextFromScript: PropTypes.func,
+  //--both in contact: availableInteractionSteps + questionResponses
+  //
+  // assignment=
+  // for cannedresponses list:
+  // maybe also needs handleNewCannedReponse
+  assignment: PropTypes.object,
+  texter: PropTypes.object,
+  // navigationToolbarChildren=
+  // next/prev buttons with figured out of
+  // replace with: first/middle/last, handleNavigatePrevious/Next
+  navigationToolbarChildren: PropTypes.object
+};
+
+export default AssignmentTexterContactControls;

--- a/src/components/AssignmentTexterContactControls.jsx
+++ b/src/components/AssignmentTexterContactControls.jsx
@@ -367,20 +367,23 @@ export class AssignmentTexterContactControls extends React.Component {
     const { messageStatus } = contact;
     const size = document.documentElement.clientWidth;
 
-    const { onNext, onPrevious, title } = navigationToolbarChildren;
+    let navigationToolbar = [];
+    if (navigationToolbarChildren) {
+      const { onNext, onPrevious, title } = navigationToolbarChildren;
 
-    const navigationToolbar = [
-      <ToolbarTitle
-        className={css(styles.navigationToolbarTitle)}
-        text={title}
-      />,
-      <IconButton onTouchTap={onPrevious} disabled={!onPrevious}>
-        <NavigateBeforeIcon />
-      </IconButton>,
-      <IconButton onTouchTap={onNext} disabled={!onNext}>
-        <NavigateNextIcon />
-      </IconButton>
-    ];
+      navigationToolbar = [
+        <ToolbarTitle
+          className={css(styles.navigationToolbarTitle)}
+          text={title}
+        />,
+        <IconButton onTouchTap={onPrevious} disabled={!onPrevious}>
+          <NavigateBeforeIcon />
+        </IconButton>,
+        <IconButton onTouchTap={onNext} disabled={!onNext}>
+          <NavigateNextIcon />
+        </IconButton>
+      ];
+    }
 
     if (messageStatusFilter === "needsMessage") {
       return (

--- a/src/components/CannedResponseForm.jsx
+++ b/src/components/CannedResponseForm.jsx
@@ -6,8 +6,8 @@ import GSForm from "./forms/GSForm";
 
 class CannedResponseForm extends React.Component {
   handleSave = formValues => {
-    const { onSaveCannedResponse } = this.props;
-    onSaveCannedResponse(formValues);
+    this.setState({ text: formValues.text });
+    this.props.onSaveCannedResponse(formValues);
   };
 
   render() {

--- a/src/components/CannedResponseMenu.jsx
+++ b/src/components/CannedResponseMenu.jsx
@@ -26,18 +26,17 @@ class CannedResponseMenu extends React.Component {
   };
 
   renderCannedResponses({ scripts, subheader, showAddScriptButton }) {
-    const { customFields, campaignId, texterId } = this.props;
+    const { customFields } = this.props;
 
     return (
       <ScriptList
-        texterId={texterId}
-        campaignId={campaignId}
         scripts={scripts}
         showAddScriptButton={showAddScriptButton}
         duplicateCampaignResponses
         customFields={customFields}
         subheader={subheader}
         onSelectCannedResponse={this.handleSelectCannedResponse}
+        onCreateCannedResponse={this.props.onCreateCannedResponse}
       />
     );
   }
@@ -86,13 +85,12 @@ class CannedResponseMenu extends React.Component {
 CannedResponseMenu.propTypes = {
   scripts: type.array,
   onSelectCannedResponse: type.func,
+  onCreateCannedResponse: type.func,
   onRequestClose: type.func,
   customFields: type.array,
-  texterId: type.number,
   userCannedResponses: type.array,
   open: type.bool,
   anchorEl: type.object,
-  campaignId: type.number,
   campaignCannedResponses: type.array
 };
 

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -50,7 +50,15 @@ const tests = {
       messageStatus: "needsMessage",
       questionResponseValues: [],
       messages: [],
-      customFields: "{}"
+      customFields: "{}",
+      location: {
+        city: "Tucson",
+        state: "AZ",
+        timezone: {
+          offset: -7,
+          hasDST: 1
+        }
+      }
     }
   },
   b: {
@@ -122,17 +130,47 @@ const tests = {
       firstName: "Joe",
       lastName: "Femur",
       messageStatus: "needsMessage",
+      location: {
+        city: "Youngstown",
+        state: "OH",
+        timezone: {
+          offset: -5,
+          hasDST: 1
+        }
+      },
       questionResponseValues: [],
       messages: [
         {
           text: "Will you come to the event?",
           isFromContact: false,
-          createdAt: new Date(Number(new Date()) - 14 * 60 * 1000) // 14 minutes ago
+          createdAt: new Date(Number(new Date()) - 314 * 60 * 1000)
         },
         {
-          text: "Yes, that would be lovely!",
+          text: "Sorry, who is this?",
           isFromContact: true,
-          createdAt: new Date()
+          createdAt: new Date(Number(new Date()) - 142 * 60 * 1000)
+        },
+        {
+          text:
+            "We are the people. We need your help, or the apocolypse will come early.",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 140 * 60 * 1000)
+        },
+        {
+          text:
+            "Oh -- the people are the best -- if only we rallied around our common interests.",
+          isFromContact: true,
+          createdAt: new Date(Number(new Date()) - 14 * 60 * 1000)
+        },
+        {
+          text: "I know, people are wonderful luminous beings.",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 10 * 60 * 1000)
+        },
+        {
+          text: "Okay, sign me up -- that event sounds great!",
+          isFromContact: true,
+          createdAt: new Date(Number(new Date()) - 4 * 60 * 1000) // 4 minutes ago
         }
       ],
       customFields:

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -75,12 +75,42 @@ const tests = {
           {
             id: "13",
             script: "Hi {firstName}, have you voted today, yet?",
-            question: { text: "", answerOptions: [] }
+            question: {
+              text: "Attend Event?",
+              answerOptions: [
+                {
+                  value: "Yes",
+                  nextInteractionStep: {
+                    script: "That's great, we'll see you there!"
+                  }
+                },
+                {
+                  value: "No",
+                  nextInteractionStep: {
+                    script: "That's too bad, but we love you anyway!"
+                  }
+                }
+              ]
+            }
           }
         ],
         customFields: ["donationLink", "vendor_id"]
       },
-      campaignCannedResponses: [],
+      campaignCannedResponses: [
+        {
+          id: "1",
+          title: "Moved",
+          text:
+            "I'm sorry, we'll update your address -- what is your current zip code?",
+          isUserCreated: false
+        },
+        {
+          id: "2",
+          title: "Wrong number",
+          text: "Ok, we'll remove you from our list.",
+          isUserCreated: false
+        }
+      ],
       userCannedResponses: []
     },
     texter: {
@@ -109,6 +139,9 @@ const tests = {
         '{"donationLink": "https://d.example.com/abc123", "vendor_id": "abc123"}'
     }
   }
+  // other tests:
+  // c: current question response is deeper in the state
+  // d: no questions at all
 };
 
 export function generateDemoTexterContact(test) {

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -1,0 +1,171 @@
+import PropTypes from "prop-types";
+import React from "react";
+
+import AssignmentTexter from "../components/AssignmentTexter";
+import AssignmentTexterContactControls from "../components/AssignmentTexterContactControls";
+import { applyScript } from "../lib/scripts";
+
+const logFunction = data => {
+  console.log("logging data", data);
+};
+
+const tests = {
+  a: {
+    disabled: false,
+    messageStatusFilter: "needsMessage",
+    navigationToolbarChildren: {
+      onNext: logFunction,
+      onPrevious: logFunction,
+      title: "21 of 42",
+      total: 42,
+      currentIndex: 21
+    },
+    assignment: {
+      campaign: {
+        id: 0,
+        useDynamicAssignment: false,
+        organization: {
+          optOutMessage:
+            "Sorry about that, removing you immediately -- have a good day!"
+        },
+        interactionSteps: [
+          {
+            id: "13",
+            script: "Hi {firstName}, have you voted today, yet?",
+            question: { text: "", answerOptions: [] }
+          }
+        ]
+      },
+      campaignCannedResponses: [],
+      userCannedResponses: []
+    },
+    texter: {
+      firstName: "Texterfirst",
+      lastName: "Tlastname"
+    },
+    contact: {
+      id: "1",
+      firstName: "Joe",
+      lastName: "Femur",
+      messageStatus: "needsMessage",
+      questionResponseValues: [],
+      messages: [],
+      customFields: "{}"
+    }
+  },
+  b: {
+    disabled: false,
+    messageStatusFilter: "needsResponse",
+    navigationToolbarChildren: {
+      onNext: logFunction,
+      onPrevious: logFunction,
+      title: "42 of 88",
+      total: 88,
+      currentIndex: 42
+    },
+    assignment: {
+      campaign: {
+        id: 0,
+        useDynamicAssignment: false,
+        organization: {
+          optOutMessage:
+            "Sorry about that, removing you immediately -- have a good day!"
+        },
+        interactionSteps: [
+          {
+            id: "13",
+            script: "Hi {firstName}, have you voted today, yet?",
+            question: { text: "", answerOptions: [] }
+          }
+        ],
+        customFields: ["donationLink", "vendor_id"]
+      },
+      campaignCannedResponses: [],
+      userCannedResponses: []
+    },
+    texter: {
+      firstName: "Texterfirst",
+      lastName: "Tlastname"
+    },
+    contact: {
+      id: "1",
+      firstName: "Joe",
+      lastName: "Femur",
+      messageStatus: "needsMessage",
+      questionResponseValues: [],
+      messages: [
+        {
+          text: "Will you come to the event?",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 14 * 60 * 1000) // 14 minutes ago
+        },
+        {
+          text: "Yes, that would be lovely!",
+          isFromContact: true,
+          createdAt: new Date()
+        }
+      ],
+      customFields:
+        '{"donationLink": "https://d.example.com/abc123", "vendor_id": "abc123"}'
+    }
+  }
+};
+
+export function generateDemoTexterContact(test) {
+  const DemoAssignmentTexterContact = function(props) {
+    const getMessageTextFromScript = script => {
+      return script
+        ? applyScript({
+            contact: test.contact,
+            texter: test.texter,
+            customFields: test.assignment.campaign.customFields,
+            script
+          })
+        : null;
+    };
+
+    return (
+      <AssignmentTexterContactControls
+        contact={test.contact}
+        campaign={test.assignment.campaign}
+        texter={test.texter}
+        assignment={test.assignment}
+        navigationToolbarChildren={test.navigationToolbarChildren}
+        messageStatusFilter={test.messageStatusFilter}
+        disabled={test.disabled}
+        onMessageFormSubmit={logFunction}
+        onOptOut={logFunction}
+        onQuestionResponseChange={logFunction}
+        onCreateCannedResponse={logFunction}
+        onExitTexter={logFunction}
+        onEditStatus={logFunction}
+        getMessageTextFromScript={getMessageTextFromScript}
+      />
+    );
+  };
+
+  const DemoTexterTest = function(props) {
+    return (
+      <AssignmentTexter
+        assignment={test.assignment}
+        contacts={[{ id: test.contact.id }]}
+        allContactsCount={test.navigationToolbarChildren.total}
+        assignContactsIfNeeded={test.assignContactsIfNeeded}
+        refreshData={logFunction}
+        loadContacts={contactIds => {
+          console.log("loadContacts", contactIds);
+          return { data: { getAssignmentContacts: [test.contact] } };
+        }}
+        getNewContacts={logFunction}
+        onRefreshAssignmentContacts={logFunction}
+        organizationId={"1"}
+        ChildComponent={DemoAssignmentTexterContact}
+      />
+    );
+  };
+
+  return DemoTexterTest;
+}
+
+export const DemoTexterNeedsMessage = generateDemoTexterContact(tests.a);
+export const DemoTexterNeedsResponse = generateDemoTexterContact(tests.b);

--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -82,12 +82,19 @@ class ScriptEditor extends React.Component {
 
     const editorState = this.getEditorState();
     this.state = {
-      editorState
+      editorState,
+      readyToAdd: false
     };
 
     this.focus = () => this.refs.editor.focus();
     this.onChange = this.onChange.bind(this);
     this.addCustomField = this.addCustomField.bind(this);
+    // start out with buttons disabled for 200ms
+    // because sometimes the click to open lands
+    // on one of the items.  After it opens, we enable them.
+    setTimeout(() => {
+      this.setState({ readyToAdd: true });
+    }, 200);
   }
 
   componentWillReceiveProps() {
@@ -95,7 +102,6 @@ class ScriptEditor extends React.Component {
     const { editorState } = this.state;
     const decorator = this.getCompositeDecorator(scriptFields);
     EditorState.set(editorState, { decorator });
-
     // this.setState({ editorState: this.getEditorState() })
   }
 
@@ -152,8 +158,11 @@ class ScriptEditor extends React.Component {
   }
 
   addCustomField(field) {
+    const { editorState, readyToAdd } = this.state;
+    if (!readyToAdd) {
+      return;
+    }
     const textToInsert = delimit(field);
-    const { editorState } = this.state;
     const selection = editorState.getSelection();
     const contentState = editorState.getCurrentContent();
     const newContentState = Modifier.insertText(

--- a/src/components/ScriptList.jsx
+++ b/src/components/ScriptList.jsx
@@ -35,12 +35,19 @@ class ScriptList extends React.Component {
     this.setState({
       dialogOpen: true
     });
+    // hack so mobile onclick doesn't close immediately
+    setTimeout(() => {
+      this.setState({ dialogReady: true });
+    }, 200);
   };
 
   handleCloseDialog = () => {
-    this.setState({
-      dialogOpen: false
-    });
+    if (this.state.dialogReady) {
+      this.setState({
+        dialogOpen: false,
+        dialogReady: false
+      });
+    }
   };
 
   render() {

--- a/src/components/ScriptList.jsx
+++ b/src/components/ScriptList.jsx
@@ -13,8 +13,6 @@ import Dialog from "material-ui/Dialog";
 import CannedResponseForm from "./CannedResponseForm";
 import GSSubmitButton from "./forms/GSSubmitButton";
 import Form from "react-formal";
-import { connect } from "react-apollo";
-import gql from "graphql-tag";
 import { log } from "../lib";
 
 // import { insert, update, remove } from '../../api/scripts/methods'
@@ -29,7 +27,6 @@ class ScriptList extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      script: props.script,
       dialogOpen: false
     };
   }
@@ -42,8 +39,7 @@ class ScriptList extends React.Component {
 
   handleCloseDialog = () => {
     this.setState({
-      dialogOpen: false,
-      script: null
+      dialogOpen: false
     });
   };
 
@@ -52,23 +48,16 @@ class ScriptList extends React.Component {
       subheader,
       scripts,
       onSelectCannedResponse,
+      onCreateCannedResponse,
       showAddScriptButton,
-      customFields,
-      campaignId,
-      mutations,
-      texterId
+      customFields
     } = this.props;
     const { dialogOpen } = this.state;
 
     const onSaveCannedResponse = async cannedResponse => {
+      this.setState({ dialogOpen: false });
       try {
-        const saveObject = {
-          ...cannedResponse,
-          campaignId,
-          userId: texterId
-        };
-        await mutations.createCannedResponse(saveObject);
-        this.setState({ dialogOpen: false });
+        await onCreateCannedResponse({ cannedResponse });
       } catch (err) {
         log.error(err);
       }
@@ -143,7 +132,6 @@ class ScriptList extends React.Component {
             <CannedResponseForm
               onSaveCannedResponse={onSaveCannedResponse}
               customFields={customFields}
-              script={this.state.script}
             />
           </Dialog>
         </Form.Context>
@@ -157,26 +145,9 @@ ScriptList.propTypes = {
   scripts: PropTypes.arrayOf(PropTypes.object),
   subheader: PropTypes.element,
   onSelectCannedResponse: PropTypes.func,
+  onCreateCannedResponse: PropTypes.func,
   showAddScriptButton: PropTypes.bool,
-  customFields: PropTypes.array,
-  campaignId: PropTypes.number,
-  mutations: PropTypes.object,
-  texterId: PropTypes.number
+  customFields: PropTypes.array
 };
 
-const mapMutationsToProps = () => ({
-  createCannedResponse: cannedResponse => ({
-    mutation: gql`
-      mutation createCannedResponse($cannedResponse: CannedResponseInput!) {
-        createCannedResponse(cannedResponse: $cannedResponse) {
-          id
-        }
-      }
-    `,
-    variables: { cannedResponse }
-  })
-});
-
-export default connect({
-  mapMutationsToProps
-})(ScriptList);
+export default ScriptList;

--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -28,7 +28,8 @@ export default class GSScriptField extends GSFormField {
     event.preventDefault();
     this.setState(
       {
-        open: true
+        open: true,
+        script: this.props.value
       },
       () => this.refs.dialogScriptInput.focus()
     );
@@ -36,8 +37,7 @@ export default class GSScriptField extends GSFormField {
 
   handleCloseDialog = () => {
     this.setState({
-      open: false,
-      script: this.props.value
+      open: false
     });
   };
 
@@ -89,6 +89,9 @@ export default class GSScriptField extends GSFormField {
       <div>
         <TextField
           multiLine
+          onFocus={event => {
+            this.handleOpenDialog(event);
+          }}
           onTouchTap={event => {
             this.handleOpenDialog(event);
           }}

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -199,6 +199,15 @@ export class AssignmentTexterContact extends React.Component {
     this.setState({ questionResponses });
   };
 
+  handleCreateCannedResponse = async ({ cannedResponse }) => {
+    const saveObject = {
+      ...cannedResponse,
+      campaignId: this.props.campaign.id,
+      userId: this.props.texter.id
+    };
+    await this.mutations.createCannedResponse(saveObject);
+  };
+
   handleSubmitSurveys = async () => {
     const { contact } = this.props;
     if (!this.state.questionResponses) {
@@ -368,6 +377,7 @@ export class AssignmentTexterContact extends React.Component {
           onMessageFormSubmit={this.handleMessageFormSubmit}
           onOptOut={this.handleOptOut}
           onQuestionResponseChange={this.handleQuestionResponseChange}
+          onCreateCannedResponse={this.handleCreateCannedResponse}
           onExitTexter={this.props.onExitTexter}
           onEditStatus={this.handleEditStatus}
           getMessageTextFromScript={this.getMessageTextFromScript}

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -5,6 +5,7 @@ import ContactToolbar from "../components/ContactToolbar";
 import MessageList from "../components/MessageList";
 import CannedResponseMenu from "../components/CannedResponseMenu";
 import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";
+import AssignmentTexterContactControls from "../components/AssignmentTexterContactControls";
 import RaisedButton from "material-ui/RaisedButton";
 import FlatButton from "material-ui/FlatButton";
 import NavigateHomeIcon from "material-ui/svg-icons/action/home";
@@ -40,27 +41,6 @@ import { dataTest } from "../lib/attributes";
 import { getContactTimezone } from "../lib/timezones";
 
 const styles = StyleSheet.create({
-  mobile: {
-    "@media(min-width: 425px)": {
-      display: "none !important"
-    }
-  },
-  desktop: {
-    "@media(max-width: 450px)": {
-      display: "none !important"
-    }
-  },
-  container: {
-    margin: 0,
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    display: "flex",
-    flexDirection: "column",
-    height: "100%"
-  },
   overlay: {
     margin: 0,
     display: "flex",
@@ -75,106 +55,10 @@ const styles = StyleSheet.create({
     backgroundColor: "black",
     color: "white",
     zIndex: 1000000
-  },
-  optOutCard: {
-    "@media(max-width: 320px)": {
-      padding: "2px 10px !important"
-    },
-    zIndex: 2000,
-    backgroundColor: "white"
-  },
-  messageForm: {
-    backgroundColor: "red"
-  },
-  loadingIndicator: {
-    maxWidth: "50%"
-  },
-  navigationToolbarTitle: {
-    fontSize: "14px",
-    fontWeight: "bold",
-    position: "relative",
-    top: 5
-  },
-  topFixedSection: {
-    flex: "0 0 auto"
-  },
-  middleScrollingSection: {
-    flex: "1 1 auto",
-    overflowY: "scroll",
-    overflow: "-moz-scrollbars-vertical"
-  },
-  bottomFixedSection: {
-    borderTop: `1px solid ${grey100}`,
-    flex: "0 0 auto",
-    marginBottom: "none"
-  },
-  messageField: {
-    padding: "0px 8px",
-    "@media(max-width: 450px)": {
-      marginBottom: "8%"
-    }
-  },
-  textField: {
-    "@media(max-width: 350px)": {
-      overflowY: "scroll !important"
-    }
-  },
-  dialogActions: {
-    marginTop: 20,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  lgMobileToolBar: {
-    "@media(max-width: 449px) and (min-width: 300px)": {
-      display: "inline-block"
-    },
-    "@media(max-width: 320px) and (min-width: 300px)": {
-      marginLeft: "-30px !important"
-    }
   }
 });
 
 const inlineStyles = {
-  mobileToolBar: {
-    position: "absolute",
-    bottom: "-5"
-  },
-  mobileCannedReplies: {
-    "@media(max-width: 450px)": {
-      marginBottom: "1"
-    }
-  },
-  dialogButton: {
-    display: "inline-block"
-  },
-  exitTexterIconButton: {
-    float: "right",
-    height: "50px",
-    zIndex: 100,
-    position: "absolute",
-    top: 0,
-    right: "-30"
-  },
-  toolbarIconButton: {
-    position: "absolute",
-    top: 0
-    // without this the toolbar icons are not centered vertically
-  },
-  actionToolbar: {
-    backgroundColor: "white",
-    "@media(min-width: 450px)": {
-      marginBottom: 5
-    },
-    "@media(max-width: 450px)": {
-      marginBottom: 50
-    }
-  },
-
-  actionToolbarFirst: {
-    backgroundColor: "white"
-  },
-
   snackbar: {
     zIndex: 1000001
   }
@@ -186,10 +70,6 @@ export class AssignmentTexterContact extends React.Component {
 
     const { assignment, campaign } = this.props;
     const { contact } = this.props;
-    const questionResponses = this.getInitialQuestionResponses(
-      contact.questionResponseValues
-    );
-    const availableSteps = this.getAvailableInteractionSteps(questionResponses);
 
     let disabled = false;
     let disabledText = "Sending...";
@@ -215,21 +95,11 @@ export class AssignmentTexterContact extends React.Component {
       disabled,
       disabledText,
       // this prevents jitter by not showing the optout/skip buttons right after sending
-      justSentNew: false,
-      questionResponses,
       snackbarError,
       snackbarActionTitle,
-      snackbarOnTouchTap,
-      optOutMessageText: campaign.organization.optOutMessage,
-      responsePopoverOpen: false,
-      messageText: this.getStartingMessageText(),
-      optOutDialogOpen: false,
-      currentInteractionStep:
-        availableSteps.length > 0
-          ? availableSteps[availableSteps.length - 1]
-          : null
+      snackbarOnTouchTap
     };
-    this.onEnter = this.onEnter.bind(this);
+
     this.setDisabled = this.setDisabled.bind(this);
   }
 
@@ -243,76 +113,13 @@ export class AssignmentTexterContact extends React.Component {
         this.setState({ disabled: false });
       }, 1500);
     }
-
-    const node = this.refs.messageScrollContainer;
-    // Does not work without this setTimeout
-    setTimeout(() => {
-      node.scrollTop = Math.floor(node.scrollHeight);
-    }, 0);
-
-    // note: key*down* is necessary to stop propagation of keyup for the textarea element
-    document.body.addEventListener("keydown", this.onEnter);
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener("keydown", this.onEnter);
-  }
-
-  onEnter(evt) {
-    if (evt.keyCode === 13) {
-      evt.preventDefault();
-      // pressing the Enter key submits
-      if (this.state.optOutDialogOpen) {
-        this.handleOptOut();
-      } else {
-        this.handleClickSendMessageButton();
-      }
-    }
   }
 
   setDisabled = async (disabled = true) => {
     this.setState({ disabled });
   };
 
-  getAvailableInteractionSteps(questionResponses) {
-    const allInteractionSteps = this.props.campaign.interactionSteps;
-    const availableSteps = [];
-
-    let step = getTopMostParent(allInteractionSteps);
-
-    while (step) {
-      availableSteps.push(step);
-      const questionResponseValue = questionResponses[step.id];
-      if (questionResponseValue) {
-        const matchingAnswerOption = step.question.answerOptions.find(
-          answerOption => answerOption.value === questionResponseValue
-        );
-        if (matchingAnswerOption && matchingAnswerOption.nextInteractionStep) {
-          step = interactionStepForId(
-            matchingAnswerOption.nextInteractionStep.id,
-            allInteractionSteps
-          );
-        } else {
-          step = null;
-        }
-      } else {
-        step = null;
-      }
-    }
-
-    return availableSteps;
-  }
-
-  getInitialQuestionResponses(questionResponseValues) {
-    const questionResponses = {};
-    questionResponseValues.forEach(questionResponse => {
-      questionResponses[questionResponse.interactionStepId] =
-        questionResponse.value;
-    });
-
-    return questionResponses;
-  }
-  getMessageTextFromScript(script) {
+  getMessageTextFromScript = script => {
     const { campaign, contact, texter } = this.props;
 
     return script
@@ -323,34 +130,6 @@ export class AssignmentTexterContact extends React.Component {
           customFields: campaign.customFields
         })
       : null;
-  }
-
-  getStartingMessageText() {
-    const { contact, campaign } = this.props;
-    const { messages } = contact;
-    return messages.length > 0
-      ? ""
-      : this.getMessageTextFromScript(
-          getTopMostParent(campaign.interactionSteps).script
-        );
-  }
-
-  handleOpenPopover = event => {
-    event.preventDefault();
-    this.setState({
-      responsePopoverAnchorEl: event.currentTarget,
-      responsePopoverOpen: true
-    });
-  };
-
-  handleClosePopover = () => {
-    this.setState({
-      responsePopoverOpen: false
-    });
-  };
-
-  handleCannedResponseChange = cannedResponseScript => {
-    this.handleChangeScript(cannedResponseScript);
   };
 
   createMessageToContact(text) {
@@ -416,8 +195,15 @@ export class AssignmentTexterContact extends React.Component {
     }
   };
 
+  handleQuestionResponseChange = ({ questionResponses }) => {
+    this.setState({ questionResponses });
+  };
+
   handleSubmitSurveys = async () => {
     const { contact } = this.props;
+    if (!this.state.questionResponses) {
+      return; // no state change
+    }
 
     const deletionIds = [];
     const questionResponseObjects = [];
@@ -453,22 +239,19 @@ export class AssignmentTexterContact extends React.Component {
     }
   };
 
-  handleClickCloseContactButton = async () => {
-    await this.handleSubmitSurveys();
-    await this.handleEditMessageStatus("closed");
-    this.props.onFinishContact();
-  };
-
-  handleEditMessageStatus = async messageStatus => {
+  handleEditStatus = async (messageStatus, finishContact) => {
     const { contact } = this.props;
     await this.props.mutations.editCampaignContactMessageStatus(
       messageStatus,
       contact.id
     );
+    if (finishContact) {
+      await this.handleSubmitSurveys();
+      this.props.onFinishContact();
+    }
   };
 
-  handleOptOut = async () => {
-    const optOutMessageText = this.state.optOutMessageText;
+  handleOptOut = async ({ optOutMessageText }) => {
     const { contact } = this.props;
     const { assignment } = this.props;
     const message = this.createMessageToContact(optOutMessageText);
@@ -491,55 +274,6 @@ export class AssignmentTexterContact extends React.Component {
       this.props.onFinishContact(contact.id);
     } catch (e) {
       this.handleSendMessageError(e);
-    }
-  };
-
-  handleOpenDialog = () => {
-    this.setState({ optOutDialogOpen: true });
-  };
-
-  handleCloseDialog = () => {
-    this.setState({ optOutDialogOpen: false });
-  };
-
-  handleChangeScript = newScript => {
-    const messageText = this.getMessageTextFromScript(newScript);
-
-    this.setState({
-      messageText
-    });
-  };
-
-  handleQuestionResponseChange = ({
-    interactionStep,
-    questionResponseValue,
-    nextScript
-  }) => {
-    const { questionResponses } = this.state;
-    const { interactionSteps } = this.props.campaign;
-    questionResponses[interactionStep.id] = questionResponseValue;
-
-    const children = getChildren(interactionStep, interactionSteps);
-    for (const childStep of children) {
-      if (childStep.id in questionResponses) {
-        questionResponses[childStep.id] = null;
-      }
-    }
-
-    this.setState(
-      {
-        questionResponses
-      },
-      () => {
-        this.handleChangeScript(nextScript);
-      }
-    );
-  };
-
-  handleClickSendMessageButton = () => {
-    this.refs.form.submit();
-    if (this.props.contact.messageStatus === "needsMessage") {
-      this.setState({ justSentNew: true });
     }
   };
 
@@ -612,323 +346,6 @@ export class AssignmentTexterContact extends React.Component {
       .max(window.MAX_MESSAGE_LENGTH)
   });
 
-  handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
-
-  renderMiddleScrollingSection() {
-    const { contact } = this.props;
-    return <MessageList contact={contact} messages={contact.messages} />;
-  }
-
-  renderSurveySection() {
-    const { contact } = this.props;
-    const { messages } = contact;
-
-    const { questionResponses } = this.state;
-
-    const availableInteractionSteps = this.getAvailableInteractionSteps(
-      questionResponses
-    );
-
-    return messages.length === 0 ? (
-      <Empty
-        title={"This is your first message to " + contact.firstName}
-        icon={<CreateIcon color="rgb(83, 180, 119)" />}
-        hideMobile
-      />
-    ) : (
-      <div>
-        <AssignmentTexterSurveys
-          contact={contact}
-          interactionSteps={availableInteractionSteps}
-          onQuestionResponseChange={this.handleQuestionResponseChange}
-          currentInteractionStep={this.state.currentInteractionStep}
-          questionResponses={questionResponses}
-        />
-      </div>
-    );
-  }
-
-  renderNeedsResponseToggleButton(contact) {
-    const { messageStatus } = contact;
-    let button = null;
-    if (messageStatus === "closed") {
-      button = (
-        <RaisedButton
-          onTouchTap={() => this.handleEditMessageStatus("needsResponse")}
-          label="Reopen"
-        />
-      );
-    } else if (messageStatus === "needsResponse") {
-      button = (
-        <RaisedButton
-          onTouchTap={this.handleClickCloseContactButton}
-          label="Skip Reply"
-        />
-      );
-    }
-
-    return button;
-  }
-
-  renderActionToolbar() {
-    const {
-      contact,
-      campaign,
-      assignment,
-      navigationToolbarChildren,
-      onFinishContact
-    } = this.props;
-    const { justSentNew } = this.state;
-    const { messageStatus } = contact;
-    const size = document.documentElement.clientWidth;
-
-    if (messageStatus === "needsMessage" || justSentNew) {
-      return (
-        <div>
-          <Toolbar style={inlineStyles.actionToolbarFirst}>
-            <ToolbarGroup firstChild>
-              <SendButton
-                threeClickEnabled={campaign.organization.threeClickEnabled}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.state.disabled}
-              />
-              {window.NOT_IN_USA &&
-              window.ALLOW_SEND_ALL &&
-              window.BULK_SEND_CHUNK_SIZE ? (
-                <BulkSendButton
-                  assignment={assignment}
-                  onFinishContact={onFinishContact}
-                  bulkSendMessages={this.bulkSendMessages}
-                  setDisabled={this.setDisabled}
-                />
-              ) : (
-                ""
-              )}
-              <div style={{ float: "right", marginLeft: 20 }}>
-                {navigationToolbarChildren}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    } else if (size < 450) {
-      // for needsResponse or messaged or convo
-      return (
-        <div>
-          <Toolbar
-            className={css(styles.mobile)}
-            style={inlineStyles.actionToolbar}
-          >
-            <ToolbarGroup
-              style={inlineStyles.mobileToolBar}
-              className={css(styles.lgMobileToolBar)}
-              firstChild
-            >
-              <RaisedButton
-                {...dataTest("optOut")}
-                secondary
-                label="Opt out"
-                onTouchTap={this.handleOpenDialog}
-                tooltip="Opt out this contact"
-              />
-              <RaisedButton
-                style={inlineStyles.mobileCannedReplies}
-                label="Canned replies"
-                onTouchTap={this.handleOpenPopover}
-              />
-              {this.renderNeedsResponseToggleButton(contact)}
-              <div style={{ float: "right", marginLeft: "-30px" }}>
-                {navigationToolbarChildren}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    } else if (size >= 768) {
-      // for needsResponse or messaged
-      return (
-        <div>
-          <Toolbar style={inlineStyles.actionToolbarFirst}>
-            <ToolbarGroup firstChild>
-              <SendButton
-                threeClickEnabled={campaign.organization.threeClickEnabled}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.state.disabled}
-              />
-              {this.renderNeedsResponseToggleButton(contact)}
-              <RaisedButton
-                label="Other responses"
-                onTouchTap={this.handleOpenPopover}
-              />
-              <RaisedButton
-                {...dataTest("optOut")}
-                secondary
-                label="Opt out"
-                onTouchTap={this.handleOpenDialog}
-                tooltip="Opt out this contact"
-                tooltipPosition="top-center"
-              />
-              <div style={{ float: "right", marginLeft: 20 }}>
-                {navigationToolbarChildren}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    }
-    return "";
-  }
-
-  renderTopFixedSection() {
-    const { contact } = this.props;
-    return (
-      <ContactToolbar
-        campaign={this.props.campaign}
-        campaignContact={contact}
-        onOptOut={this.handleNavigateNext}
-        rightToolbarIcon={
-          <IconButton
-            onTouchTap={this.props.onExitTexter}
-            style={inlineStyles.exitTexterIconButton}
-            tooltip="Return Home"
-            tooltipPosition="bottom-center"
-          >
-            <NavigateHomeIcon />
-          </IconButton>
-        }
-      />
-    );
-  }
-
-  renderCannedResponsePopover() {
-    const { campaign, assignment, texter } = this.props;
-    const { userCannedResponses, campaignCannedResponses } = assignment;
-
-    return (
-      <CannedResponseMenu
-        onRequestClose={this.handleClosePopover}
-        open={this.state.responsePopoverOpen}
-        anchorEl={this.state.responsePopoverAnchorEl}
-        campaignCannedResponses={campaignCannedResponses}
-        userCannedResponses={userCannedResponses}
-        customFields={campaign.customFields}
-        campaignId={campaign.id}
-        texterId={texter.id}
-        onSelectCannedResponse={this.handleCannedResponseChange}
-      />
-    );
-  }
-
-  renderOptOutDialog() {
-    if (!this.state.optOutDialogOpen) {
-      return "";
-    }
-    return (
-      <Card>
-        <CardTitle className={css(styles.optOutCard)} title="Opt out user" />
-        <Divider />
-        <CardActions className={css(styles.optOutCard)}>
-          <GSForm
-            className={css(styles.optOutCard)}
-            schema={this.optOutSchema}
-            onChange={({ optOutMessageText }) =>
-              this.setState({ optOutMessageText })
-            }
-            value={{ optOutMessageText: this.state.optOutMessageText }}
-            onSubmit={this.handleOptOut}
-          >
-            <Form.Field
-              name="optOutMessageText"
-              fullWidth
-              autoFocus
-              multiLine
-            />
-            <div className={css(styles.dialogActions)}>
-              <FlatButton
-                style={inlineStyles.dialogButton}
-                label="Cancel"
-                onTouchTap={this.handleCloseDialog}
-              />
-              <Form.Button
-                type="submit"
-                style={inlineStyles.dialogButton}
-                component={GSSubmitButton}
-                label={
-                  this.state.optOutMessageText.length
-                    ? "Send"
-                    : "Opt Out without Text"
-                }
-              />
-            </div>
-          </GSForm>
-        </CardActions>
-      </Card>
-    );
-  }
-
-  renderCorrectSendButton() {
-    const { campaign } = this.props;
-    const { contact } = this.props;
-    if (
-      contact.messageStatus === "messaged" ||
-      contact.messageStatus === "convo" ||
-      contact.messageStatus === "needsResponse"
-    ) {
-      return (
-        <SendButtonArrow
-          threeClickEnabled={campaign.organization.threeClickEnabled}
-          onFinalTouchTap={this.handleClickSendMessageButton}
-          disabled={this.state.disabled}
-        />
-      );
-    }
-    return null;
-  }
-
-  renderBottomFixedSection() {
-    const { optOutDialogOpen } = this.state;
-    const { contact } = this.props;
-    const { messageStatus } = contact;
-
-    const message = optOutDialogOpen ? (
-      ""
-    ) : (
-      <div className={css(styles.messageField)}>
-        <GSForm
-          ref="form"
-          schema={this.messageSchema}
-          value={{ messageText: this.state.messageText }}
-          onSubmit={this.handleMessageFormSubmit}
-          onChange={
-            messageStatus === "needsMessage" ? "" : this.handleMessageFormChange
-          }
-        >
-          <Form.Field
-            className={css(styles.textField)}
-            name="messageText"
-            label="Your message"
-            multiLine
-            fullWidth
-            rowsMax={6}
-          />
-          {this.renderCorrectSendButton()}
-        </GSForm>
-      </div>
-    );
-
-    return (
-      <div>
-        {this.renderSurveySection()}
-        <div>
-          {message}
-          {optOutDialogOpen ? "" : this.renderActionToolbar()}
-        </div>
-        {this.renderOptOutDialog()}
-        {this.renderCannedResponsePopover()}
-      </div>
-    );
-  }
-
   render() {
     return (
       <div>
@@ -940,28 +357,34 @@ export class AssignmentTexterContact extends React.Component {
         ) : (
           ""
         )}
-        <div
-          className={css(styles.container)}
-          style={
-            this.props.contact.messageStatus === "needsResponse"
-              ? { backgroundColor: "rgba(83, 180, 119, 0.25)" }
-              : {}
-          }
-        >
-          <div className={css(styles.topFixedSection)}>
-            {this.renderTopFixedSection()}
-          </div>
-          <div
-            {...dataTest("messageList")}
-            ref="messageScrollContainer"
-            className={css(styles.middleScrollingSection)}
-          >
-            {this.renderMiddleScrollingSection()}
-          </div>
-          <div className={css(styles.bottomFixedSection)}>
-            {this.renderBottomFixedSection()}
-          </div>
-        </div>
+        <AssignmentTexterContactControls
+          contact={this.props.contact}
+          campaign={this.props.campaign}
+          texter={this.props.texter}
+          assignment={this.props.assignment}
+          navigationToolbarChildren={this.props.navigationToolbarChildren}
+          messageStatusFilter={this.props.messageStatusFilter}
+          disabled={this.state.disabled}
+          onMessageFormSubmit={this.handleMessageFormSubmit}
+          onOptOut={this.handleOptOut}
+          onQuestionResponseChange={this.handleQuestionResponseChange}
+          onExitTexter={this.props.onExitTexter}
+          onEditStatus={this.handleEditStatus}
+          getMessageTextFromScript={this.getMessageTextFromScript}
+        />
+        {this.props.contact.messageStatus === "needsMessage" &&
+        window.NOT_IN_USA &&
+        window.ALLOW_SEND_ALL &&
+        window.BULK_SEND_CHUNK_SIZE ? (
+          <BulkSendButton
+            assignment={this.props.assignment}
+            onFinishContact={this.props.onFinishContact}
+            bulkSendMessages={this.bulkSendMessages}
+            setDisabled={this.setDisabled}
+          />
+        ) : (
+          ""
+        )}
         <Snackbar
           style={inlineStyles.snackbar}
           open={!!this.state.snackbarError}
@@ -979,12 +402,13 @@ AssignmentTexterContact.propTypes = {
   campaign: PropTypes.object,
   assignment: PropTypes.object,
   texter: PropTypes.object,
-  navigationToolbarChildren: PropTypes.array,
+  navigationToolbarChildren: PropTypes.object,
   onFinishContact: PropTypes.func,
   router: PropTypes.object,
   mutations: PropTypes.object,
   refreshData: PropTypes.func,
-  onExitTexter: PropTypes.func
+  onExitTexter: PropTypes.func,
+  messageStatusFilter: PropTypes.string
 };
 
 const mapMutationsToProps = () => ({
@@ -1007,6 +431,16 @@ const mapMutationsToProps = () => ({
       optOut,
       campaignContactId
     }
+  }),
+  createCannedResponse: cannedResponse => ({
+    mutation: gql`
+      mutation createCannedResponse($cannedResponse: CannedResponseInput!) {
+        createCannedResponse(cannedResponse: $cannedResponse) {
+          id
+        }
+      }
+    `,
+    variables: { cannedResponse }
   }),
   editCampaignContactMessageStatus: (messageStatus, campaignContactId) => ({
     mutation: gql`

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
 import AssignmentTexter from "../components/AssignmentTexter";
+import AssignmentTexterContact from "../containers/AssignmentTexterContact";
 import { withRouter } from "react-router";
 import loadData from "./hoc/load-data";
 import gql from "graphql-tag";
@@ -191,6 +192,8 @@ export class TexterTodo extends React.Component {
         getNewContacts={this.getNewContacts}
         onRefreshAssignmentContacts={this.refreshAssignmentContacts}
         organizationId={this.props.params.organizationId}
+        ChildComponent={AssignmentTexterContact}
+        messageStatusFilter={this.props.messageStatus}
       />
     );
   }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -27,6 +27,7 @@ export {
   getInteractionTree,
   sortInteractionSteps,
   interactionStepForId,
+  getAvailableInteractionSteps,
   getTopMostParent,
   getChildren,
   makeTree

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -130,3 +130,37 @@ export function assembleAnswerOptions(allInteractionSteps) {
   });
   return interactionStepsCopy;
 }
+
+export function getAvailableInteractionSteps(
+  questionResponses,
+  allInteractionSteps
+) {
+  // helper for the client
+  // questionResponses: key=interactionStepId:value=questionResponse.value
+  // interactionSteps: all interaction steps
+  const availableSteps = [];
+
+  let step = getTopMostParent(allInteractionSteps);
+
+  while (step) {
+    availableSteps.push(step);
+    const questionResponseValue = questionResponses[step.id];
+    if (questionResponseValue) {
+      const matchingAnswerOption = step.question.answerOptions.find(
+        answerOption => answerOption.value === questionResponseValue
+      );
+      if (matchingAnswerOption && matchingAnswerOption.nextInteractionStep) {
+        step = interactionStepForId(
+          matchingAnswerOption.nextInteractionStep.id,
+          allInteractionSteps
+        );
+      } else {
+        step = null;
+      }
+    } else {
+      step = null;
+    }
+  }
+
+  return availableSteps;
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -23,6 +23,10 @@ import Settings from "./containers/Settings";
 import UserEdit from "./containers/UserEdit";
 import TexterFaqs from "./components/TexterFrequentlyAskedQuestions";
 import FAQs from "./lib/faqs";
+import {
+  DemoTexterNeedsMessage,
+  DemoTexterNeedsResponse
+} from "./components/DemoTexterAssignment";
 
 export default function makeRoutes(requireAuth = () => {}) {
   return (
@@ -162,6 +166,22 @@ export default function makeRoutes(requireAuth = () => {}) {
         component={JoinTeam}
         onEnter={requireAuth}
       />
+      <Route path="demo" component={TexterDashboard}>
+        <Route
+          path="text"
+          components={{
+            main: props => <DemoTexterNeedsMessage {...props} />,
+            topNav: null
+          }}
+        />
+        <Route
+          path="reply"
+          components={{
+            main: props => <DemoTexterNeedsResponse {...props} />,
+            topNav: null
+          }}
+        />
+      </Route>
     </Route>
   );
 }


### PR DESCRIPTION
This is preliminary work in order to work on design changes for Texters.

## Description

This splits out the container/AssignmentTexterContact.jsx screen so that the container is responsible for the network requests and coordinating top-state (e.g. if contact is opted out then the whole page is disabled).  It moves the rest into components/AssignmentTexterContactControls.jsx
In addition:
* We abstract out the network-layers within TexterTodo.jsx stack, so that we can have purely static demo versions of texting.
* Then we create two new routes: /demo/text and /demo/reply which reproduce the new message screen and then the reply screen.
* While understanding the sub-elements used in AssignmentTexterContactControls some minor bugs were fixed for "Add new Canned Response"

The reason this is above 300 lines is:
* It's a huge delete/add when splitting out AssignmentTexterContact into AssignmentTexterContactControls
* the DemoTexterAssignment.js has many lines for test/demo data.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [na] My PR is labeled [WIP] if it is in progress
