### PR TITLE
[developer tools] Fix syntax error in .eslintrc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["airbnb", "prettier"]
+  "extends": ["airbnb", "prettier"],
   "parser": "babel-eslint",
   "env": { "jest": true, "node": true, "browser": true, "jasmine": true }
 }


### PR DESCRIPTION
## Description

A missing comma in `.eslintrc` caused eslint to not work.  I'm not sure if that was the case in all situations but it broke the vim ale plugin which was unpleasant.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
