### PR TITLE
remove superfluous indexes from campaign-contact

### DIFF
--- a/migrations/20190207220000_init_db.js
+++ b/migrations/20190207220000_init_db.js
@@ -148,7 +148,7 @@ const initialize = async (knex, Promise) => {
           .notNullable();
         t.boolean("is_opted_out").defaultTo(false);
         t.text("timezone_offset").defaultTo("");
-        if (isSqlite) {
+        if (!isSqlite) {
           t.index("assignment_id");
           t.foreign("assignment_id").references("assignment.id");
           t.index("campaign_id");

--- a/migrations/20190207220000_init_db.js
+++ b/migrations/20190207220000_init_db.js
@@ -148,11 +148,12 @@ const initialize = async (knex, Promise) => {
           .notNullable();
         t.boolean("is_opted_out").defaultTo(false);
         t.text("timezone_offset").defaultTo("");
-
-        t.index("assignment_id");
-        t.foreign("assignment_id").references("assignment.id");
-        t.index("campaign_id");
-        t.foreign("campaign_id").references("campaign.id");
+        if (isSqlite) {
+          t.index("assignment_id");
+          t.foreign("assignment_id").references("assignment.id");
+          t.index("campaign_id");
+          t.foreign("campaign_id").references("campaign.id");
+        }
         t.index("cell");
         t.index(
           ["campaign_id", "assignment_id"],

--- a/migrations/20200218220127_del_contact_xtraindexes.js
+++ b/migrations/20200218220127_del_contact_xtraindexes.js
@@ -1,0 +1,19 @@
+exports.up = function up(knex) {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  return knex.schema.alterTable("campaign_contact", table => {
+    if (!isSqlite) {
+      table.dropIndex("assignment_id");
+      table.dropIndex("campaign_id");
+    }
+  });
+};
+
+exports.down = function down(knex) {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  return knex.schema.alterTable("campaign_contact", table => {
+    if (!isSqlite) {
+      table.index("assignment_id");
+      table.index("campaign_id");
+    }
+  });
+};

--- a/src/server/models/campaign-contact.js
+++ b/src/server/models/campaign-contact.js
@@ -2,9 +2,6 @@ import thinky from "./thinky";
 const type = thinky.type;
 import { requiredString, optionalString, timestamp } from "./custom-types";
 
-import Campaign from "./campaign";
-import Assignment from "./assignment";
-
 const CampaignContact = thinky.createModel(
   "campaign_contact",
   type
@@ -45,11 +42,9 @@ const CampaignContact = thinky.createModel(
   { noAutoCreation: true }
 );
 
-// can we drop these with the lower two added?
-CampaignContact.ensureIndex("assignment_id");
-CampaignContact.ensureIndex("campaign_id");
-
+// for updating is_opted_out:
 CampaignContact.ensureIndex("cell");
+
 CampaignContact.ensureIndex("campaign_assignment", doc => [
   doc("campaign_id"),
   doc("assignment_id")


### PR DESCRIPTION
## Description

Reduces memory and write pressure in the database.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
