### PR TITLE
revert eslint on commit-hook because we have not eslint'd everything,…

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,9 +189,6 @@
     }
   },
   "lint-staged": {
-    "*.{js,jsx}": [
-      "eslint"
-    ],
     "*.{js,jsx,css,json}": [
       "prettier --write",
       "git add"


### PR DESCRIPTION
eslint is doing too much, and since we haven't pre-linted the files, this will cause too much churn in PRs. Let's eslint as separate PRs (doing no changes besides). Since eslints don't have a '--write' like prettier, this will be piece-meal work.