### PR TITLE
Contact loaders phase 2

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,5 @@
 {
-  "extends": ["airbnb", "prettier"]
+  "extends": ["airbnb", "prettier"],
   "parser": "babel-eslint",
   "env": { "jest": true, "node": true, "browser": true, "jasmine": true }
 }

--- a/__test__/integrations/contact-loaders/csv-upload.test.js
+++ b/__test__/integrations/contact-loaders/csv-upload.test.js
@@ -100,6 +100,7 @@ describe("ingest-contact-loader method: csv-upload backend", async () => {
     const job = {
       payload: await gzip(JSON.stringify({ contacts })),
       campaign_id: testCampaign.id,
+      job_type: "ingest.csv-upload",
       id: 1
     };
     await processContactLoad(job);
@@ -115,6 +116,7 @@ describe("ingest-contact-loader method: csv-upload backend", async () => {
     const job = {
       payload: await gzip(JSON.stringify({ contacts: dupeContacts })),
       campaign_id: testCampaign.id,
+      job_type: "ingest.csv-upload",
       id: 1
     };
     await processContactLoad(job);

--- a/__test__/integrations/contact-loaders/csv-upload.test.js
+++ b/__test__/integrations/contact-loaders/csv-upload.test.js
@@ -123,7 +123,13 @@ describe("ingest-contact-loader method: csv-upload backend", async () => {
     const dbContacts = await r
       .knex("campaign_contact")
       .where("campaign_id", testCampaign.id);
+    const adminResult = await r
+      .knex("campaign_admin")
+      .where("campaign_id", testCampaign.id)
+      .first();
     expect(dbContacts.length).toBe(1);
+    expect(adminResult.duplicate_contacts_count).toBe(1);
+    expect(adminResult.contacts_count).toBe(1);
     expect(dbContacts[0].first_name).toBe("fdsa");
     expect(dbContacts[0].last_name).toBe("yyyy");
     expect(dbContacts[0].custom_fields).toBe('{"custom1": "xyz"}');

--- a/docs/HOWTO-use-contact-loaders.md
+++ b/docs/HOWTO-use-contact-loaders.md
@@ -74,3 +74,34 @@ Then you'll want to implement `react-component.js`. This file is passed whatever
 `getClientChoiceData()` in the backend, along with some context for the component. It will be loaded
 when the campaign admin chooses your ingest method (set it first in the list of CONTACT_LOADERS env
 var to be listed first).
+
+### Using addServerEndpoints
+
+There are a couple use-cases for addServerEndpoints where you add extra url paths
+to the base Spoke application.  In all of these cases, it's important to be mindful of
+security -- it's a powerful option, but also a dangerous one.
+
+*Some use cases:*
+
+* Supporting asynchronous webhook apis (where e.g. processContactLoad sends a request for data and needs to set an endpoint where the other host sends the data back in)
+* Start campaign links triggered from a different web site
+* A side-channel for very interactive steps in the react component with an api.
+
+Start your paths with either `/int*` (for integration) or `/sign*` (for signup) --
+using these starting points will ensure that your endpoints will not (nor in the future)
+conflict with application endpoints.  Also try to include your contact-loader's name
+somewhere in the endpoints so different contact loaders are unlikely to collide.
+
+*Security*
+
+If the endpoint is connected used by a user, use `req.isAuthenticated()` and `req.user` to
+test permissions and login state.  If they are not logged-in, then
+<code>res.redirect(`/login?nextUrl=${encodeURIComponent(req.url)}`)</code> force a login and
+revisit.
+
+If the endpoint is connected to from another server, make sure you validate it in some way.
+If you cannot whitelist specific host names/ip-addresses, then try to use a shared secret.
+Ideally, you should be able to cheaply validate the request without making requests or
+database lookups.
+
+

--- a/migrations/20200220094840_campaign_admin_table.js
+++ b/migrations/20200220094840_campaign_admin_table.js
@@ -1,0 +1,29 @@
+exports.up = async function up(knex, Promise) {
+  if (!(await knex.schema.hasTable("campaign_admin"))) {
+    return knex.schema.createTable("campaign_admin", t => {
+      t.increments("id");
+      t.integer("campaign_id").notNullable();
+      t.text("ingest_method");
+      t.text("ingest_data_reference");
+      t.text("ingest_result");
+      t.boolean("ingest_success");
+      t.integer("contacts_count");
+      t.integer("deleted_optouts_count");
+      t.integer("duplicate_contacts_count");
+      t.timestamp("updated_at")
+        .notNullable()
+        .defaultTo(knex.fn.now());
+      t.timestamp("created_at")
+        .notNullable()
+        .defaultTo(knex.fn.now());
+
+      t.index("campaign_id");
+      t.foreign("campaign_id").references("campaign.id");
+    });
+  }
+  return Promise.resolve();
+};
+
+exports.down = function down(knex, Promise) {
+  return knex.schema.dropTableIfExists("campaign_admin");
+};

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -17,6 +17,13 @@ export const schema = `
     name: String!
     displayName: String
     clientChoiceData: String
+    success: Boolean
+    result: String
+    reference: String
+    contactsCount: Int
+    deletedOptouts: Int
+    deletedDupes: Int
+    updatedAt: Date
   }
 
   type JobRequest {

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -243,7 +243,10 @@ const rootSchema = gql`
       userId: String!
       inviteId: String!
     ): Organization
-    joinOrganization(organizationUuid: String!): Organization
+    joinOrganization(
+      organizationUuid: String!
+      queryParams: String
+    ): Organization
     editOrganizationRoles(
       organizationId: String!
       userId: String!
@@ -304,6 +307,7 @@ const rootSchema = gql`
     assignUserToCampaign(
       organizationUuid: String!
       campaignId: String!
+      queryParams: String
     ): Campaign
     userAgreeTerms(userId: String!): User
     reassignCampaignContacts(

--- a/src/components/CampaignContactsChoiceForm.jsx
+++ b/src/components/CampaignContactsChoiceForm.jsx
@@ -44,9 +44,17 @@ export default class CampaignContactsChoiceForm extends React.Component {
   };
 
   getCurrentMethod() {
-    const { ingestMethodChoices } = this.props;
-    if (this.state.ingestMethodIndex) {
+    const { ingestMethodChoices, pastIngestMethod } = this.props;
+    if (typeof this.state.ingestMethodIndex === "number") {
       return ingestMethodChoices[this.state.ingestMethodIndex];
+    } else if (pastIngestMethod && pastIngestMethod.name) {
+      const index = ingestMethodChoices.findIndex(
+        m => m.name === pastIngestMethod.name
+      );
+      if (index) {
+        // make sure it's available
+        return ingestMethodChoices[index];
+      }
     }
     return ingestMethodChoices[0];
   }
@@ -63,9 +71,13 @@ export default class CampaignContactsChoiceForm extends React.Component {
   }
 
   render() {
-    const { ingestMethodChoices } = this.props;
+    const { ingestMethodChoices, pastIngestMethod } = this.props;
     const ingestMethod = this.getCurrentMethod();
     const ingestMethodName = ingestMethod.name;
+    const lastResult =
+      pastIngestMethod && pastIngestMethod.name === ingestMethodName
+        ? pastIngestMethod
+        : null;
     const IngestComponent = components[ingestMethodName];
     return (
       <div>
@@ -127,6 +139,7 @@ export default class CampaignContactsChoiceForm extends React.Component {
             saveDisabled={this.props.saveDisabled}
             saveLabel={this.props.saveLabel}
             clientChoiceData={ingestMethod.clientChoiceData}
+            lastResult={lastResult}
             jobResultMessage={null}
           />
         </div>
@@ -147,5 +160,6 @@ CampaignContactsChoiceForm.propTypes = {
   saveLabel: type.string,
   jobResultMessage: type.string,
   ingestMethodChoices: type.array.isRequired,
+  pastIngestMethod: type.object,
   contactsCount: type.number
 };

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -70,7 +70,9 @@ class Login extends React.Component {
     this.setState({ active: e.target.name });
   };
 
-  naiveVerifyInviteValid = nextUrl =>
+  naiveVerifyInviteValid = (nextUrl, maybeSignup) =>
+    (/^\/int/.test(nextUrl) && !maybeSignup) || // integration urls
+    /^\/sign/.test(nextUrl) || // signup integration urls
     /\/\w{8}-(\w{4}\-){3}\w{12}(\/|$)/.test(nextUrl);
 
   render() {
@@ -91,7 +93,7 @@ class Login extends React.Component {
       nextUrl && (nextUrl.includes("join") || nextUrl.includes("invite"));
     let displaySignUp;
     if (inviteLink) {
-      displaySignUp = this.naiveVerifyInviteValid(nextUrl);
+      displaySignUp = this.naiveVerifyInviteValid(nextUrl, true);
     }
 
     const saveLabels = {

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -74,6 +74,7 @@ const campaignInfoFragment = `
   }
   ingestMethod {
     name
+    success
     result
     reference
     contactsCount

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -74,6 +74,12 @@ const campaignInfoFragment = `
   }
   ingestMethod {
     name
+    result
+    reference
+    contactsCount
+    deletedOptouts
+    deletedDupes
+    updatedAt
   }
   editors
 `;
@@ -321,6 +327,8 @@ class AdminCampaignEdit extends React.Component {
           contactsCount: this.props.campaignData.campaign.contactsCount,
           ingestMethodChoices:
             this.props.campaignData.campaign.ingestMethodsAvailable || "",
+          pastIngestMethod:
+            this.props.campaignData.campaign.ingestMethod || null,
           jobResultMessage:
             (
               this.props.pendingJobsData.campaign.pendingJobs.filter(job =>

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -29,6 +29,10 @@ const campaignInfoFragment = `
   creator {
     displayName
   }
+  ingestMethod {
+    success
+    contactsCount
+  }
 `;
 
 const inlineStyles = {
@@ -77,7 +81,8 @@ export class CampaignList extends React.Component {
       isStarted,
       isArchived,
       hasUnassignedContacts,
-      hasUnsentInitialMessages
+      hasUnsentInitialMessages,
+      ingestMethod
     } = campaign;
     const { adminPerms, selectMultiple } = this.props;
 
@@ -99,6 +104,10 @@ export class CampaignList extends React.Component {
     const tags = [];
     if (!isStarted) {
       tags.push("Not started");
+    }
+
+    if (ingestMethod && ingestMethod.success === false) {
+      tags.push("Contact loading failed");
     }
 
     if (hasUnassignedContacts) {
@@ -128,6 +137,9 @@ export class CampaignList extends React.Component {
           {dueByMoment.isValid()
             ? dueByMoment.format("MMM D, YYYY")
             : "No due date set"}
+          {ingestMethod && ingestMethod.contactsCount
+            ? ` - contacts: ${ingestMethod.contactsCount}`
+            : ""}
         </span>
       </span>
     );

--- a/src/containers/JoinTeam.jsx
+++ b/src/containers/JoinTeam.jsx
@@ -21,7 +21,9 @@ class JoinTeam extends React.Component {
     let organization = null;
     let campaign = null;
     try {
-      organization = await this.props.mutations.joinOrganization();
+      organization = await this.props.mutations.joinOrganization(
+        this.props.location.search
+      );
     } catch (ex) {
       this.setState({
         errors:
@@ -31,7 +33,9 @@ class JoinTeam extends React.Component {
 
     if (this.props.params.campaignId) {
       try {
-        campaign = await this.props.mutations.assignUserToCampaign();
+        campaign = await this.props.mutations.assignUserToCampaign(
+          this.props.location.search
+        );
       } catch (ex) {
         this.setState({
           errors:
@@ -59,29 +63,41 @@ class JoinTeam extends React.Component {
 
 JoinTeam.propTypes = {
   mutations: PropTypes.object,
-  router: PropTypes.object
+  router: PropTypes.object,
+  location: PropTypes.object
 };
 
 const mapMutationsToProps = ({ ownProps }) => ({
-  joinOrganization: () => ({
+  joinOrganization: queryParams => ({
     mutation: gql`
-      mutation joinOrganization($organizationUuid: String!) {
-        joinOrganization(organizationUuid: $organizationUuid) {
+      mutation joinOrganization(
+        $organizationUuid: String!
+        $queryParams: String
+      ) {
+        joinOrganization(
+          organizationUuid: $organizationUuid
+          queryParams: $queryParams
+        ) {
           id
         }
       }
     `,
-    variables: { organizationUuid: ownProps.params.organizationUuid }
+    variables: {
+      organizationUuid: ownProps.params.organizationUuid,
+      queryParams: queryParams
+    }
   }),
-  assignUserToCampaign: () => ({
+  assignUserToCampaign: queryParams => ({
     mutation: gql`
       mutation assignUserToCampaign(
         $organizationUuid: String!
         $campaignId: String!
+        $queryParams: String
       ) {
         assignUserToCampaign(
           organizationUuid: $organizationUuid
           campaignId: $campaignId
+          queryParams: $queryParams
         ) {
           id
         }
@@ -89,7 +105,8 @@ const mapMutationsToProps = ({ ownProps }) => ({
     `,
     variables: {
       campaignId: ownProps.params.campaignId,
-      organizationUuid: ownProps.params.organizationUuid
+      organizationUuid: ownProps.params.organizationUuid,
+      queryParams: queryParams
     }
   })
 });

--- a/src/integrations/contact-loaders/csv-upload/index.js
+++ b/src/integrations/contact-loaders/csv-upload/index.js
@@ -2,7 +2,7 @@ import { completeContactLoad } from "../../../workers/jobs";
 import { r, CampaignContact } from "../../../server/models";
 import { getConfig, hasConfig } from "../../../server/api/lib/config";
 
-import { updateJob } from "../../../lib";
+import { updateJob } from "../../../workers/lib";
 import { getTimezoneByZip, unzipPayload } from "../../../workers/jobs";
 
 export const name = "csv-upload";
@@ -119,6 +119,9 @@ export async function processContactLoad(job, maxContacts) {
     datum.campaign_id = campaignId;
   }
   for (let index = 0; index < numChunks; index++) {
+    await updateJob(job, Math.round((100 / numChunks) * index)).catch(err => {
+      console.error("Error updating job:", campaignId, job.id, err);
+    });
     const savePortion = contacts.slice(
       index * chunkSize,
       (index + 1) * chunkSize

--- a/src/integrations/contact-loaders/test-fakedata/react-component.js
+++ b/src/integrations/contact-loaders/test-fakedata/react-component.js
@@ -19,7 +19,14 @@ export class CampaignContactsForm extends React.Component {
   };
 
   render() {
-    const { clientChoiceData } = this.props;
+    const { clientChoiceData, lastResult } = this.props;
+    let resultMessage = "";
+    if (lastResult && lastResult.result) {
+      const { message, finalCount } = JSON.parse(lastResult.result);
+      resultMessage = message
+        ? message
+        : `Final count was ${finalCount} when you chose ${lastResult.reference}`;
+    }
     return (
       <GSForm
         schema={yup.object({
@@ -48,9 +55,9 @@ export class CampaignContactsForm extends React.Component {
             primaryText={clientChoiceData}
             leftIcon={this.props.icons.check}
           />
-          {this.props.jobResultMessage ? (
+          {resultMessage ? (
             <ListItem
-              primaryText={this.props.jobResultMessage}
+              primaryText={resultMessage}
               leftIcon={this.props.icons.warning}
             />
           ) : null}
@@ -77,5 +84,6 @@ CampaignContactsForm.propTypes = {
   saveLabel: type.string,
 
   clientChoiceData: type.string,
-  jobResultMessage: type.string
+  jobResultMessage: type.string,
+  lastResult: type.object
 };

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -53,6 +53,11 @@ export function buildCampaignQuery(
   }
 
   query = query.where("campaign.organization_id", organizationId);
+  query = query.leftJoin(
+    "campaign_admin",
+    "campaign_admin.campaign_id",
+    "campaign.id"
+  );
   query = addCampaignsFilterToQuery(query, campaignsFilter);
 
   return query;
@@ -60,7 +65,11 @@ export function buildCampaignQuery(
 
 export async function getCampaigns(organizationId, cursor, campaignsFilter) {
   let campaignsQuery = buildCampaignQuery(
-    r.knex.select("*"),
+    r.knex.select(
+      "campaign.*",
+      "campaign_admin.contacts_count",
+      "campaign_admin.ingest_success"
+    ),
     organizationId,
     campaignsFilter
   );
@@ -241,10 +250,37 @@ export const resolvers = {
       );
     },
     ingestMethod: async (campaign, _, { user, loaders }) => {
-      // FUTURE: which ingestMethod was used and status
-      // try { ... for SUPERVOLUNTEER
-      // await accessRequired(user, campaign.organization_id, "ADMIN", true);
-      return null;
+      try {
+        await accessRequired(user, campaign.organization_id, "ADMIN", true);
+      } catch (err) {
+        return null; // for SUPERVOLUNTEERS
+      }
+      if (campaign.hasOwnProperty("contacts_count")) {
+        return {
+          contactsCount: campaign.contacts_count,
+          success: campaign.ingest_success || null
+        };
+      }
+
+      const status =
+        campaign.campaignAdmin ||
+        (await r
+          .knex("campaign_admin")
+          .where("campaign_id", campaign.id)
+          .first());
+      if (!status || !status.ingest_method) {
+        return null;
+      }
+      return {
+        name: status.ingest_method,
+        success: status.ingest_success,
+        result: status.ingest_result,
+        reference: status.ingest_data_reference,
+        contactsCount: status.contacts_count,
+        deletedOptouts: status.deleted_optouts_count,
+        deletedDupes: status.duplicate_contacts_count,
+        updatedAt: status.updated_at ? new Date(status.updated_at) : null
+      };
     },
     texters: async (campaign, _, { user }) => {
       await accessRequired(

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -642,6 +642,9 @@ const rootMutations = {
         is_archived: false
       });
       const newCampaign = await campaignInstance.save();
+      await r.knex("campaign_admin").insert({
+        campaign_id: newCampaign.id
+      });
       const newCampaignId = newCampaign.id;
       const oldCampaignId = campaign.id;
 

--- a/src/server/middleware/app-renderer.jsx
+++ b/src/server/middleware/app-renderer.jsx
@@ -43,9 +43,12 @@ export default wrap(async (req, res) => {
   const store = new Store(memoryHistory);
   const history = syncHistoryWithStore(memoryHistory, store.data);
   const authCheck = (nextState, replace) => {
+    const query = nextState.location.search
+      ? encodeURIComponent(nextState.location.search)
+      : "";
     if (!req.isAuthenticated()) {
       replace({
-        pathname: `/login?nextUrl=${nextState.location.pathname}`
+        pathname: `/login?nextUrl=${nextState.location.pathname}${query}`
       });
     }
   };

--- a/src/server/models/campaign-admin.js
+++ b/src/server/models/campaign-admin.js
@@ -1,0 +1,28 @@
+import thinky from "./thinky";
+const type = thinky.type;
+import { optionalString, requiredString, timestamp } from "./custom-types";
+
+const CampaignAdmin = thinky.createModel(
+  "campaign_admin",
+  type
+    .object()
+    .schema({
+      id: type.string(),
+      campaign_id: requiredString(),
+      ingest_method: optionalString(),
+      ingest_data_reference: optionalString(),
+      ingest_result: optionalString(),
+      ingest_success: type.boolean(),
+      contacts_count: type.number().integer(),
+      deleted_optouts_count: type.number().integer(),
+      duplicate_contacts_count: type.number().integer(),
+      updated_at: timestamp(),
+      created_at: timestamp()
+    })
+    .allowExtra(false),
+  { noAutoCreation: true }
+);
+
+CampaignAdmin.ensureIndex("campaign_id");
+
+export default CampaignAdmin;

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -5,6 +5,7 @@ import User from "./user";
 import PendingMessagePart from "./pending-message-part";
 import Organization from "./organization";
 import Campaign from "./campaign";
+import CampaignAdmin from "./campaign-admin";
 import Assignment from "./assignment";
 import CampaignContact from "./campaign-contact";
 import InteractionStep from "./interaction-step";
@@ -43,6 +44,7 @@ const tableList = [
   "organization", // good candidate?
   "user", // good candidate
   "campaign", // good candidate
+  "campaign_admin",
   "assignment",
   // the rest are alphabetical
   "campaign_contact", // ?good candidate (or by cell)
@@ -120,6 +122,7 @@ export {
   datawarehouse,
   Assignment,
   Campaign,
+  CampaignAdmin,
   CampaignContact,
   InteractionStep,
   Invite,


### PR DESCRIPTION
# Enhance contact-loaders for persistence and some api/integration use-cases

## Description

* keep track of last ingestMethod and its success/counts
* pass through url query parameters when logging in and signing up to allow for interesting endpoint integrations (e.g. VAN => creating a campaign immediately and loading the contacts in the same step)
* contacts count on completion is displayed on the Campaign List page 
![spoke_contactscampaignlist](https://user-images.githubusercontent.com/52117/74991752-e4a02100-5414-11ea-94a9-fd0d0cbab068.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
