### PR TITLE
Fix send button alignment

### DIFF
--- a/src/components/SendButton.jsx
+++ b/src/components/SendButton.jsx
@@ -10,7 +10,6 @@ const styles = StyleSheet.create({
   container: {
     display: "inline-block",
     marginLeft: 24,
-    marginBottom: 10
   }
 });
 class SendButton extends Component {


### PR DESCRIPTION
# Fixes #1399 

## Description

Removes extraneous margin that was making the send button misaligned.

![image](https://user-images.githubusercontent.com/3174006/75220898-66fe4d00-5755-11ea-9c01-0625ca6c9fb4.png)


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
