### PR TITLE
Experimental new texter UI

### DIFF
--- a/src/components/AssignmentTexterContactControls.jsx
+++ b/src/components/AssignmentTexterContactControls.jsx
@@ -333,7 +333,7 @@ export class AssignmentTexterContactControls extends React.Component {
     );
   }
 
-  renderNeedsResponseToggleButton(contact) {
+  renderNeedsResponseToggleButton(contact, messageStatusFilter) {
     const { messageStatus } = contact;
     let button = null;
     if (messageStatus === "closed") {
@@ -343,7 +343,7 @@ export class AssignmentTexterContactControls extends React.Component {
           label="Reopen"
         />
       );
-    } else if (messageStatus === "needsResponse") {
+    } else if (messageStatusFilter === "needsResponse") {
       button = (
         <RaisedButton
           onTouchTap={() => this.props.onEditStatus("closed", true)}
@@ -366,7 +366,12 @@ export class AssignmentTexterContactControls extends React.Component {
     } = this.props;
     const { messageStatus } = contact;
     const size = document.documentElement.clientWidth;
-
+    console.log(
+      "renderActionToolbar",
+      messageStatusFilter,
+      messageStatus,
+      contact
+    );
     let navigationToolbar = [];
     if (navigationToolbarChildren) {
       const { onNext, onPrevious, title } = navigationToolbarChildren;
@@ -427,7 +432,10 @@ export class AssignmentTexterContactControls extends React.Component {
                 label="Canned replies"
                 onTouchTap={this.handleOpenPopover}
               />
-              {this.renderNeedsResponseToggleButton(contact)}
+              {this.renderNeedsResponseToggleButton(
+                contact,
+                messageStatusFilter
+              )}
               <div style={{ float: "right", marginLeft: "-30px" }}>
                 {navigationToolbar}
               </div>
@@ -446,7 +454,10 @@ export class AssignmentTexterContactControls extends React.Component {
                 onFinalTouchTap={this.handleClickSendMessageButton}
                 disabled={this.props.disabled}
               />
-              {this.renderNeedsResponseToggleButton(contact)}
+              {this.renderNeedsResponseToggleButton(
+                contact,
+                messageStatusFilter
+              )}
               <RaisedButton
                 label="Other responses"
                 onTouchTap={this.handleOpenPopover}

--- a/src/components/AssignmentTexterContactControls.jsx
+++ b/src/components/AssignmentTexterContactControls.jsx
@@ -212,7 +212,10 @@ export class AssignmentTexterContactControls extends React.Component {
     if (evt.keyCode === 13) {
       evt.preventDefault();
       // pressing the Enter key submits
-      if (!this.state.optOutDialogOpen) {
+      if (this.state.optOutDialogOpen) {
+        const { optOutMessageText } = this.state;
+        this.props.onOptOut({ optOutMessageText });
+      } else {
         this.handleClickSendMessageButton();
       }
     }

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -39,75 +39,8 @@ import CreateIcon from "material-ui/svg-icons/content/create";
 import { dataTest } from "../lib/attributes";
 import { getContactTimezone } from "../lib/timezones";
 
-const styles = StyleSheet.create({
-  mobile: {
-    "@media(min-width: 425px)": {
-      display: "none !important"
-    }
-  },
-  desktop: {
-    "@media(max-width: 450px)": {
-      display: "none !important"
-    }
-  },
-  container: {
-    margin: 0,
-    position: "absolute",
-    top: 0,
-    bottom: 0,
-    left: 0,
-    right: 0,
-    display: "flex",
-    flexDirection: "column",
-    height: "100%"
-  },
-  optOutCard: {
-    "@media(max-width: 320px)": {
-      padding: "2px 10px !important"
-    },
-    zIndex: 2000,
-    backgroundColor: "white"
-  },
-  messageForm: {
-    backgroundColor: "red"
-  },
-  loadingIndicator: {
-    maxWidth: "50%"
-  },
-  navigationToolbarTitle: {
-    fontSize: "12px"
-  },
-  topFixedSection: {
-    flex: "0 0 auto"
-  },
-  middleScrollingSection: {
-    flex: "1 1 auto",
-    overflowY: "scroll",
-    overflow: "-moz-scrollbars-vertical",
-    overflowX: "hidden"
-  },
-  textField: {
-    "@media(max-width: 350px)": {
-      overflowY: "scroll !important"
-    }
-  },
-  dialogActions: {
-    marginTop: 20,
-    display: "flex",
-    flexDirection: "row",
-    justifyContent: "flex-end"
-  },
-  lgMobileToolBar: {
-    "@media(max-width: 449px) and (min-width: 300px)": {
-      display: "inline-block"
-    },
-    "@media(max-width: 320px) and (min-width: 300px)": {
-      marginLeft: "-30px !important"
-    }
-  }
-});
-
 const inlineStyles = {
+  // passed to MessageList whole
   mobileToolBar: {
     position: "absolute",
     bottom: "-5"
@@ -116,9 +49,6 @@ const inlineStyles = {
     "@media(max-width: 450px)": {
       marginBottom: "1"
     }
-  },
-  dialogButton: {
-    display: "inline-block"
   },
   exitTexterIconButton: {
     float: "left",
@@ -181,12 +111,22 @@ const inlineStyles = {
 };
 
 const flexStyles = StyleSheet.create({
-  sectionHeaderToolbar: {
-    // see ContactToolbarNew component
+  topContainer: {
+    margin: 0,
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: "flex",
+    flexDirection: "column",
+    height: "100%"
   },
-  /// * Section Scrolling Message Thread
+  sectionHeaderToolbar: {
+    flex: "0 0 auto"
+  },
+  /// * Section Scroll3ing Message Thread
   sectionMessageThread: {
-    // middleScrollingSection: {
     flex: "1 1 auto",
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical",
@@ -194,7 +134,20 @@ const flexStyles = StyleSheet.create({
   },
   /// * Section OptOut Dialog
   sectionOptOutDialog: {
-    // uses Card default
+    "@media(max-width: 320px)": {
+      padding: "2px 10px !important"
+    },
+    zIndex: 2000,
+    backgroundColor: "white"
+  },
+  subSectionOptOutDialogActions: {
+    marginTop: 20,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  subSubSectionOptOutDialogActionButton: {
+    display: "inline-block"
   },
   /// * Section Texting Input Field
   sectionMessageField: {
@@ -202,6 +155,11 @@ const flexStyles = StyleSheet.create({
     flex: "2 0 20px",
     padding: "0px 4px",
     marginBottom: "8px"
+  },
+  subSectionMessageFieldTextField: {
+    "@media(max-width: 350px)": {
+      overflowY: "scroll !important"
+    }
   },
   /// * Section Reply/Exit Buttons
   sectionButtons: {
@@ -302,6 +260,7 @@ export class AssignmentTexterContactControls extends React.Component {
       questionResponses,
       props.campaign.interactionSteps
     );
+    console.log("availableSteps", availableSteps);
     this.state = {
       questionResponses,
       optOutMessageText: props.campaign.organization.optOutMessage,
@@ -309,6 +268,7 @@ export class AssignmentTexterContactControls extends React.Component {
       messageText: this.getStartingMessageText(),
       optOutDialogOpen: false,
       messageFocus: false,
+      availableSteps: availableSteps,
       currentInteractionStep:
         availableSteps.length > 0
           ? availableSteps[availableSteps.length - 1]
@@ -394,9 +354,16 @@ export class AssignmentTexterContactControls extends React.Component {
       }
     }
 
+    const availableSteps = getAvailableInteractionSteps(
+      questionResponses,
+      interactionSteps
+    );
+    // TODO sky: ? do we sometimes need to update state.currentInteractionStep?
+    // it doesn't seem to be able to change if we clear a response
     this.setState(
       {
-        questionResponses
+        questionResponses,
+        availableSteps
       },
       () => {
         this.handleChangeScript(nextScript);
@@ -505,11 +472,14 @@ export class AssignmentTexterContactControls extends React.Component {
     }
     return (
       <Card>
-        <CardTitle className={css(styles.optOutCard)} title="Opt out user" />
+        <CardTitle
+          className={css(flexStyles.sectionOptOutDialog)}
+          title="Opt out user"
+        />
         <Divider />
-        <CardActions className={css(styles.optOutCard)}>
+        <CardActions className={css(flexStyles.sectionOptOutDialog)}>
           <GSForm
-            className={css(styles.optOutCard)}
+            className={css(flexStyles.sectionOptOutDialog)}
             schema={this.optOutSchema}
             onChange={({ optOutMessageText }) =>
               this.setState({ optOutMessageText })
@@ -523,15 +493,19 @@ export class AssignmentTexterContactControls extends React.Component {
               autoFocus
               multiLine
             />
-            <div className={css(styles.dialogActions)}>
+            <div className={css(flexStyles.subSectionOptOutDialogActions)}>
               <FlatButton
-                style={inlineStyles.dialogButton}
+                className={css(
+                  flexStyles.subSubSectionOptOutDialogActionButton
+                )}
                 label="Cancel"
                 onTouchTap={this.handleCloseDialog}
               />
               <Form.Button
                 type="submit"
-                style={inlineStyles.dialogButton}
+                className={css(
+                  flexStyles.subSubSectionOptOutDialogActionButton
+                )}
                 component={GSSubmitButton}
                 label={
                   this.state.optOutMessageText.length
@@ -549,7 +523,7 @@ export class AssignmentTexterContactControls extends React.Component {
   renderMessageSending() {
     console.log("renderMessageSending", this.props);
     const { contact, messageStatusFilter } = this.props;
-    const { optOutDialogOpen } = this.state;
+    const { optOutDialogOpen, availableSteps } = this.state;
     const firstMessage = messageStatusFilter === "needsMessage";
 
     const message = (
@@ -562,7 +536,7 @@ export class AssignmentTexterContactControls extends React.Component {
           onChange={firstMessage ? "" : this.handleMessageFormChange}
         >
           <Form.Field
-            className={css(styles.textField)}
+            className={css(flexStyles.subSectionMessageFieldTextField)}
             name="messageText"
             label="Your message"
             onFocus={() => {
@@ -580,13 +554,16 @@ export class AssignmentTexterContactControls extends React.Component {
     );
 
     const sendButtonHeight = firstMessage ? "40%" : "36px";
-    const currentQuestion = "Do you believe in love?";
+    const currentQuestion =
+      this.state.currentInteractionStep &&
+      this.state.currentInteractionStep.question &&
+      this.state.currentInteractionStep.question.text;
     console.log(
       "REFS renderMessageSending return",
       message,
       this.refs.answerButtons && this.refs.answerButtons.offsetHeight
     );
-    const quickButtonSpace =
+    const shortcutButtonSpace =
       this.refs.answerButtons &&
       // 114=25(top q)+40(main btns)+40(xtra row)+9px(padding)
       this.refs.answerButtons.offsetHeight >= 105;
@@ -609,7 +586,7 @@ export class AssignmentTexterContactControls extends React.Component {
             ) : null}
             <div
               className={css(flexStyles.subSubAnswerButtonsColumns)}
-              style={quickButtonSpace ? { height: "89px" } : null}
+              style={shortcutButtonSpace ? { height: "89px" } : null}
             >
               <FlatButton
                 label={
@@ -623,7 +600,10 @@ export class AssignmentTexterContactControls extends React.Component {
                 onTouchTap={this.handleOpenPopover}
                 className={css(flexStyles.flatButton)}
                 labelStyle={inlineStyles.flatButtonLabel}
-                backgroundColor="white"
+                backgroundColor={
+                  availableSteps.length ? "white" : "rgb(176, 176, 176)"
+                }
+                disabled={!availableSteps.length}
               />
               <div
                 style={{
@@ -655,7 +635,7 @@ export class AssignmentTexterContactControls extends React.Component {
               style={{
                 float: "right",
                 marginRight: "18px",
-                height: quickButtonSpace ? "89px" : "42px"
+                height: shortcutButtonSpace ? "89px" : "42px"
               }}
             >
               <FlatButton
@@ -735,8 +715,8 @@ export class AssignmentTexterContactControls extends React.Component {
     const { optOutDialogOpen } = this.state;
     console.log("AssignmentTexterContactNewControls", this.props);
     return (
-      <div className={css(styles.container)}>
-        <div className={css(styles.topFixedSection)}>
+      <div className={css(flexStyles.topContainer)}>
+        <div className={css(flexStyles.sectionHeaderToolbar)}>
           <ContactToolbarNew
             campaign={this.props.campaign}
             campaignContact={this.props.contact}
@@ -756,7 +736,7 @@ export class AssignmentTexterContactControls extends React.Component {
         <div
           {...dataTest("messageList")}
           ref="messageScrollContainer"
-          className={css(styles.middleScrollingSection)}
+          className={css(flexStyles.sectionMessageThread)}
         >
           <MessageList
             contact={this.props.contact}

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -291,7 +291,10 @@ export class AssignmentTexterContactControls extends React.Component {
     if (evt.keyCode === 13) {
       evt.preventDefault();
       // pressing the Enter key submits
-      if (!this.state.optOutDialogOpen) {
+      if (this.state.optOutDialogOpen) {
+        const { optOutMessageText } = this.state;
+        this.props.onOptOut({ optOutMessageText });
+      } else {
         this.handleClickSendMessageButton();
       }
     }

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -1,0 +1,786 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { StyleSheet, css } from "aphrodite";
+import ContactToolbarNew from "../components/ContactToolbarNew";
+import MessageList from "../components/MessageList";
+import CannedResponseMenu from "../components/CannedResponseMenu";
+import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";
+import RaisedButton from "material-ui/RaisedButton";
+import FlatButton from "material-ui/FlatButton";
+import NavigateHomeIcon from "material-ui/svg-icons/action/home";
+import NavigateBeforeIcon from "material-ui/svg-icons/image/navigate-before";
+import NavigateNextIcon from "material-ui/svg-icons/image/navigate-next";
+import { grey100 } from "material-ui/styles/colors";
+import IconButton from "material-ui/IconButton/IconButton";
+import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
+import { Card, CardActions, CardTitle } from "material-ui/Card";
+import Divider from "material-ui/Divider";
+import gql from "graphql-tag";
+import yup from "yup";
+import GSForm from "../components/forms/GSForm";
+import Form from "react-formal";
+import GSSubmitButton from "../components/forms/GSSubmitButton";
+import SendButton from "../components/SendButton";
+import SendButtonArrow from "../components/SendButtonArrow";
+import CircularProgress from "material-ui/CircularProgress";
+import Snackbar from "material-ui/Snackbar";
+import {
+  getChildren,
+  getAvailableInteractionSteps,
+  getTopMostParent,
+  interactionStepForId,
+  log,
+  isBetweenTextingHours
+} from "../lib";
+import Empty from "../components/Empty";
+import CreateIcon from "material-ui/svg-icons/content/create";
+import { dataTest } from "../lib/attributes";
+import { getContactTimezone } from "../lib/timezones";
+
+const styles = StyleSheet.create({
+  mobile: {
+    "@media(min-width: 425px)": {
+      display: "none !important"
+    }
+  },
+  desktop: {
+    "@media(max-width: 450px)": {
+      display: "none !important"
+    }
+  },
+  container: {
+    margin: 0,
+    position: "absolute",
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    display: "flex",
+    flexDirection: "column",
+    height: "100%"
+  },
+  optOutCard: {
+    "@media(max-width: 320px)": {
+      padding: "2px 10px !important"
+    },
+    zIndex: 2000,
+    backgroundColor: "white"
+  },
+  messageForm: {
+    backgroundColor: "red"
+  },
+  loadingIndicator: {
+    maxWidth: "50%"
+  },
+  navigationToolbarTitle: {
+    fontSize: "12px"
+  },
+  topFixedSection: {
+    flex: "0 0 auto"
+  },
+  middleScrollingSection: {
+    flex: "1 1 auto",
+    overflowY: "scroll",
+    overflow: "-moz-scrollbars-vertical",
+    overflowX: "hidden"
+  },
+  bottomFixedSection: {
+    borderTop: `1px solid ${grey100}`,
+    flex: "1 0 auto",
+    marginBottom: "none"
+  },
+  messageField: {
+    flex: "2 0 20px",
+    padding: "0px 4px",
+    marginBottom: "8px"
+  },
+  textField: {
+    "@media(max-width: 350px)": {
+      overflowY: "scroll !important"
+    }
+  },
+  dialogActions: {
+    marginTop: 20,
+    display: "flex",
+    flexDirection: "row",
+    justifyContent: "flex-end"
+  },
+  lgMobileToolBar: {
+    "@media(max-width: 449px) and (min-width: 300px)": {
+      display: "inline-block"
+    },
+    "@media(max-width: 320px) and (min-width: 300px)": {
+      marginLeft: "-30px !important"
+    }
+  }
+});
+
+const inlineStyles = {
+  mobileToolBar: {
+    position: "absolute",
+    bottom: "-5"
+  },
+  mobileCannedReplies: {
+    "@media(max-width: 450px)": {
+      marginBottom: "1"
+    }
+  },
+  dialogButton: {
+    display: "inline-block"
+  },
+  exitTexterIconButton: {
+    float: "left",
+    height: "56px",
+    zIndex: 100,
+    top: 0,
+    left: "-20"
+  },
+  toolbarIconButton: {
+    position: "absolute",
+    top: 0
+    // without this the toolbar icons are not centered vertically
+  },
+  actionToolbar: {
+    backgroundColor: "white",
+    "@media(min-width: 450px)": {
+      marginBottom: 5
+    },
+    "@media(max-width: 450px)": {
+      marginBottom: 50
+    }
+  },
+  actionToolbarFirst: {
+    backgroundColor: "white"
+  },
+  messageList: {
+    backgroundColor: "#f0f0f0",
+    flex: "2 4 auto",
+    overflowY: "scroll",
+    overflow: "-moz-scrollbars-vertical",
+    overflowX: "hidden"
+  },
+  messageSent: {
+    textAlign: "right",
+    marginLeft: "30%",
+    backgroundColor: "#009D52",
+    color: "white",
+    borderRadius: "16px",
+    fontWeight: "600",
+    marginBottom: "10px",
+    fontSize: "13px"
+  },
+  messageReceived: {
+    fontSize: "13px",
+    marginRight: "30%",
+    backgroundColor: "white",
+    borderRadius: "16px",
+    fontWeight: "600",
+    fontSize: "105%",
+    marginBottom: "10px"
+  }
+};
+
+export class AssignmentTexterContactControls extends React.Component {
+  constructor(props) {
+    super(props);
+
+    const questionResponses = {};
+    // initial values
+    props.contact.questionResponseValues.forEach(questionResponse => {
+      questionResponses[questionResponse.interactionStepId] =
+        questionResponse.value;
+    });
+    const availableSteps = getAvailableInteractionSteps(
+      questionResponses,
+      props.campaign.interactionSteps
+    );
+    this.state = {
+      questionResponses,
+      optOutMessageText: props.campaign.organization.optOutMessage,
+      responsePopoverOpen: false,
+      messageText: this.getStartingMessageText(),
+      optOutDialogOpen: false,
+      messageFocus: false,
+      currentInteractionStep:
+        availableSteps.length > 0
+          ? availableSteps[availableSteps.length - 1]
+          : null
+    };
+  }
+
+  componentDidMount() {
+    const node = this.refs.messageScrollContainer;
+    // Does not work without this setTimeout
+    setTimeout(() => {
+      node.scrollTop = Math.floor(node.scrollHeight);
+    }, 0);
+
+    // note: key*down* is necessary to stop propagation of keyup for the textarea element
+    document.body.addEventListener("keydown", this.onEnter);
+  }
+
+  componentWillUnmount() {
+    document.body.removeEventListener("keydown", this.onEnter);
+  }
+
+  getStartingMessageText() {
+    const { campaign, messageStatusFilter } = this.props;
+    return messageStatusFilter === "needsMessage"
+      ? this.props.getMessageTextFromScript(
+          getTopMostParent(campaign.interactionSteps).script
+        )
+      : "";
+  }
+
+  onEnter = evt => {
+    // FUTURE: consider disabling except in needsMessage
+    if (evt.keyCode === 13) {
+      evt.preventDefault();
+      // pressing the Enter key submits
+      if (!this.state.optOutDialogOpen) {
+        this.handleClickSendMessageButton();
+      }
+    }
+  };
+
+  optOutSchema = yup.object({
+    optOutMessageText: yup.string()
+  });
+
+  messageSchema = yup.object({
+    messageText: yup
+      .string()
+      .required("Can't send empty message")
+      .max(window.MAX_MESSAGE_LENGTH)
+  });
+
+  handleClickSendMessageButton = () => {
+    this.refs.form.submit();
+  };
+
+  handleCannedResponseChange = cannedResponseScript => {
+    this.handleChangeScript(cannedResponseScript);
+  };
+
+  handleOpenDialog = () => {
+    this.setState({ optOutDialogOpen: true });
+  };
+
+  handleCloseDialog = () => {
+    this.setState({ optOutDialogOpen: false });
+  };
+
+  handleQuestionResponseChange = ({
+    interactionStep,
+    questionResponseValue,
+    nextScript
+  }) => {
+    const { questionResponses } = this.state;
+    const { interactionSteps } = this.props.campaign;
+    questionResponses[interactionStep.id] = questionResponseValue;
+
+    const children = getChildren(interactionStep, interactionSteps);
+    for (const childStep of children) {
+      if (childStep.id in questionResponses) {
+        questionResponses[childStep.id] = null;
+      }
+    }
+
+    this.setState(
+      {
+        questionResponses
+      },
+      () => {
+        this.handleChangeScript(nextScript);
+        // a bit odd, but we need to update the parent context's state as well
+        // this is because responses are sent to the server on many other actions
+        // so any of those can trigger a question response update
+        this.props.onQuestionResponseChange({ questionResponses });
+      }
+    );
+  };
+
+  handleChangeScript = newScript => {
+    const messageText = this.props.getMessageTextFromScript(newScript);
+
+    this.setState({
+      messageText
+    });
+  };
+
+  handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
+
+  handleOpenPopover = event => {
+    event.preventDefault();
+    this.setState({
+      responsePopoverAnchorEl: event.currentTarget,
+      responsePopoverOpen: true
+    });
+  };
+
+  handleClosePopover = () => {
+    this.setState({
+      responsePopoverOpen: false
+    });
+  };
+
+  renderMiddleScrollingSection() {
+    const { contact } = this.props;
+    return (
+      <MessageList
+        contact={contact}
+        messages={contact.messages}
+        styles={inlineStyles}
+      />
+    );
+  }
+
+  renderSurveySection() {
+    const { campaign, contact } = this.props;
+    const { questionResponses } = this.state;
+    const { messages } = contact;
+
+    const availableInteractionSteps = getAvailableInteractionSteps(
+      questionResponses,
+      campaign.interactionSteps
+    );
+
+    return messages.length === 0 ? (
+      <Empty
+        title={"This is your first message to " + contact.firstName}
+        icon={<CreateIcon color="rgb(83, 180, 119)" />}
+        hideMobile
+      />
+    ) : (
+      <div>
+        <AssignmentTexterSurveys
+          contact={contact}
+          interactionSteps={availableInteractionSteps}
+          onQuestionResponseChange={this.handleQuestionResponseChange}
+          currentInteractionStep={this.state.currentInteractionStep}
+          questionResponses={questionResponses}
+        />
+      </div>
+    );
+  }
+
+  renderNeedsResponseToggleButton(contact) {
+    const { messageStatus } = contact;
+    let button = null;
+    if (messageStatus === "closed") {
+      button = (
+        <RaisedButton
+          onTouchTap={() => this.props.onEditStatus("needsResponse")}
+          label="Reopen"
+        />
+      );
+    } else if (messageStatus === "needsResponse") {
+      button = (
+        <RaisedButton
+          onTouchTap={() => this.props.onEditStatus("closed", true)}
+          label="Skip"
+        />
+      );
+    }
+
+    return button;
+  }
+
+  renderActionToolbar() {
+    const {
+      contact,
+      campaign,
+      assignment,
+      navigationToolbarChildren,
+      onFinishContact,
+      messageStatusFilter
+    } = this.props;
+    const { messageStatus } = contact;
+    const size = document.documentElement.clientWidth;
+
+    let navigationToolbar = [];
+    if (navigationToolbarChildren) {
+      const { onNext, onPrevious, title } = navigationToolbarChildren;
+
+      navigationToolbar = [
+        <ToolbarTitle
+          className={css(styles.navigationToolbarTitle)}
+          text={title}
+        />,
+        <IconButton onTouchTap={onPrevious} disabled={!onPrevious}>
+          <NavigateBeforeIcon />
+        </IconButton>,
+        <IconButton onTouchTap={onNext} disabled={!onNext}>
+          <NavigateNextIcon />
+        </IconButton>
+      ];
+    }
+
+    if (messageStatusFilter === "needsMessage") {
+      return (
+        <div>
+          <Toolbar style={inlineStyles.actionToolbarFirst}>
+            <ToolbarGroup firstChild>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.props.disabled}
+              />
+              <div style={{ float: "right", marginLeft: 20 }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    } else if (size < 450) {
+      // for needsResponse or messaged or convo
+      return (
+        <div>
+          <Toolbar
+            className={css(styles.mobile)}
+            style={inlineStyles.actionToolbar}
+          >
+            <ToolbarGroup
+              style={inlineStyles.mobileToolBar}
+              className={css(styles.lgMobileToolBar)}
+              firstChild
+            >
+              <RaisedButton
+                {...dataTest("optOut")}
+                secondary
+                label="Opt out"
+                onTouchTap={this.handleOpenDialog}
+                tooltip="Opt out this contact"
+              />
+              <RaisedButton
+                style={inlineStyles.mobileCannedReplies}
+                label="Canned replies"
+                onTouchTap={this.handleOpenPopover}
+              />
+              {this.renderNeedsResponseToggleButton(contact)}
+              <div style={{ float: "right", marginLeft: "-30px" }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    } else if (size >= 768) {
+      // for needsResponse or messaged
+      return (
+        <div>
+          <Toolbar style={inlineStyles.actionToolbarFirst}>
+            <ToolbarGroup firstChild>
+              <SendButton
+                threeClickEnabled={false}
+                onFinalTouchTap={this.handleClickSendMessageButton}
+                disabled={this.props.disabled}
+              />
+              {this.renderNeedsResponseToggleButton(contact)}
+              <RaisedButton
+                label="Other responses"
+                onTouchTap={this.handleOpenPopover}
+              />
+              <RaisedButton
+                {...dataTest("optOut")}
+                secondary
+                label="Opt out"
+                onTouchTap={this.handleOpenDialog}
+                tooltip="Opt out this contact"
+                tooltipPosition="top-center"
+              />
+              <div style={{ float: "right", marginLeft: 20 }}>
+                {navigationToolbar}
+              </div>
+            </ToolbarGroup>
+          </Toolbar>
+        </div>
+      );
+    }
+    return "";
+  }
+
+  renderTopFixedSection() {
+    const { contact } = this.props;
+    return (
+      <ContactToolbarNew
+        campaign={this.props.campaign}
+        campaignContact={contact}
+        navigationToolbarChildren={this.props.navigationToolbarChildren}
+        leftToolbarIcon={
+          <IconButton
+            onTouchTap={this.props.onExitTexter}
+            style={inlineStyles.exitTexterIconButton}
+            tooltip="Return Home"
+            tooltipPosition="bottom-center"
+          >
+            <NavigateHomeIcon color={"white"} />
+          </IconButton>
+        }
+      />
+    );
+  }
+
+  renderCannedResponsePopover() {
+    const { campaign, assignment, texter } = this.props;
+    const { userCannedResponses, campaignCannedResponses } = assignment;
+
+    return (
+      <CannedResponseMenu
+        onRequestClose={this.handleClosePopover}
+        open={this.state.responsePopoverOpen}
+        anchorEl={this.state.responsePopoverAnchorEl}
+        campaignCannedResponses={campaignCannedResponses}
+        userCannedResponses={userCannedResponses}
+        customFields={campaign.customFields}
+        onSelectCannedResponse={this.handleCannedResponseChange}
+        onCreateCannedResponse={this.props.onCreateCannedResponse}
+      />
+    );
+  }
+
+  renderOptOutDialog() {
+    if (!this.state.optOutDialogOpen) {
+      return "";
+    }
+    return (
+      <Card>
+        <CardTitle className={css(styles.optOutCard)} title="Opt out user" />
+        <Divider />
+        <CardActions className={css(styles.optOutCard)}>
+          <GSForm
+            className={css(styles.optOutCard)}
+            schema={this.optOutSchema}
+            onChange={({ optOutMessageText }) =>
+              this.setState({ optOutMessageText })
+            }
+            value={{ optOutMessageText: this.state.optOutMessageText }}
+            onSubmit={this.props.onOptOut}
+          >
+            <Form.Field
+              name="optOutMessageText"
+              fullWidth
+              autoFocus
+              multiLine
+            />
+            <div className={css(styles.dialogActions)}>
+              <FlatButton
+                style={inlineStyles.dialogButton}
+                label="Cancel"
+                onTouchTap={this.handleCloseDialog}
+              />
+              <Form.Button
+                type="submit"
+                style={inlineStyles.dialogButton}
+                component={GSSubmitButton}
+                label={
+                  this.state.optOutMessageText.length
+                    ? "Send"
+                    : "Opt Out without Text"
+                }
+              />
+            </div>
+          </GSForm>
+        </CardActions>
+      </Card>
+    );
+  }
+
+  renderCorrectSendButton() {
+    const { campaign } = this.props;
+    const { contact } = this.props;
+    if (
+      contact.messageStatus === "messaged" ||
+      contact.messageStatus === "convo" ||
+      contact.messageStatus === "needsResponse"
+    ) {
+      return (
+        <SendButtonArrow
+          threeClickEnabled={false}
+          onFinalTouchTap={this.handleClickSendMessageButton}
+          disabled={this.props.disabled}
+        />
+      );
+    }
+    return null;
+  }
+
+  renderBottomFixedSection() {
+    const { optOutDialogOpen } = this.state;
+    /*
+        {this.renderSurveySection()}
+        <div>
+          {message}
+          { ? "" : this.renderActionToolbar()}
+        </div>
+        {
+        {this.renderCannedResponsePopover()}
+        {this.renderCorrectSendButton()}
+    */
+
+    return optOutDialogOpen ? (
+      this.renderOptOutDialog()
+    ) : (
+      <div style={wrapper}></div>
+    );
+  }
+
+  render() {
+    console.log("AssignmentTexterContactNewControls", this.props);
+    const { messageStatusFilter } = this.props;
+    const { optOutDialogOpen } = this.state;
+    const message = (
+      <div className={css(styles.messageField)}>
+        <GSForm
+          ref="form"
+          schema={this.messageSchema}
+          value={{ messageText: this.state.messageText }}
+          onSubmit={this.props.onMessageFormSubmit}
+          onChange={
+            messageStatusFilter === "needsMessage"
+              ? ""
+              : this.handleMessageFormChange
+          }
+        >
+          <Form.Field
+            className={css(styles.textField)}
+            name="messageText"
+            label="Your message"
+            onFocus={() => {
+              this.setState({ messageFocus: true });
+            }}
+            onBlur={() => {
+              this.setState({ messageFocus: false });
+            }}
+            multiLine
+            fullWidth
+            rowsMax={6}
+          />
+        </GSForm>
+      </div>
+    );
+    const wrapper = {
+      display: "flex",
+      flexDirection: "column",
+      alignItems: "stretch",
+      alignContent: "stretch"
+    };
+    const buttons = {
+      flex: "4 1 auto", // stretches and shrinks more quickly than message
+      display: "flex",
+      flexWrap: "wrap",
+      overflow: "hidden",
+      position: "relative"
+    };
+    const button1 = {
+      height: "30px",
+      border: "1px solid black",
+      padding: "3px"
+    };
+    const firstMessage = messageStatusFilter === "needsMessage";
+    const sendButtonHeight = firstMessage ? "40%" : "36px";
+    const sendButtonWrapper = {
+      flex: `0 0 ${sendButtonHeight}`,
+      height: sendButtonHeight,
+      padding: "12px"
+    };
+
+    const sendButton = {
+      width: "100%",
+      height: "100%"
+    };
+    return (
+      <div
+        className={css(styles.container)}
+        style={
+          this.props.contact.messageStatus === "needsResponse"
+            ? { backgroundColor: "rgba(83, 180, 119, 0.25)" }
+            : {}
+        }
+      >
+        <div className={css(styles.topFixedSection)}>
+          {this.renderTopFixedSection()}
+        </div>
+        {this.renderMiddleScrollingSection()}
+        {optOutDialogOpen
+          ? this.renderOptOutDialog()
+          : [
+              message,
+              firstMessage ? null : (
+                <div style={buttons}>
+                  Question: []
+                  <div style={button1}>Question Answered</div>
+                  <div style={button1}>Other Responses</div>
+                  <div style={button1}>Left</div>
+                  <div style={button1}>Opt-Out</div>
+                  <div style={button1}>Right</div>
+                  <div style={button1}>Skip</div>
+                  <div style={{ position: "absolute" }}>
+                    <div style={button1}>Question Answered</div>
+                    <div style={button1}>Other Responses</div>
+                    <div style={button1}>Left</div>
+                    <div style={button1}>Skip</div>
+                    <div style={button1}>Opt-Out</div>
+                    <div style={button1}>Right</div>
+                    <div style={button1}>Question Answered</div>
+                    <div style={button1}>Other Responses</div>
+                    <div style={button1}>Left</div>
+                    <div style={button1}>Skip</div>
+                    <div style={button1}>Opt-Out</div>
+                    <div style={button1}>Right</div>
+                    <div style={button1}>Question Answered</div>
+                    <div style={button1}>Other Responses</div>
+                    <div style={button1}>Left</div>
+                    <div style={button1}>Skip</div>
+                    <div style={button1}>Opt-Out</div>
+                    <div style={button1}>Right</div>
+                  </div>
+                </div>
+              ),
+              <div style={sendButtonWrapper}>
+                <RaisedButton
+                  {...dataTest("send")}
+                  onTouchTap={this.handleClickSendMessageButton}
+                  disabled={this.props.disabled}
+                  label={"Send"}
+                  style={sendButton}
+                  primary
+                />
+              </div>
+            ]}
+      </div>
+    );
+  }
+}
+/*
+        <div className={css(styles.bottomFixedSection)}>
+          {this.renderBottomFixedSection()}
+        </div>
+
+*/
+
+AssignmentTexterContactControls.propTypes = {
+  // data
+  contact: PropTypes.object,
+  campaign: PropTypes.object,
+  assignment: PropTypes.object,
+  texter: PropTypes.object,
+
+  // parent state
+  disabled: PropTypes.bool,
+  navigationToolbarChildren: PropTypes.object,
+  messageStatusFilter: PropTypes.string,
+
+  // parent config/callbacks
+  startingMessage: PropTypes.string,
+  onMessageFormSubmit: PropTypes.func,
+  onOptOut: PropTypes.func,
+  onQuestionResponseChange: PropTypes.func,
+  onCreateCannedResponse: PropTypes.func,
+  onExitTexter: PropTypes.func,
+  onEditStatus: PropTypes.func,
+  getMessageTextFromScript: PropTypes.func
+};
+
+export default AssignmentTexterContactControls;

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -8,25 +8,16 @@ import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";
 import RaisedButton from "material-ui/RaisedButton";
 import FlatButton from "material-ui/FlatButton";
 import NavigateHomeIcon from "material-ui/svg-icons/action/home";
-import NavigateBeforeIcon from "material-ui/svg-icons/image/navigate-before";
-import NavigateNextIcon from "material-ui/svg-icons/image/navigate-next";
 import ArrowBackIcon from "material-ui/svg-icons/navigation/arrow-back";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
-import { grey100 } from "material-ui/styles/colors";
 import IconButton from "material-ui/IconButton/IconButton";
-import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
 import { Card, CardActions, CardTitle } from "material-ui/Card";
 import Divider from "material-ui/Divider";
-import gql from "graphql-tag";
 import yup from "yup";
 import GSForm from "../components/forms/GSForm";
 import Form from "react-formal";
-import GSSubmitButton from "../components/forms/GSSubmitButton";
-import SendButton from "../components/SendButton";
-import SendButtonArrow from "../components/SendButtonArrow";
-import CircularProgress from "material-ui/CircularProgress";
 import Popover from "material-ui/Popover";
-import Snackbar from "material-ui/Snackbar";
+
 import {
   getChildren,
   getAvailableInteractionSteps,
@@ -35,15 +26,12 @@ import {
   log,
   isBetweenTextingHours
 } from "../lib";
-import Empty from "../components/Empty";
-import CreateIcon from "material-ui/svg-icons/content/create";
+
 import { dataTest } from "../lib/attributes";
-import { getContactTimezone } from "../lib/timezones";
 
 const messageListStyles = {
   // passesd directly to <MessageList>
   messageList: {
-    backgroundColor: "#f0f0f0",
     flex: "2 4 auto",
     overflow: "hidden",
     overflow: "-moz-scrollbars-vertical"
@@ -108,10 +96,11 @@ const flexStyles = StyleSheet.create({
   },
   /// * Section Scrolling Message Thread
   sectionMessageThread: {
-    flex: "1 4 auto",
+    flex: "1 2 auto",
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical",
-    overflowX: "hidden"
+    overflowX: "hidden",
+    backgroundColor: "#f0f0f0"
   },
   /// * Section OptOut Dialog
   sectionOptOutDialog: {
@@ -128,7 +117,7 @@ const flexStyles = StyleSheet.create({
   /// * Section Texting Input Field
   sectionMessageField: {
     // messageField
-    flex: "2 0 20px",
+    flex: "1 0 20px",
     padding: "0px 4px",
     marginBottom: "8px"
   },
@@ -146,7 +135,7 @@ const flexStyles = StyleSheet.create({
     "@media(min-height: 600px)": {
       flexBasis: "190px"
     },
-    flexGrow: "4",
+    flexGrow: "0",
     flexShrink: "0",
     // flexBasis: ${130px|190px}", // stretches and shrinks more quickly than message
     flexDirection: "column",
@@ -511,7 +500,10 @@ export class AssignmentTexterContactControls extends React.Component {
               this.setState({ optOutMessageText })
             }
             value={{ optOutMessageText: this.state.optOutMessageText }}
-            onSubmit={this.props.onOptOut}
+            onSubmit={obj => {
+              console.log("Optout submit", obj);
+              this.props.onOptOut(obj);
+            }}
           >
             <div
               style={{
@@ -576,7 +568,6 @@ export class AssignmentTexterContactControls extends React.Component {
               />
               <FlatButton
                 type="submit"
-                onTouchTap={this.props.onOptOut}
                 className={css(flexStyles.flatButton)}
                 labelStyle={inlineStyles.flatButtonLabel}
                 style={{

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -10,6 +10,8 @@ import FlatButton from "material-ui/FlatButton";
 import NavigateHomeIcon from "material-ui/svg-icons/action/home";
 import NavigateBeforeIcon from "material-ui/svg-icons/image/navigate-before";
 import NavigateNextIcon from "material-ui/svg-icons/image/navigate-next";
+import ArrowBackIcon from "material-ui/svg-icons/navigation/arrow-back";
+import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 import { grey100 } from "material-ui/styles/colors";
 import IconButton from "material-ui/IconButton/IconButton";
 import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
@@ -83,16 +85,6 @@ const styles = StyleSheet.create({
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical",
     overflowX: "hidden"
-  },
-  bottomFixedSection: {
-    borderTop: `1px solid ${grey100}`,
-    flex: "1 0 auto",
-    marginBottom: "none"
-  },
-  messageField: {
-    flex: "2 0 20px",
-    padding: "0px 4px",
-    marginBottom: "8px"
   },
   textField: {
     "@media(max-width: 350px)": {
@@ -177,8 +169,120 @@ const inlineStyles = {
     fontWeight: "600",
     fontSize: "105%",
     marginBottom: "10px"
+  },
+  sendButton: {
+    width: "100%",
+    height: "100%",
+    borderRadius: "0px"
+  },
+  flatButtonLabel: {
+    textTransform: "none"
   }
 };
+
+const flexStyles = StyleSheet.create({
+  sectionHeaderToolbar: {
+    // see ContactToolbarNew component
+  },
+  /// * Section Scrolling Message Thread
+  sectionMessageThread: {
+    // middleScrollingSection: {
+    flex: "1 1 auto",
+    overflowY: "scroll",
+    overflow: "-moz-scrollbars-vertical",
+    overflowX: "hidden"
+  },
+  /// * Section OptOut Dialog
+  sectionOptOutDialog: {
+    // uses Card default
+  },
+  /// * Section Texting Input Field
+  sectionMessageField: {
+    // messageField
+    flex: "2 0 20px",
+    padding: "0px 4px",
+    marginBottom: "8px"
+  },
+  /// * Section Reply/Exit Buttons
+  sectionButtons: {
+    // buttons
+    flex: "4 0 130px", // stretches and shrinks more quickly than message
+    flexDirection: "column",
+    display: "flex",
+    // flexWrap: "wrap",
+    overflow: "hidden",
+    position: "relative",
+    backgroundColor: "rgb(240, 240, 240)"
+  },
+  subButtonsAnswerButtons: {
+    flex: "1 1 80px", // keeps bottom buttons in place
+    // internal:
+    margin: "9px 0px 0px 9px",
+    width: "100%",
+    // similar to 572 below, but give room for other shortcut-buttons
+    maxWidth: "820px"
+  },
+  subSubButtonsAnswerButtonsCurrentQuestion: {
+    marginBottom: "4px",
+    //flex: "0 0 auto",
+    width: "100%",
+    // for mobile:
+    whiteSpace: "nowrap",
+    overflow: "hidden"
+  },
+  subSubAnswerButtonsColumns: {
+    "@media(min-width: 450px)": {
+      // mobile crunch gives up on 50%, so only bigger
+      width: "46%"
+    },
+    display: "inline-block",
+    //flex: "1 1 50%",
+    overflow: "hidden",
+    position: "relative"
+  },
+  subButtonsExitButtons: {
+    // next/prev/skip/optout
+    // width: "100%", default is better on mobile
+    maxWidth: "572px",
+    height: "40px",
+    margin: "9px",
+    // default works better for mobile right margin
+    // flex: "0 0 40px",
+    // internal:
+    display: "flex",
+    flexDirection: "column",
+    flexWrap: "wrap",
+    alignContent: "space-between",
+    // to 'win' against absoslute positioned content above it:
+    backgroundColor: "rgb(240, 240, 240)",
+    zIndex: "10"
+  },
+  /// * Section Send Button
+  sectionSend: {
+    //sendButtonWrapper
+    //flex: `0 0 ${sendButtonHeight}`, VARIABLE BELOW
+    //height: ${sendButtonHeight}, VARIABLE BELOW
+    padding: "9px"
+  },
+  flatButton: {
+    height: "40px",
+    border: "1px solid #949494",
+    // FlatButton property, setting here, overrides hover
+    // backgroundColor: "white",
+    borderRadius: "0",
+    boxShadow: "none",
+    "@media(max-width: 450px)": {
+      // mobile crunch
+      minWidth: "auto"
+    }
+  },
+  flatButtonLabelMobile: {
+    "@media(max-width: 327px)": {
+      // mobile crunch
+      display: "none"
+    }
+  }
+});
 
 export class AssignmentTexterContactControls extends React.Component {
   constructor(props) {
@@ -324,17 +428,6 @@ export class AssignmentTexterContactControls extends React.Component {
     });
   };
 
-  renderMiddleScrollingSection() {
-    const { contact } = this.props;
-    return (
-      <MessageList
-        contact={contact}
-        messages={contact.messages}
-        styles={inlineStyles}
-      />
-    );
-  }
-
   renderSurveySection() {
     const { campaign, contact } = this.props;
     const { questionResponses } = this.state;
@@ -345,22 +438,14 @@ export class AssignmentTexterContactControls extends React.Component {
       campaign.interactionSteps
     );
 
-    return messages.length === 0 ? (
-      <Empty
-        title={"This is your first message to " + contact.firstName}
-        icon={<CreateIcon color="rgb(83, 180, 119)" />}
-        hideMobile
+    return (
+      <AssignmentTexterSurveys
+        contact={contact}
+        interactionSteps={availableInteractionSteps}
+        onQuestionResponseChange={this.handleQuestionResponseChange}
+        currentInteractionStep={this.state.currentInteractionStep}
+        questionResponses={questionResponses}
       />
-    ) : (
-      <div>
-        <AssignmentTexterSurveys
-          contact={contact}
-          interactionSteps={availableInteractionSteps}
-          onQuestionResponseChange={this.handleQuestionResponseChange}
-          currentInteractionStep={this.state.currentInteractionStep}
-          questionResponses={questionResponses}
-        />
-      </div>
     );
   }
 
@@ -369,16 +454,22 @@ export class AssignmentTexterContactControls extends React.Component {
     let button = null;
     if (messageStatus === "closed") {
       button = (
-        <RaisedButton
+        <FlatButton
           onTouchTap={() => this.props.onEditStatus("needsResponse")}
           label="Reopen"
+          className={css(flexStyles.flatButton)}
+          labelStyle={inlineStyles.flatButtonLabel}
+          backgroundColor="white"
         />
       );
-    } else if (messageStatus === "needsResponse") {
+    } else {
       button = (
-        <RaisedButton
+        <FlatButton
           onTouchTap={() => this.props.onEditStatus("closed", true)}
           label="Skip"
+          className={css(flexStyles.flatButton)}
+          labelStyle={inlineStyles.flatButtonLabel}
+          backgroundColor="white"
         />
       );
     }
@@ -501,27 +592,6 @@ export class AssignmentTexterContactControls extends React.Component {
     return "";
   }
 
-  renderTopFixedSection() {
-    const { contact } = this.props;
-    return (
-      <ContactToolbarNew
-        campaign={this.props.campaign}
-        campaignContact={contact}
-        navigationToolbarChildren={this.props.navigationToolbarChildren}
-        leftToolbarIcon={
-          <IconButton
-            onTouchTap={this.props.onExitTexter}
-            style={inlineStyles.exitTexterIconButton}
-            tooltip="Return Home"
-            tooltipPosition="bottom-center"
-          >
-            <NavigateHomeIcon color={"white"} />
-          </IconButton>
-        }
-      />
-    );
-  }
-
   renderCannedResponsePopover() {
     const { campaign, assignment, texter } = this.props;
     const { userCannedResponses, campaignCannedResponses } = assignment;
@@ -587,61 +657,20 @@ export class AssignmentTexterContactControls extends React.Component {
     );
   }
 
-  renderCorrectSendButton() {
-    const { campaign } = this.props;
-    const { contact } = this.props;
-    if (
-      contact.messageStatus === "messaged" ||
-      contact.messageStatus === "convo" ||
-      contact.messageStatus === "needsResponse"
-    ) {
-      return (
-        <SendButtonArrow
-          threeClickEnabled={false}
-          onFinalTouchTap={this.handleClickSendMessageButton}
-          disabled={this.props.disabled}
-        />
-      );
-    }
-    return null;
-  }
-
-  renderBottomFixedSection() {
+  renderMessageSending() {
+    console.log("renderMessageSending", this.props);
+    const { contact, messageStatusFilter } = this.props;
     const { optOutDialogOpen } = this.state;
-    /*
-        {this.renderSurveySection()}
-        <div>
-          {message}
-          { ? "" : this.renderActionToolbar()}
-        </div>
-        {
-        {this.renderCannedResponsePopover()}
-        {this.renderCorrectSendButton()}
-    */
+    const firstMessage = messageStatusFilter === "needsMessage";
 
-    return optOutDialogOpen ? (
-      this.renderOptOutDialog()
-    ) : (
-      <div style={wrapper}></div>
-    );
-  }
-
-  render() {
-    console.log("AssignmentTexterContactNewControls", this.props);
-    const { messageStatusFilter } = this.props;
-    const { optOutDialogOpen } = this.state;
     const message = (
-      <div className={css(styles.messageField)}>
+      <div className={css(flexStyles.sectionMessageField)}>
         <GSForm
           ref="form"
           schema={this.messageSchema}
           value={{ messageText: this.state.messageText }}
           onSubmit={this.props.onMessageFormSubmit}
-          onChange={
-            messageStatusFilter === "needsMessage"
-              ? ""
-              : this.handleMessageFormChange
-          }
+          onChange={firstMessage ? "" : this.handleMessageFormChange}
         >
           <Form.Field
             className={css(styles.textField)}
@@ -660,105 +689,209 @@ export class AssignmentTexterContactControls extends React.Component {
         </GSForm>
       </div>
     );
-    const wrapper = {
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "stretch",
-      alignContent: "stretch"
-    };
-    const buttons = {
-      flex: "4 1 auto", // stretches and shrinks more quickly than message
-      display: "flex",
-      flexWrap: "wrap",
-      overflow: "hidden",
-      position: "relative"
-    };
-    const button1 = {
-      height: "30px",
-      border: "1px solid black",
-      padding: "3px"
-    };
-    const firstMessage = messageStatusFilter === "needsMessage";
-    const sendButtonHeight = firstMessage ? "40%" : "36px";
-    const sendButtonWrapper = {
-      flex: `0 0 ${sendButtonHeight}`,
-      height: sendButtonHeight,
-      padding: "12px"
-    };
 
-    const sendButton = {
-      width: "100%",
-      height: "100%"
-    };
-    return (
-      <div
-        className={css(styles.container)}
-        style={
-          this.props.contact.messageStatus === "needsResponse"
-            ? { backgroundColor: "rgba(83, 180, 119, 0.25)" }
-            : {}
-        }
-      >
-        <div className={css(styles.topFixedSection)}>
-          {this.renderTopFixedSection()}
-        </div>
-        {this.renderMiddleScrollingSection()}
-        {optOutDialogOpen
-          ? this.renderOptOutDialog()
-          : [
-              message,
-              firstMessage ? null : (
-                <div style={buttons}>
-                  Question: []
-                  <div style={button1}>Question Answered</div>
-                  <div style={button1}>Other Responses</div>
-                  <div style={button1}>Left</div>
-                  <div style={button1}>Opt-Out</div>
-                  <div style={button1}>Right</div>
-                  <div style={button1}>Skip</div>
-                  <div style={{ position: "absolute" }}>
-                    <div style={button1}>Question Answered</div>
-                    <div style={button1}>Other Responses</div>
-                    <div style={button1}>Left</div>
-                    <div style={button1}>Skip</div>
-                    <div style={button1}>Opt-Out</div>
-                    <div style={button1}>Right</div>
-                    <div style={button1}>Question Answered</div>
-                    <div style={button1}>Other Responses</div>
-                    <div style={button1}>Left</div>
-                    <div style={button1}>Skip</div>
-                    <div style={button1}>Opt-Out</div>
-                    <div style={button1}>Right</div>
-                    <div style={button1}>Question Answered</div>
-                    <div style={button1}>Other Responses</div>
-                    <div style={button1}>Left</div>
-                    <div style={button1}>Skip</div>
-                    <div style={button1}>Opt-Out</div>
-                    <div style={button1}>Right</div>
-                  </div>
-                </div>
-              ),
-              <div style={sendButtonWrapper}>
-                <RaisedButton
-                  {...dataTest("send")}
-                  onTouchTap={this.handleClickSendMessageButton}
-                  disabled={this.props.disabled}
-                  label={"Send"}
-                  style={sendButton}
-                  primary
+    const sendButtonHeight = firstMessage ? "40%" : "36px";
+    const currentQuestion = "Do you believe in love?";
+    console.log(
+      "REFS renderMessageSending return",
+      message,
+      this.refs.answerButtons && this.refs.answerButtons.offsetHeight
+    );
+    const quickButtonSpace =
+      this.refs.answerButtons &&
+      // 114=25(top q)+40(main btns)+40(xtra row)+9px(padding)
+      this.refs.answerButtons.offsetHeight >= 105;
+    return [
+      message,
+      firstMessage ? null : (
+        <div className={css(flexStyles.sectionButtons)}>
+          <div
+            className={css(flexStyles.subButtonsAnswerButtons)}
+            ref="answerButtons"
+          >
+            {currentQuestion ? (
+              <div
+                className={css(
+                  flexStyles.subSubButtonsAnswerButtonsCurrentQuestion
+                )}
+              >
+                <b>Current Question:</b> {currentQuestion}
+              </div>
+            ) : null}
+            <div
+              className={css(flexStyles.subSubAnswerButtonsColumns)}
+              style={quickButtonSpace ? { height: "89px" } : null}
+            >
+              <FlatButton
+                label={
+                  <span>
+                    Answer Q
+                    <span className={css(flexStyles.flatButtonLabelMobile)}>
+                      uestion
+                    </span>
+                  </span>
+                }
+                onTouchTap={this.handleOpenPopover}
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                backgroundColor="white"
+              />
+              <div
+                style={{
+                  height: "40px",
+                  position: "absolute",
+                  top: "40px",
+                  width: "100%",
+                  padding: "9px 9px 0 9px"
+                }}
+              >
+                <FlatButton
+                  label={"Yes"}
+                  onTouchTap={this.handleOpenPopover}
+                  className={css(flexStyles.flatButton)}
+                  labelStyle={inlineStyles.flatButtonLabel}
+                  backgroundColor="white"
+                />
+                <FlatButton
+                  label={"No"}
+                  onTouchTap={this.handleOpenPopover}
+                  className={css(flexStyles.flatButton)}
+                  labelStyle={inlineStyles.flatButtonLabel}
+                  backgroundColor="white"
                 />
               </div>
-            ]}
+            </div>
+            <div
+              className={css(flexStyles.subSubAnswerButtonsColumns)}
+              style={{
+                float: "right",
+                marginRight: "18px",
+                height: quickButtonSpace ? "89px" : "42px"
+              }}
+            >
+              <FlatButton
+                label="Other Responses"
+                onTouchTap={this.handleOpenPopover}
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                backgroundColor="white"
+              />
+            </div>
+          </div>
+          <div className={css(flexStyles.subButtonsExitButtons)}>
+            <FlatButton
+              onTouchTap={this.props.navigationToolbarChildren.onPrevious}
+              disabled={!this.props.navigationToolbarChildren.onPrevious}
+              tooltip="Previous Contact"
+              tooltipPosition="button-center"
+              className={css(flexStyles.flatButton)}
+              style={{ paddingTop: "6px" }}
+              label={<ArrowBackIcon />}
+              backgroundColor={
+                this.props.navigationToolbarChildren.onPrevious
+                  ? "white"
+                  : "rgb(176, 176, 176)"
+              }
+            />
+
+            {this.renderNeedsResponseToggleButton(contact)}
+
+            <FlatButton
+              {...dataTest("optOut")}
+              secondary
+              label="Opt-out"
+              onTouchTap={this.handleOpenDialog}
+              tooltip="Opt out this contact"
+              className={css(flexStyles.flatButton)}
+              labelStyle={inlineStyles.flatButtonLabel}
+              backgroundColor="white"
+            />
+
+            <FlatButton
+              onTouchTap={this.props.navigationToolbarChildren.onNext}
+              disabled={!this.props.navigationToolbarChildren.onNext}
+              tooltip="Next Contact"
+              tooltipPosition="bottom-center"
+              label={<ArrowForwardIcon />}
+              className={css(flexStyles.flatButton)}
+              style={{ paddingTop: "6px" }}
+              backgroundColor={
+                this.props.navigationToolbarChildren.onNext
+                  ? "white"
+                  : "rgb(176, 176, 176)"
+              }
+              labelStyle={inlineStyles.flatButtonLabel}
+            />
+          </div>
+        </div>
+      ),
+      <div
+        className={css(flexStyles.sectionSend)}
+        style={{ flex: `0 0 ${sendButtonHeight}`, height: sendButtonHeight }}
+      >
+        <RaisedButton
+          {...dataTest("send")}
+          onTouchTap={this.handleClickSendMessageButton}
+          disabled={this.props.disabled}
+          label={"Send"}
+          style={inlineStyles.sendButton}
+          primary
+        />
+      </div>,
+      this.renderCannedResponsePopover()
+    ];
+
+    /*
+        {this.renderSurveySection()}
+        <div>
+          {message}
+          { ? "" : this.renderActionToolbar()}
+        </div>
+        {
+        {this.renderCannedResponsePopover()}
+    */
+  }
+
+  render() {
+    const { optOutDialogOpen } = this.state;
+    console.log("AssignmentTexterContactNewControls", this.props);
+    return (
+      <div className={css(styles.container)}>
+        <div className={css(styles.topFixedSection)}>
+          <ContactToolbarNew
+            campaign={this.props.campaign}
+            campaignContact={this.props.contact}
+            navigationToolbarChildren={this.props.navigationToolbarChildren}
+            leftToolbarIcon={
+              <IconButton
+                onTouchTap={this.props.onExitTexter}
+                style={inlineStyles.exitTexterIconButton}
+                tooltip="Return Home"
+                tooltipPosition="bottom-center"
+              >
+                <NavigateHomeIcon color={"white"} />
+              </IconButton>
+            }
+          />
+        </div>
+        <div
+          {...dataTest("messageList")}
+          ref="messageScrollContainer"
+          className={css(styles.middleScrollingSection)}
+        >
+          <MessageList
+            contact={this.props.contact}
+            messages={this.props.contact.messages}
+            styles={inlineStyles}
+          />
+        </div>
+        {optOutDialogOpen
+          ? this.renderOptOutDialog()
+          : this.renderMessageSending()}
       </div>
     );
   }
 }
-/*
-        <div className={css(styles.bottomFixedSection)}>
-          {this.renderBottomFixedSection()}
-        </div>
-
-*/
 
 AssignmentTexterContactControls.propTypes = {
   // data

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -40,47 +40,13 @@ import CreateIcon from "material-ui/svg-icons/content/create";
 import { dataTest } from "../lib/attributes";
 import { getContactTimezone } from "../lib/timezones";
 
-const inlineStyles = {
-  // passed to MessageList whole
-  mobileToolBar: {
-    position: "absolute",
-    bottom: "-5"
-  },
-  mobileCannedReplies: {
-    "@media(max-width: 450px)": {
-      marginBottom: "1"
-    }
-  },
-  exitTexterIconButton: {
-    float: "left",
-    height: "56px",
-    zIndex: 100,
-    top: 0,
-    left: "-20"
-  },
-  toolbarIconButton: {
-    position: "absolute",
-    top: 0
-    // without this the toolbar icons are not centered vertically
-  },
-  actionToolbar: {
-    backgroundColor: "white",
-    "@media(min-width: 450px)": {
-      marginBottom: 5
-    },
-    "@media(max-width: 450px)": {
-      marginBottom: 50
-    }
-  },
-  actionToolbarFirst: {
-    backgroundColor: "white"
-  },
+const messageListStyles = {
+  // passesd directly to <MessageList>
   messageList: {
     backgroundColor: "#f0f0f0",
     flex: "2 4 auto",
-    overflowY: "scroll",
-    overflow: "-moz-scrollbars-vertical",
-    overflowX: "hidden"
+    overflow: "hidden",
+    overflow: "-moz-scrollbars-vertical"
   },
   messageSent: {
     textAlign: "right",
@@ -100,6 +66,20 @@ const inlineStyles = {
     fontWeight: "600",
     fontSize: "105%",
     marginBottom: "10px"
+  }
+};
+
+const inlineStyles = {
+  inlineBlock: {
+    display: "inline-block"
+  },
+  exitTexterIconButton: {
+    float: "left",
+    padding: "3px",
+    height: "56px",
+    zIndex: 100,
+    top: 0,
+    left: "-12px"
   },
   sendButton: {
     width: "100%",
@@ -126,18 +106,16 @@ const flexStyles = StyleSheet.create({
   sectionHeaderToolbar: {
     flex: "0 0 auto"
   },
-  /// * Section Scroll3ing Message Thread
+  /// * Section Scrolling Message Thread
   sectionMessageThread: {
-    flex: "1 1 auto",
+    flex: "1 4 auto",
     overflowY: "scroll",
     overflow: "-moz-scrollbars-vertical",
     overflowX: "hidden"
   },
   /// * Section OptOut Dialog
   sectionOptOutDialog: {
-    "@media(max-width: 320px)": {
-      padding: "2px 10px !important"
-    },
+    padding: "4px 10px 9px 10px",
     zIndex: 2000,
     backgroundColor: "white"
   },
@@ -146,9 +124,6 @@ const flexStyles = StyleSheet.create({
     display: "flex",
     flexDirection: "row",
     justifyContent: "flex-end"
-  },
-  subSubSectionOptOutDialogActionButton: {
-    display: "inline-block"
   },
   /// * Section Texting Input Field
   sectionMessageField: {
@@ -164,8 +139,16 @@ const flexStyles = StyleSheet.create({
   },
   /// * Section Reply/Exit Buttons
   sectionButtons: {
-    // buttons
-    flex: "4 0 130px", // stretches and shrinks more quickly than message
+    // TODO: maybe make this contingent on whether there are answer buttons
+    "@media(max-height: 600px)": {
+      flexBasis: "130px"
+    },
+    "@media(min-height: 600px)": {
+      flexBasis: "190px"
+    },
+    flexGrow: "4",
+    flexShrink: "0",
+    // flexBasis: ${130px|190px}", // stretches and shrinks more quickly than message
     flexDirection: "column",
     display: "flex",
     // flexWrap: "wrap",
@@ -261,7 +244,6 @@ export class AssignmentTexterContactControls extends React.Component {
       questionResponses,
       props.campaign.interactionSteps
     );
-    console.log("availableSteps", availableSteps);
     this.state = {
       questionResponses,
       optOutMessageText: props.campaign.organization.optOutMessage,
@@ -531,6 +513,53 @@ export class AssignmentTexterContactControls extends React.Component {
             value={{ optOutMessageText: this.state.optOutMessageText }}
             onSubmit={this.props.onOptOut}
           >
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                justifyContent: "flex-end"
+              }}
+            >
+              <FlatButton
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                style={{
+                  margin: "9px",
+                  color:
+                    this.state.optOutMessageText ===
+                    this.props.campaign.organization.optOutMessage
+                      ? "white"
+                      : "#494949",
+                  backgroundColor:
+                    this.state.optOutMessageText ===
+                    this.props.campaign.organization.optOutMessage
+                      ? "#727272"
+                      : "white"
+                }}
+                label="Standard Message"
+                onTouchTap={() => {
+                  this.setState({
+                    optOutMessageText: this.props.campaign.organization
+                      .optOutMessage
+                  });
+                }}
+              />
+              <FlatButton
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                style={{
+                  margin: "0 9px 0 9px",
+                  color:
+                    this.state.optOutMessageText === "" ? "white" : "#494949",
+                  backgroundColor:
+                    this.state.optOutMessageText === "" ? "#727272" : "white"
+                }}
+                label="No Message"
+                onTouchTap={() => {
+                  this.setState({ optOutMessageText: "" });
+                }}
+              />
+            </div>
             <Form.Field
               name="optOutMessageText"
               fullWidth
@@ -539,22 +568,27 @@ export class AssignmentTexterContactControls extends React.Component {
             />
             <div className={css(flexStyles.subSectionOptOutDialogActions)}>
               <FlatButton
-                className={css(
-                  flexStyles.subSubSectionOptOutDialogActionButton
-                )}
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                style={inlineStyles.inlineBlock}
                 label="Cancel"
                 onTouchTap={this.handleCloseDialog}
               />
-              <Form.Button
+              <FlatButton
                 type="submit"
-                className={css(
-                  flexStyles.subSubSectionOptOutDialogActionButton
-                )}
-                component={GSSubmitButton}
+                onTouchTap={this.props.onOptOut}
+                className={css(flexStyles.flatButton)}
+                labelStyle={inlineStyles.flatButtonLabel}
+                style={{
+                  ...inlineStyles.inlineBlock,
+                  borderColor: "#790000",
+                  color: "white"
+                }}
+                backgroundColor="#BC0000"
                 label={
                   this.state.optOutMessageText.length
-                    ? "Send"
-                    : "Opt Out without Text"
+                    ? "Opt-Out"
+                    : "Opt-Out without Text"
                 }
               />
             </div>
@@ -565,9 +599,13 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   renderMessageSending() {
-    console.log("renderMessageSending", this.props);
     const { contact, messageStatusFilter } = this.props;
-    const { optOutDialogOpen, availableSteps } = this.state;
+    const {
+      optOutDialogOpen,
+      availableSteps,
+      questionResponses,
+      currentInteractionStep
+    } = this.state;
     const firstMessage = messageStatusFilter === "needsMessage";
 
     const message = (
@@ -598,16 +636,25 @@ export class AssignmentTexterContactControls extends React.Component {
     );
 
     const sendButtonHeight = firstMessage ? "40%" : "36px";
-    const currentQuestion =
-      this.state.currentInteractionStep &&
-      this.state.currentInteractionStep.question;
-    console.log(
-      "REFS renderMessageSending return",
-      message,
-      this.refs.answerButtons && this.refs.answerButtons.offsetHeight,
-      "old height",
-      this.state.currentShortcutSpace
-    );
+    let currentQuestion = null;
+    let currentQuestionAnswered = null;
+    let currentQuestionOptions = null;
+    if (currentInteractionStep) {
+      currentQuestion = currentInteractionStep.question;
+      currentQuestionAnswered = questionResponses[currentInteractionStep.id];
+      currentQuestionOptions = currentQuestion.answerOptions.map(answer => {
+        const label = answer.value.match(/^(\w+)([^\s\w]|$)/);
+        return {
+          answer: answer,
+          label: label ? label[1] : "Yes__No__Maybe__toomuch"
+        };
+      });
+      const joinedLength = currentQuestionOptions.map(o => o.label).join("__");
+      if (joinedLength.length > 14) {
+        // too many/long options
+        currentQuestionOptions = null;
+      }
+    }
     const shortcutButtonSpace =
       // 114=25(top q)+40(main btns)+40(xtra row)+9px(padding)
       ((this.refs.answerButtons && this.refs.answerButtons.offsetHeight) ||
@@ -626,7 +673,15 @@ export class AssignmentTexterContactControls extends React.Component {
                   flexStyles.subSubButtonsAnswerButtonsCurrentQuestion
                 )}
               >
-                <b>Current Question:</b> {currentQuestion.text}
+                {currentQuestionAnswered ? (
+                  <span>
+                    {currentQuestion.text}: <b>{currentQuestionAnswered}</b>
+                  </span>
+                ) : (
+                  <span>
+                    <b>Current Question:</b> {currentQuestion.text}
+                  </span>
+                )}
               </div>
             ) : null}
             <div
@@ -650,26 +705,46 @@ export class AssignmentTexterContactControls extends React.Component {
                 }
                 disabled={!availableSteps.length}
               />
-              {currentQuestion ? (
+              {currentQuestionOptions ? (
                 <div
                   style={{
                     height: "40px",
                     position: "absolute",
                     top: "40px",
                     width: "100%",
-                    padding: "9px 9px 0 9px"
+                    padding: "9px"
                   }}
                 >
-                  {currentQuestion.answerOptions.map(answer => (
+                  {currentQuestionOptions.map(opt => (
                     <FlatButton
-                      key={answer.value.replace(/\W/, "")}
-                      label={answer.value}
+                      key={opt.answer.value.replace(/\W/, "")}
+                      label={opt.label}
                       onTouchTap={evt => {
-                        console.log("Shortcut Answer", evt, answer, this);
+                        this.handleQuestionResponseChange({
+                          interactionStep: currentInteractionStep,
+                          questionResponseValue: opt.answer.value,
+                          nextScript:
+                            (opt.answer.nextInteractionStep &&
+                              opt.answer.nextInteractionStep.script) ||
+                            null
+                        });
                       }}
                       className={css(flexStyles.flatButton)}
-                      labelStyle={inlineStyles.flatButtonLabel}
-                      backgroundColor="white"
+                      style={{ marginLeft: "9px" }}
+                      labelStyle={{
+                        ...inlineStyles.flatButtonLabel,
+                        color:
+                          opt.answer.value ===
+                          questionResponses[currentInteractionStep.id]
+                            ? "white"
+                            : "#494949"
+                      }}
+                      backgroundColor={
+                        opt.answer.value ===
+                        questionResponses[currentInteractionStep.id]
+                          ? "#727272"
+                          : "white"
+                      }
                     />
                   ))}
                 </div>
@@ -759,7 +834,6 @@ export class AssignmentTexterContactControls extends React.Component {
 
   render() {
     const { optOutDialogOpen } = this.state;
-    console.log("AssignmentTexterContactNewControls", this.props);
     return (
       <div className={css(flexStyles.topContainer)}>
         <div className={css(flexStyles.sectionHeaderToolbar)}>
@@ -787,7 +861,7 @@ export class AssignmentTexterContactControls extends React.Component {
           <MessageList
             contact={this.props.contact}
             messages={this.props.contact.messages}
-            styles={inlineStyles}
+            styles={messageListStyles}
           />
         </div>
         {optOutDialogOpen

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -170,6 +170,9 @@ const flexStyles = StyleSheet.create({
       // mobile crunch gives up on 50%, so only bigger
       width: "46%"
     },
+    "@media(min-height: 600px)": {
+      height: "89px"
+    },
     display: "inline-block",
     //flex: "1 1 50%",
     overflow: "hidden",
@@ -500,10 +503,7 @@ export class AssignmentTexterContactControls extends React.Component {
               this.setState({ optOutMessageText })
             }
             value={{ optOutMessageText: this.state.optOutMessageText }}
-            onSubmit={obj => {
-              console.log("Optout submit", obj);
-              this.props.onOptOut(obj);
-            }}
+            onSubmit={this.props.onOptOut}
           >
             <div
               style={{
@@ -675,10 +675,7 @@ export class AssignmentTexterContactControls extends React.Component {
                 )}
               </div>
             ) : null}
-            <div
-              className={css(flexStyles.subSubAnswerButtonsColumns)}
-              style={shortcutButtonSpace ? { height: "89px" } : null}
-            >
+            <div className={css(flexStyles.subSubAnswerButtonsColumns)}>
               <FlatButton
                 label={
                   <span>
@@ -745,8 +742,7 @@ export class AssignmentTexterContactControls extends React.Component {
               className={css(flexStyles.subSubAnswerButtonsColumns)}
               style={{
                 float: "right",
-                marginRight: "18px",
-                height: shortcutButtonSpace ? "89px" : "42px"
+                marginRight: "18px"
               }}
             >
               <FlatButton

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -25,6 +25,7 @@ import GSSubmitButton from "../components/forms/GSSubmitButton";
 import SendButton from "../components/SendButton";
 import SendButtonArrow from "../components/SendButtonArrow";
 import CircularProgress from "material-ui/CircularProgress";
+import Popover from "material-ui/Popover";
 import Snackbar from "material-ui/Snackbar";
 import {
   getChildren,
@@ -265,6 +266,7 @@ export class AssignmentTexterContactControls extends React.Component {
       questionResponses,
       optOutMessageText: props.campaign.organization.optOutMessage,
       responsePopoverOpen: false,
+      answerPopoverOpen: false,
       messageText: this.getStartingMessageText(),
       optOutDialogOpen: false,
       currentShortcutSpace: 0,
@@ -399,6 +401,20 @@ export class AssignmentTexterContactControls extends React.Component {
 
   handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
 
+  handleOpenAnswerPopover = event => {
+    event.preventDefault();
+    this.setState({
+      answerPopoverAnchorEl: event.currentTarget,
+      answerPopoverOpen: true
+    });
+  };
+
+  handleCloseAnswerPopover = () => {
+    this.setState({
+      answerPopoverOpen: false
+    });
+  };
+
   handleOpenResponsePopover = event => {
     event.preventDefault();
     this.setState({
@@ -415,7 +431,7 @@ export class AssignmentTexterContactControls extends React.Component {
 
   renderSurveySection() {
     const { campaign, contact } = this.props;
-    const { questionResponses } = this.state;
+    const { answerPopoverOpen, questionResponses } = this.state;
     const { messages } = contact;
 
     const availableInteractionSteps = getAvailableInteractionSteps(
@@ -424,13 +440,27 @@ export class AssignmentTexterContactControls extends React.Component {
     );
 
     return (
-      <AssignmentTexterSurveys
-        contact={contact}
-        interactionSteps={availableInteractionSteps}
-        onQuestionResponseChange={this.handleQuestionResponseChange}
-        currentInteractionStep={this.state.currentInteractionStep}
-        questionResponses={questionResponses}
-      />
+      <Popover
+        style={inlineStyles.popover}
+        open={answerPopoverOpen}
+        anchorEl={this.state.answerPopoverAnchorEl}
+        anchorOrigin={{ horizontal: "left", vertical: "bottom" }}
+        targetOrigin={{ horizontal: "left", vertical: "bottom" }}
+        onRequestClose={this.handleCloseAnswerPopover}
+        style={{
+          overflowY: "scroll",
+          width: "75%"
+        }}
+      >
+        <AssignmentTexterSurveys
+          contact={contact}
+          interactionSteps={availableInteractionSteps}
+          onQuestionResponseChange={this.handleQuestionResponseChange}
+          currentInteractionStep={this.state.currentInteractionStep}
+          questionResponses={questionResponses}
+          onRequestClose={this.handleCloseAnswerPopover}
+        />
+      </Popover>
     );
   }
 
@@ -612,9 +642,7 @@ export class AssignmentTexterContactControls extends React.Component {
                     </span>
                   </span>
                 }
-                onTouchTap={evt => {
-                  console.log("answer question", evt, this);
-                }}
+                onTouchTap={this.handleOpenAnswerPopover}
                 className={css(flexStyles.flatButton)}
                 labelStyle={inlineStyles.flatButtonLabel}
                 backgroundColor={
@@ -724,7 +752,8 @@ export class AssignmentTexterContactControls extends React.Component {
           primary
         />
       </div>,
-      this.renderCannedResponsePopover()
+      this.renderCannedResponsePopover(),
+      this.renderSurveySection()
     ];
   }
 

--- a/src/components/AssignmentTexterContactNewControls.jsx
+++ b/src/components/AssignmentTexterContactNewControls.jsx
@@ -216,6 +216,10 @@ const flexStyles = StyleSheet.create({
   },
   subButtonsAnswerButtons: {
     flex: "1 1 80px", // keeps bottom buttons in place
+    // height:105: webkit needs constraint on height sometimes
+    //   during the inflection point of showing the shortcut-buttons
+    //   without the height, the exit buttons get pushed down oddly
+    height: "105px",
     // internal:
     margin: "9px 0px 0px 9px",
     width: "100%",
@@ -477,121 +481,6 @@ export class AssignmentTexterContactControls extends React.Component {
     return button;
   }
 
-  renderActionToolbar() {
-    const {
-      contact,
-      campaign,
-      assignment,
-      navigationToolbarChildren,
-      onFinishContact,
-      messageStatusFilter
-    } = this.props;
-    const { messageStatus } = contact;
-    const size = document.documentElement.clientWidth;
-
-    let navigationToolbar = [];
-    if (navigationToolbarChildren) {
-      const { onNext, onPrevious, title } = navigationToolbarChildren;
-
-      navigationToolbar = [
-        <ToolbarTitle
-          className={css(styles.navigationToolbarTitle)}
-          text={title}
-        />,
-        <IconButton onTouchTap={onPrevious} disabled={!onPrevious}>
-          <NavigateBeforeIcon />
-        </IconButton>,
-        <IconButton onTouchTap={onNext} disabled={!onNext}>
-          <NavigateNextIcon />
-        </IconButton>
-      ];
-    }
-
-    if (messageStatusFilter === "needsMessage") {
-      return (
-        <div>
-          <Toolbar style={inlineStyles.actionToolbarFirst}>
-            <ToolbarGroup firstChild>
-              <SendButton
-                threeClickEnabled={false}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.props.disabled}
-              />
-              <div style={{ float: "right", marginLeft: 20 }}>
-                {navigationToolbar}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    } else if (size < 450) {
-      // for needsResponse or messaged or convo
-      return (
-        <div>
-          <Toolbar
-            className={css(styles.mobile)}
-            style={inlineStyles.actionToolbar}
-          >
-            <ToolbarGroup
-              style={inlineStyles.mobileToolBar}
-              className={css(styles.lgMobileToolBar)}
-              firstChild
-            >
-              <RaisedButton
-                {...dataTest("optOut")}
-                secondary
-                label="Opt out"
-                onTouchTap={this.handleOpenDialog}
-                tooltip="Opt out this contact"
-              />
-              <RaisedButton
-                style={inlineStyles.mobileCannedReplies}
-                label="Canned replies"
-                onTouchTap={this.handleOpenPopover}
-              />
-              {this.renderNeedsResponseToggleButton(contact)}
-              <div style={{ float: "right", marginLeft: "-30px" }}>
-                {navigationToolbar}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    } else if (size >= 768) {
-      // for needsResponse or messaged
-      return (
-        <div>
-          <Toolbar style={inlineStyles.actionToolbarFirst}>
-            <ToolbarGroup firstChild>
-              <SendButton
-                threeClickEnabled={false}
-                onFinalTouchTap={this.handleClickSendMessageButton}
-                disabled={this.props.disabled}
-              />
-              {this.renderNeedsResponseToggleButton(contact)}
-              <RaisedButton
-                label="Other responses"
-                onTouchTap={this.handleOpenPopover}
-              />
-              <RaisedButton
-                {...dataTest("optOut")}
-                secondary
-                label="Opt out"
-                onTouchTap={this.handleOpenDialog}
-                tooltip="Opt out this contact"
-                tooltipPosition="top-center"
-              />
-              <div style={{ float: "right", marginLeft: 20 }}>
-                {navigationToolbar}
-              </div>
-            </ToolbarGroup>
-          </Toolbar>
-        </div>
-      );
-    }
-    return "";
-  }
-
   renderCannedResponsePopover() {
     const { campaign, assignment, texter } = this.props;
     const { userCannedResponses, campaignCannedResponses } = assignment;
@@ -840,16 +729,6 @@ export class AssignmentTexterContactControls extends React.Component {
       </div>,
       this.renderCannedResponsePopover()
     ];
-
-    /*
-        {this.renderSurveySection()}
-        <div>
-          {message}
-          { ? "" : this.renderActionToolbar()}
-        </div>
-        {
-        {this.renderCannedResponsePopover()}
-    */
   }
 
   render() {

--- a/src/components/AssignmentTexterSurveys.jsx
+++ b/src/components/AssignmentTexterSurveys.jsx
@@ -2,6 +2,8 @@ import PropTypes from "prop-types";
 import React, { Component } from "react";
 import { grey50 } from "material-ui/styles/colors";
 import { Card, CardHeader, CardText } from "material-ui/Card";
+import Subheader from "material-ui/Subheader";
+import { List, ListItem } from "material-ui/List";
 import MenuItem from "material-ui/MenuItem";
 import Divider from "material-ui/Divider";
 import SelectField from "material-ui/SelectField";
@@ -81,7 +83,7 @@ class AssignmentTexterSurveys extends Component {
       />
     ));
 
-    menuItems.push(<Divider />);
+    menuItems.push(<Divider key={`div${step.id}`} />);
     menuItems.push(
       <MenuItem
         key="clear"
@@ -93,8 +95,9 @@ class AssignmentTexterSurveys extends Component {
     return menuItems;
   }
 
-  renderStep(step, isCurrentStep) {
-    const { questionResponses } = this.props;
+  renderStep(step) {
+    const { questionResponses, currentInteractionStep } = this.props;
+    const isCurrentStep = step.id === currentInteractionStep.id;
     const responseValue = questionResponses[step.id];
     const { question } = step;
 
@@ -121,6 +124,30 @@ class AssignmentTexterSurveys extends Component {
     );
   }
 
+  renderCurrentStep(step) {
+    const { onRequestClose } = this.props;
+    if (typeof this.props.onRequestClose != "function") {
+      return this.renderStep(step);
+    }
+    return (
+      <List>
+        <Divider />
+        <Subheader>{step.question.text}</Subheader>
+        {step.question.answerOptions.map((answerOption, index) => (
+          <ListItem
+            value={answerOption.value}
+            onTouchTap={() => {
+              this.handleSelectChange(step, index, answerOption.value);
+              this.props.onRequestClose();
+            }}
+            key={answerOption.value}
+            primaryText={answerOption.value}
+          />
+        ))}
+      </List>
+    );
+  }
+
   render() {
     const { interactionSteps, currentInteractionStep } = this.props;
 
@@ -135,12 +162,10 @@ class AssignmentTexterSurveys extends Component {
         <CardText style={styles.cardText}>
           {showAllQuestions
             ? ""
-            : this.renderStep(currentInteractionStep, true)}
+            : this.renderCurrentStep(currentInteractionStep)}
         </CardText>
         <CardText style={styles.cardText} expandable>
-          {interactionSteps.map(step =>
-            this.renderStep(step, step.id === currentInteractionStep.id)
-          )}
+          {interactionSteps.map(step => this.renderStep(step))}
         </CardText>
       </Card>
     );
@@ -152,7 +177,8 @@ AssignmentTexterSurveys.propTypes = {
   interactionSteps: PropTypes.array,
   currentInteractionStep: PropTypes.object,
   questionResponses: PropTypes.object,
-  onQuestionResponseChange: PropTypes.func
+  onQuestionResponseChange: PropTypes.func,
+  onRequestClose: PropTypes.func
 };
 
 export default AssignmentTexterSurveys;

--- a/src/components/ContactToolbarNew.jsx
+++ b/src/components/ContactToolbarNew.jsx
@@ -1,0 +1,120 @@
+import PropTypes from "prop-types";
+import React from "react";
+import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
+import { getDisplayPhoneNumber } from "../lib/phone-format";
+import { getLocalTime, getContactTimezone } from "../lib/timezones";
+import { getProcessEnvDstReferenceTimezone } from "../lib/tz-helpers";
+import { grey100 } from "material-ui/styles/colors";
+
+const inlineStyles = {
+  toolbar: {
+    backgroundColor: "#515259",
+    color: "white"
+  },
+  topFlex: {
+    width: "100%",
+    display: "flex",
+    flexWrap: "wrap",
+    flexDirection: "column",
+    alignContent: "space-between"
+  },
+  titleSmall: {
+    height: "18px",
+    lineHeight: "18px",
+    paddingTop: "4px",
+    paddingRight: "10px",
+    color: "#B0B0B0",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    width: "50%"
+  },
+  titleBig: {
+    height: "34px",
+    lineHeight: "34px",
+    paddingRight: "10px",
+    fontWeight: "bold",
+    color: "white",
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+    whiteSpace: "nowrap",
+    width: "50%"
+  }
+};
+
+const ContactToolbar = function ContactToolbar(props) {
+  const { campaignContact, leftToolbarIcon } = props;
+
+  const { location } = campaignContact;
+
+  let city = "";
+  let state = "";
+  let timezone = null;
+  let offset = 0;
+  let hasDST = false;
+
+  if (location) {
+    city = location.city;
+    state = location.state;
+    timezone = location.timezone;
+    if (timezone) {
+      offset = timezone.offset || offset;
+      hasDST = timezone.hasDST || hasDST;
+    }
+    const adjustedLocationTZ = getContactTimezone(props.campaign, location);
+    if (adjustedLocationTZ && adjustedLocationTZ.timezone) {
+      offset = adjustedLocationTZ.timezone.offset;
+      hasDST = adjustedLocationTZ.timezone.hasDST;
+    }
+  }
+
+  let formattedLocation = `${state}`;
+  if (city && state) {
+    formattedLocation = `${formattedLocation}, `;
+  }
+  formattedLocation = `${formattedLocation}${city}`;
+
+  const dstReferenceTimezone = props.campaign.overrideOrganizationTextingHours
+    ? props.campaign.timezone
+    : getProcessEnvDstReferenceTimezone();
+
+  const formattedLocalTime = getLocalTime(
+    offset,
+    hasDST,
+    dstReferenceTimezone
+  ).format("LT"); // format('h:mm a')
+
+  return (
+    <div>
+      <Toolbar style={inlineStyles.toolbar}>
+        {leftToolbarIcon}
+        <div style={inlineStyles.topFlex}>
+          <div style={inlineStyles.titleSmall}>
+            {props.navigationToolbarChildren.title}
+          </div>
+          <div style={inlineStyles.titleBig} title={props.campaign.title}>
+            {props.campaign.title} ({props.campaign.id})
+          </div>
+          <div style={inlineStyles.titleSmall}>
+            {formattedLocalTime} - {formattedLocation}
+          </div>
+          <div
+            style={{ fontSize: "24px", ...inlineStyles.titleBig }}
+            title={`id:${campaignContact.id} m:${campaignContact.messages.length} s:${campaignContact.messageStatus}`}
+          >
+            {campaignContact.firstName}
+          </div>
+        </div>
+      </Toolbar>
+    </div>
+  );
+};
+
+ContactToolbar.propTypes = {
+  campaignContact: PropTypes.object, // contacts for current assignment
+  campaign: PropTypes.object,
+  leftToolbarIcon: PropTypes.element,
+  navigationToolbarChildren: PropTypes.object
+};
+
+export default ContactToolbar;

--- a/src/components/ContactToolbarNew.jsx
+++ b/src/components/ContactToolbarNew.jsx
@@ -93,7 +93,8 @@ const ContactToolbar = function ContactToolbar(props) {
             {props.navigationToolbarChildren.title}
           </div>
           <div style={inlineStyles.titleBig} title={props.campaign.title}>
-            {props.campaign.title} ({props.campaign.id})
+            <span style={{ color: "#B0B0B0" }}>({props.campaign.id})</span>{" "}
+            {props.campaign.title}
           </div>
           <div style={inlineStyles.titleSmall}>
             {formattedLocalTime} - {formattedLocation}

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -188,25 +188,6 @@ const tests = {
             "We are the people. We need your help, or the apocolypse will come early.",
           isFromContact: false,
           createdAt: new Date(Number(new Date()) - 140 * 60 * 1000)
-        },
-        {
-          id: "fake4",
-          text:
-            "Oh -- the people are the best -- if only we rallied around our common interests.",
-          isFromContact: true,
-          createdAt: new Date(Number(new Date()) - 14 * 60 * 1000)
-        },
-        {
-          id: "fake5",
-          text: "I know, people are wonderful luminous beings.",
-          isFromContact: false,
-          createdAt: new Date(Number(new Date()) - 10 * 60 * 1000)
-        },
-        {
-          id: "fake6",
-          text: "Okay, sign me up -- that event sounds great!",
-          isFromContact: true,
-          createdAt: new Date(Number(new Date()) - 4 * 60 * 1000) // 4 minutes ago
         }
       ],
       customFields:

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -23,7 +23,7 @@ const tests = {
     },
     assignment: {
       campaign: {
-        id: 123,
+        id: 10123,
         title: "Event Recruitment for Saving the World",
         useDynamicAssignment: false,
         organization: {
@@ -76,7 +76,7 @@ const tests = {
     },
     assignment: {
       campaign: {
-        id: 123,
+        id: 10123,
         title: "Event Recruitment for Saving the World",
         useDynamicAssignment: false,
         organization: {
@@ -225,7 +225,7 @@ const tests = {
     },
     assignment: {
       campaign: {
-        id: 123,
+        id: 10123,
         title: "Event Recruitment for Saving the World",
         useDynamicAssignment: false,
         organization: {

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -3,6 +3,7 @@ import React from "react";
 
 import AssignmentTexter from "../components/AssignmentTexter";
 import AssignmentTexterContactControls from "../components/AssignmentTexterContactControls";
+import AssignmentTexterContactNewControls from "../components/AssignmentTexterContactNewControls";
 import { applyScript } from "../lib/scripts";
 
 const logFunction = data => {
@@ -22,7 +23,8 @@ const tests = {
     },
     assignment: {
       campaign: {
-        id: 0,
+        id: 123,
+        title: "Event Recruitment for Saving the World",
         useDynamicAssignment: false,
         organization: {
           optOutMessage:
@@ -73,7 +75,8 @@ const tests = {
     },
     assignment: {
       campaign: {
-        id: 0,
+        id: 123,
+        title: "Event Recruitment for Saving the World",
         useDynamicAssignment: false,
         organization: {
           optOutMessage:
@@ -180,10 +183,15 @@ const tests = {
   // other tests:
   // c: current question response is deeper in the state
   // d: no questions at all
+  // e: opted out
 };
 
 export function generateDemoTexterContact(test) {
   const DemoAssignmentTexterContact = function(props) {
+    const ControlsComponent = /new=1/.test(document.location.search)
+      ? AssignmentTexterContactNewControls
+      : AssignmentTexterContactControls;
+    console.log("DemoAssignmentTexterContact", props);
     const getMessageTextFromScript = script => {
       return script
         ? applyScript({
@@ -196,7 +204,7 @@ export function generateDemoTexterContact(test) {
     };
 
     return (
-      <AssignmentTexterContactControls
+      <ControlsComponent
         contact={test.contact}
         campaign={test.assignment.campaign}
         texter={test.texter}

--- a/src/components/DemoTexterAssignment.jsx
+++ b/src/components/DemoTexterAssignment.jsx
@@ -33,7 +33,8 @@ const tests = {
         interactionSteps: [
           {
             id: "13",
-            script: "Hi {firstName}, have you voted today, yet?",
+            script:
+              "Hi {firstName}, have you voted today, yet? This election is crucial to a Democratic victory and removing fascism from power.",
             question: { text: "", answerOptions: [] }
           }
         ]
@@ -92,13 +93,39 @@ const tests = {
                 {
                   value: "Yes",
                   nextInteractionStep: {
-                    script: "That's great, we'll see you there!"
+                    id: "14",
+                    script:
+                      "That's great, we'll see you there! Will you bring a friend?"
                   }
                 },
                 {
                   value: "No",
                   nextInteractionStep: {
+                    id: "15",
                     script: "That's too bad, but we love you anyway!"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            id: "14",
+            script:
+              "That's great, we'll see you there! Will you bring a friend?",
+            question: {
+              text: "Bring friend?",
+              answerOptions: [
+                {
+                  value: "Yes, with friend",
+                  nextInteractionStep: {
+                    script: "Super, we'll add your +1"
+                  }
+                },
+                {
+                  value: "No, no friends",
+                  nextInteractionStep: {
+                    script:
+                      "It's too bad, hopefully you'll meet some cool people there."
                   }
                 }
               ]
@@ -144,33 +171,193 @@ const tests = {
       questionResponseValues: [],
       messages: [
         {
+          id: "fake1",
           text: "Will you come to the event?",
           isFromContact: false,
           createdAt: new Date(Number(new Date()) - 314 * 60 * 1000)
         },
         {
+          id: "fake2",
           text: "Sorry, who is this?",
           isFromContact: true,
           createdAt: new Date(Number(new Date()) - 142 * 60 * 1000)
         },
         {
+          id: "fake3",
           text:
             "We are the people. We need your help, or the apocolypse will come early.",
           isFromContact: false,
           createdAt: new Date(Number(new Date()) - 140 * 60 * 1000)
         },
         {
+          id: "fake4",
           text:
             "Oh -- the people are the best -- if only we rallied around our common interests.",
           isFromContact: true,
           createdAt: new Date(Number(new Date()) - 14 * 60 * 1000)
         },
         {
+          id: "fake5",
           text: "I know, people are wonderful luminous beings.",
           isFromContact: false,
           createdAt: new Date(Number(new Date()) - 10 * 60 * 1000)
         },
         {
+          id: "fake6",
+          text: "Okay, sign me up -- that event sounds great!",
+          isFromContact: true,
+          createdAt: new Date(Number(new Date()) - 4 * 60 * 1000) // 4 minutes ago
+        }
+      ],
+      customFields:
+        '{"donationLink": "https://d.example.com/abc123", "vendor_id": "abc123"}'
+    }
+  },
+  c: {
+    disabled: false,
+    messageStatusFilter: "needsResponse",
+    navigationToolbarChildren: {
+      onNext: null,
+      onPrevious: logFunction,
+      title: "88 of 88",
+      total: 88,
+      currentIndex: 88
+    },
+    assignment: {
+      campaign: {
+        id: 123,
+        title: "Event Recruitment for Saving the World",
+        useDynamicAssignment: false,
+        organization: {
+          optOutMessage:
+            "Sorry about that, removing you immediately -- have a good day!"
+        },
+        interactionSteps: [
+          {
+            id: "13",
+            script: "Hi {firstName}, have you voted today, yet?",
+            question: {
+              text: "Attend Event?",
+              answerOptions: [
+                {
+                  value: "Yes",
+                  nextInteractionStep: {
+                    id: "14",
+                    script:
+                      "That's great, we'll see you there! Will you bring a friend?"
+                  }
+                },
+                {
+                  value: "No",
+                  nextInteractionStep: {
+                    id: "15",
+                    script: "That's too bad, but we love you anyway!"
+                  }
+                }
+              ]
+            }
+          },
+          {
+            id: "14",
+            script:
+              "That's great, we'll see you there! Will you bring a friend?",
+            question: {
+              text: "Bring friend?",
+              answerOptions: [
+                {
+                  value: "Yes, with friend",
+                  nextInteractionStep: {
+                    script: "Super, we'll add your +1"
+                  }
+                },
+                {
+                  value: "No, no friends",
+                  nextInteractionStep: {
+                    script:
+                      "It's too bad, hopefully you'll meet some cool people there."
+                  }
+                }
+              ]
+            }
+          }
+        ],
+        customFields: ["donationLink", "vendor_id"]
+      },
+      campaignCannedResponses: [
+        {
+          id: "1",
+          title: "Moved",
+          text:
+            "I'm sorry, we'll update your address -- what is your current zip code?",
+          isUserCreated: false
+        },
+        {
+          id: "2",
+          title: "Wrong number",
+          text: "Ok, we'll remove you from our list.",
+          isUserCreated: false
+        }
+      ],
+      userCannedResponses: []
+    },
+    texter: {
+      firstName: "Texterfirst",
+      lastName: "Tlastname"
+    },
+    contact: {
+      id: "1",
+      firstName: "Joe",
+      lastName: "Femur",
+      messageStatus: "needsMessage",
+      location: {
+        city: "Youngstown",
+        state: "OH",
+        timezone: {
+          offset: -5,
+          hasDST: 1
+        }
+      },
+      questionResponseValues: [
+        {
+          interactionStepId: "13",
+          value: "Yes"
+        }
+      ],
+      messages: [
+        {
+          id: "fake1",
+          text: "Will you come to the event?",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 314 * 60 * 1000)
+        },
+        {
+          id: "fake2",
+          text: "Sorry, who is this?",
+          isFromContact: true,
+          createdAt: new Date(Number(new Date()) - 142 * 60 * 1000)
+        },
+        {
+          id: "fake3",
+          text:
+            "We are the people. We need your help, or the apocolypse will come early.",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 140 * 60 * 1000)
+        },
+        {
+          id: "fake4",
+          text:
+            "Oh -- the people are the best -- if only we rallied around our common interests.",
+          isFromContact: true,
+          createdAt: new Date(Number(new Date()) - 14 * 60 * 1000)
+        },
+        {
+          id: "fake5",
+          text: "I know, people are wonderful luminous beings.",
+          isFromContact: false,
+          createdAt: new Date(Number(new Date()) - 10 * 60 * 1000)
+        },
+        {
+          id: "fake6",
           text: "Okay, sign me up -- that event sounds great!",
           isFromContact: true,
           createdAt: new Date(Number(new Date()) - 4 * 60 * 1000) // 4 minutes ago
@@ -180,6 +367,7 @@ const tests = {
         '{"donationLink": "https://d.example.com/abc123", "vendor_id": "abc123"}'
     }
   }
+
   // other tests:
   // c: current question response is deeper in the state
   // d: no questions at all
@@ -248,3 +436,6 @@ export function generateDemoTexterContact(test) {
 
 export const DemoTexterNeedsMessage = generateDemoTexterContact(tests.a);
 export const DemoTexterNeedsResponse = generateDemoTexterContact(tests.b);
+export const DemoTexterNeedsResponse2ndQuestion = generateDemoTexterContact(
+  tests.c
+);

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -34,9 +34,10 @@ const MessageList = function MessageList(props) {
     <div>
       <Divider />
       <ListItem
-        style={defaultStyles.optOut}
-        leftIcon={<ProhibitedIcon style={{ fill: red300 }} />}
         disabled
+        style={defaultStyles.optOut}
+        key={"optout-item"}
+        leftIcon={<ProhibitedIcon style={{ fill: red300 }} />}
         primaryText={`${contact.firstName} opted out of texts`}
         secondaryText={moment(optOut.createdAt).fromNow()}
       />

--- a/src/components/MessageList.jsx
+++ b/src/components/MessageList.jsx
@@ -6,7 +6,7 @@ import ProhibitedIcon from "material-ui/svg-icons/av/not-interested";
 import Divider from "material-ui/Divider";
 import { red300 } from "material-ui/styles/colors";
 
-const styles = {
+const defaultStyles = {
   optOut: {
     fontSize: "13px",
     fontStyle: "italic"
@@ -23,14 +23,18 @@ const styles = {
 };
 
 const MessageList = function MessageList(props) {
-  const { contact } = props;
+  const { contact, styles } = props;
   const { optOut, messages } = contact;
+
+  const received = (styles && styles.messageReceived) || defaultStyles.received;
+  const sent = (styles && styles.messageSent) || defaultStyles.sent;
+  const listStyle = (styles && styles.messageList) || {};
 
   const optOutItem = optOut ? (
     <div>
       <Divider />
       <ListItem
-        style={styles.optOut}
+        style={defaultStyles.optOut}
         leftIcon={<ProhibitedIcon style={{ fill: red300 }} />}
         disabled
         primaryText={`${contact.firstName} opted out of texts`}
@@ -42,11 +46,11 @@ const MessageList = function MessageList(props) {
   );
 
   return (
-    <List>
+    <List style={listStyle}>
       {messages.map(message => (
         <ListItem
           disabled
-          style={message.isFromContact ? styles.received : styles.sent}
+          style={message.isFromContact ? received : sent}
           key={message.id}
           primaryText={message.text}
           secondaryText={moment.utc(message.createdAt).fromNow()}
@@ -58,7 +62,8 @@ const MessageList = function MessageList(props) {
 };
 
 MessageList.propTypes = {
-  contact: PropTypes.object
+  contact: PropTypes.object,
+  styles: PropTypes.object
 };
 
 export default MessageList;

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { StyleSheet, css } from "aphrodite";
-import ContactToolbar from "../components/ContactToolbar";
 import MessageList from "../components/MessageList";
 import CannedResponseMenu from "../components/CannedResponseMenu";
 import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -5,6 +5,7 @@ import MessageList from "../components/MessageList";
 import CannedResponseMenu from "../components/CannedResponseMenu";
 import AssignmentTexterSurveys from "../components/AssignmentTexterSurveys";
 import AssignmentTexterContactControls from "../components/AssignmentTexterContactControls";
+import AssignmentTexterContactNewControls from "../components/AssignmentTexterContactNewControls";
 import RaisedButton from "material-ui/RaisedButton";
 import FlatButton from "material-ui/FlatButton";
 import NavigateHomeIcon from "material-ui/svg-icons/action/home";
@@ -280,8 +281,9 @@ export class AssignmentTexterContact extends React.Component {
       await this.handleSubmitSurveys();
       await this.props.mutations.createOptOut(optOut, contact.id);
       this.props.onFinishContact(contact.id);
-    } catch (e) {
-      this.handleSendMessageError(e);
+    } catch (err) {
+      console.log("handleOptOut Error", err);
+      this.handleSendMessageError(err);
     }
   };
 
@@ -355,6 +357,9 @@ export class AssignmentTexterContact extends React.Component {
   });
 
   render() {
+    const ControlsComponent = /new=1/.test(document.location.search)
+      ? AssignmentTexterContactNewControls
+      : AssignmentTexterContactControls;
     return (
       <div>
         {this.state.disabled ? (
@@ -365,7 +370,7 @@ export class AssignmentTexterContact extends React.Component {
         ) : (
           ""
         )}
-        <AssignmentTexterContactControls
+        <ControlsComponent
           contact={this.props.contact}
           campaign={this.props.campaign}
           texter={this.props.texter}

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -200,12 +200,21 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleCreateCannedResponse = async ({ cannedResponse }) => {
-    const saveObject = {
-      ...cannedResponse,
-      campaignId: this.props.campaign.id,
-      userId: this.props.texter.id
-    };
-    await this.mutations.createCannedResponse(saveObject);
+    try {
+      const saveObject = {
+        ...cannedResponse,
+        campaignId: this.props.campaign.id,
+        userId: this.props.texter.id
+      };
+      await this.props.mutations.createCannedResponse(saveObject);
+    } catch (err) {
+      console.log(
+        "handleCreateCannedRepsonse Error",
+        err,
+        cannedResponse,
+        this
+      );
+    }
   };
 
   handleSubmitSurveys = async () => {

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -205,7 +205,8 @@ TexterTodo.propTypes = {
   params: PropTypes.object,
   data: PropTypes.object,
   mutations: PropTypes.object,
-  router: PropTypes.object
+  router: PropTypes.object,
+  location: PropTypes.object
 };
 
 const mapQueriesToProps = ({ ownProps }) => ({

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -61,6 +61,7 @@ export const dataQuery = gql`
       }
       campaign {
         id
+        title
         isArchived
         useDynamicAssignment
         overrideOrganizationTextingHours

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -25,7 +25,8 @@ import TexterFaqs from "./components/TexterFrequentlyAskedQuestions";
 import FAQs from "./lib/faqs";
 import {
   DemoTexterNeedsMessage,
-  DemoTexterNeedsResponse
+  DemoTexterNeedsResponse,
+  DemoTexterNeedsResponse2ndQuestion
 } from "./components/DemoTexterAssignment";
 
 export default function makeRoutes(requireAuth = () => {}) {
@@ -178,6 +179,13 @@ export default function makeRoutes(requireAuth = () => {}) {
           path="reply"
           components={{
             main: props => <DemoTexterNeedsResponse {...props} />,
+            topNav: null
+          }}
+        />
+        <Route
+          path="reply2"
+          components={{
+            main: props => <DemoTexterNeedsResponse2ndQuestion {...props} />,
             topNav: null
           }}
         />

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -802,6 +802,7 @@ const rootMutations = {
         campaignId: cannedResponse.campaignId,
         userId: cannedResponse.userId
       });
+      return cannedResponseInstance;
     },
     createOrganization: async (
       _,


### PR DESCRIPTION
# Fixes many UI bugs large and small for the Texter Contact interface.

## Description

Creates a second interface when you add `?new=1` to the texter todo which after testing we could make the default one.  Most of the 'large' diff size is because I have copied two files to replace the old ones -- however in this transition state, they need to be new files.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress

![spoke-newui-desktop](https://user-images.githubusercontent.com/52117/75645346-a1636080-5c13-11ea-9caa-2407d601f9d8.png)
![spoke-newui-iphone5](https://user-images.githubusercontent.com/52117/75645349-a1fbf700-5c13-11ea-8d81-155487de7193.png)
![spoke-newui-iphonex](https://user-images.githubusercontent.com/52117/75645352-a2948d80-5c13-11ea-9af4-0c253bd97b42.png)
