### PR TITLE
adds conditional for teams in user menu

### DIFF
--- a/src/containers/UserMenu.jsx
+++ b/src/containers/UserMenu.jsx
@@ -116,15 +116,18 @@ class UserMenu extends Component {
               {currentUser.email}
             </MenuItem>
             <Divider />
-            <Subheader>Teams</Subheader>
-            {currentUser.organizations.map(organization => (
-              <MenuItem
-                key={organization.id}
-                primaryText={organization.name}
-                value={organization.id}
-              />
-            ))}
-            <Divider />
+            {currentUser.organizations.length > 1 && (
+              <Subheader>Teams</Subheader>
+            )}
+            {currentUser.organizations.length > 1 &&
+              currentUser.organizations.map(organization => (
+                <MenuItem
+                  key={organization.id}
+                  primaryText={organization.name}
+                  value={organization.id}
+                />
+              ))}
+            {currentUser.organizations.length > 1 && <Divider />}
             <MenuItem
               {...dataTest("home")}
               primaryText="Home"


### PR DESCRIPTION
# Fixes #1390 

## Description
Adds a conditional check in the user menu to only show the teams section if texter is part of more than one organization, otherwise it will not show

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
