### PR TITLE
Refactor parse-csv

### DIFF
--- a/__test__/integrations/contact-loaders/csv-upload.test.js
+++ b/__test__/integrations/contact-loaders/csv-upload.test.js
@@ -5,11 +5,15 @@ import {
   getClientChoiceData,
   processContactLoad
 } from "../../../src/integrations/contact-loaders/csv-upload";
-import { CampaignContactsForm } from "../../../src/integrations/contact-loaders/csv-upload/react-component";
+import {
+  ensureCamelCaseRequiredHeaders,
+  CampaignContactsForm
+} from "../../../src/integrations/contact-loaders/csv-upload/react-component";
 
 // csv-upload libs for validation
 import { unzipPayload } from "../../../src/workers/jobs";
-import { parseCSV, gzip } from "../../../src/lib";
+import { gzip } from "../../../src/lib";
+const srcLib = require("../../../src/lib/parse_csv");
 
 // server-testing libs
 import { r } from "../../../src/server/models/";
@@ -157,6 +161,10 @@ describe("ingest-contact-loader method: csv-upload frontend", async () => {
     component = wrapper.instance();
   });
 
+  afterEach(async () => {
+    jest.restoreAllMocks();
+  });
+
   it("csv-upload:component updates onChange on upload", async () => {
     didSubmit = false;
     changeData = null;
@@ -229,5 +237,42 @@ describe("ingest-contact-loader method: csv-upload frontend", async () => {
     expect(choiceComponent.getCurrentMethod().name).toBe("csv-upload");
     const contactsForm = choiceWrapper.find(CampaignContactsForm);
     expect(contactsForm.props().saveLabel).toBe("Save");
+  });
+  it("csv-upload:component passes headerTransformer to Papa.parse", async () => {
+    didSubmit = false;
+    changeData = null;
+    jest.spyOn(srcLib, "parseCSV");
+    const csvData =
+      "firstName,lastName,cell,zip,custom_foo,custom_xxx" +
+      "\nDolores,Huerta,2095550100,95201,bar,yyy";
+    component.handleUpload({
+      target: { files: [csvData] },
+      preventDefault: () => null
+    });
+    await sleep(5);
+    expect(srcLib.parseCSV.mock.calls[0][2]).toHaveProperty(
+      "headerTransformer"
+    );
+  });
+});
+
+describe("ensureCamelCaseRequiredHeaders", () => {
+  it("translates snake_case to camelCase for required fields firstName and lastName", () => {
+    expect(ensureCamelCaseRequiredHeaders("first_name")).toEqual("firstName");
+    expect(ensureCamelCaseRequiredHeaders("last_name")).toEqual("lastName");
+  });
+
+  it("does not translate one-word required fields (specifically, zip) at all", () => {
+    expect(ensureCamelCaseRequiredHeaders("zip")).toEqual("zip");
+  });
+
+  it("does not translate any other column headers", () => {
+    expect(ensureCamelCaseRequiredHeaders("van_id")).toEqual("van_id");
+    expect(ensureCamelCaseRequiredHeaders("district")).toEqual("district");
+  });
+
+  it("translates CamelCaps to camelCase for required fields firstName and lastName", () => {
+    expect(ensureCamelCaseRequiredHeaders("FirstName")).toEqual("firstName");
+    expect(ensureCamelCaseRequiredHeaders("LastName")).toEqual("lastName");
   });
 });

--- a/__test__/lib/parse-csv.test.js
+++ b/__test__/lib/parse-csv.test.js
@@ -1,11 +1,12 @@
-import { parseCSV } from "../../src/lib";
+import Papa from "papaparse";
+import { parseCSV, organizationCustomFields } from "../../src/lib";
 
 describe("parseCSV", () => {
   describe("with PHONE_NUMBER_COUNTRY set", () => {
     beforeEach(() => (process.env.PHONE_NUMBER_COUNTRY = "AU"));
     afterEach(() => delete process.env.PHONE_NUMBER_COUNTRY);
 
-    it("should consider phone numbers from that country as valid", () => {
+    it("considers phone numbers from that country as valid", () => {
       const csv = "firstName,lastName,cell\ntest,test,61468511000";
       parseCSV(csv, ({ contacts, customFields, validationStats, error }) => {
         expect(error).toBeFalsy();
@@ -14,20 +15,332 @@ describe("parseCSV", () => {
     });
   });
 
-  describe("When required headers are snake case", () => {
-    const mockCallback = jest.fn();
-    const csv =
-      "first_name,last_name,cell,zip\r\nJerome,Garcia,14155551212,94970\r\n";
+  describe("when a header transformer is provided", () => {
+    let csv;
 
-    it("should call the callback with a contact with camel case fields", () => {
-      parseCSV(csv, mockCallback);
+    beforeEach(async () => {
+      csv =
+        "first_name,last_name,cell,zip\r\nJerome,Garcia,14155551212,94970\r\n";
+      jest.spyOn(Papa, "parse");
+    });
+
+    afterEach(async () => {
+      jest.restoreAllMocks();
+    });
+
+    it("is passed to Papa.parse", async () => {
+      parseCSV(csv, () => {}, { headerTransformer: () => {} });
+      expect(Papa.parse).toHaveBeenCalledTimes(1);
+      expect(Papa.parse.mock.calls[0][0]).toEqual(csv);
+      expect(Papa.parse.mock.calls[0][1]).toHaveProperty("transformHeader");
+    });
+
+    describe("and when a header transformer is not provided", () => {
+      it("does not pass a header transformer to Papa.parse", async () => {
+        parseCSV(csv, () => {}, {});
+        expect(Papa.parse).toHaveBeenCalledTimes(1);
+        expect(Papa.parse.mock.calls[0][0]).toEqual(csv);
+        expect(Papa.parse.mock.calls[0][1]).not.toHaveProperty(
+          "transformHeader"
+        );
+      });
+    });
+  });
+
+  describe("When a rowTransformer is provided", () => {
+    const mockCallback = jest.fn();
+
+    const mockContacts = [
+      {
+        cell: "12024561111",
+        firstName: "Aaa",
+        lastName: "Bbb",
+        zip: "20500"
+      },
+      {
+        cell: "12024561414",
+        firstName: "Ccc",
+        lastName: "Ddd",
+        zip: "20501"
+      }
+    ];
+
+    const contacts = [
+      {
+        cell: "12024561110",
+        firstName: "Www",
+        lastName: "Xxx",
+        zip: "10500"
+      },
+      {
+        cell: "12024561410",
+        firstName: "Yyy",
+        lastName: "Zzz",
+        zip: "10501"
+      }
+    ];
+
+    const mockRowTransformer = jest
+      .fn()
+      .mockReturnValue({ rows: [], fields: [] })
+      .mockReturnValueOnce({ row: mockContacts[0], addedFields: [] })
+      .mockReturnValueOnce({ row: mockContacts[1], addedFields: [] });
+
+    const csv = `${Object.keys(contacts[0]).join(",")}\r\n${Object.values(
+      contacts[0]
+    ).join(",")}\r\n${Object.values(contacts[1]).join(",")}`;
+
+    it("it calls the rowTransformer for each row and returns the transformed data", () => {
+      parseCSV(csv, mockCallback, {
+        rowTransformer: mockRowTransformer
+      });
+
+      expect(mockRowTransformer).toHaveBeenCalledTimes(2);
+      expect(mockRowTransformer.mock.calls[0][0]).toEqual(
+        expect.arrayContaining(Object.keys(contacts[0]))
+      );
+      expect(mockRowTransformer.mock.calls[0][1]).toEqual(contacts[0]);
 
       expect(mockCallback).toHaveBeenCalledTimes(1);
       expect(mockCallback.mock.calls[0][0].contacts[0]).toEqual({
-        cell: "+14155551212",
-        firstName: "Jerome",
-        lastName: "Garcia",
-        zip: "94970"
+        cell: "+12024561111",
+        first_name: "Aaa",
+        last_name: "Bbb",
+        zip: "20500",
+        custom_fields: "{}",
+        external_id: ""
+      });
+      expect(mockCallback.mock.calls[0][0].contacts[1]).toEqual({
+        cell: "+12024561414",
+        first_name: "Ccc",
+        last_name: "Ddd",
+        zip: "20501",
+        custom_fields: "{}",
+        external_id: ""
+      });
+    });
+  });
+
+  describe("#organizationCustomFields", () => {
+    let contacts = [];
+    let customFields = [];
+    let expected = [];
+
+    beforeEach(async () => {
+      contacts = [
+        {
+          CanvassFileRequestID: "1286",
+          VanID: "20700354",
+          Address: "241 Ozno Sq, Pomizivi, TN 13358",
+          firstName: "Marion",
+          lastName: "Cook",
+          StreetAddress: "241 Ozno Sq",
+          City: "Pomizivi",
+          State: "TN",
+          ZipOrPostal: "",
+          County: "Suffolk",
+          Employer: "",
+          Occupation: "",
+          Email: "",
+          HomePhone: "",
+          IsHomePhoneACellExchange: "",
+          CellPhone: "(831) 401-6718",
+          WorkPhone: "",
+          IsWorkPhoneACellExchange: "",
+          Phone: "(670) 427-8081",
+          OptInPhone: "",
+          OptInStatus: "",
+          OptInPhoneType: "",
+          CongressionalDistrict: "",
+          StateHouse: "004",
+          StateSenate: "002",
+          Party: "R",
+          PollingLocation: "",
+          PollingAddress: "",
+          PollingCity: "",
+          cell: "+18314016718",
+          zip: "13358",
+          external_id: "20700354"
+        },
+        {
+          CanvassFileRequestID: "1286",
+          VanID: "21681436",
+          Address: "902 Hamze Pl, Biuhke, SC 35341",
+          firstName: "Bill",
+          lastName: "Fiore",
+          StreetAddress: "902 Hamze Pl",
+          City: "Biuhke",
+          State: "SC",
+          ZipOrPostal: "",
+          County: "",
+          Employer: "",
+          Occupation: "",
+          Email: "",
+          HomePhone: "",
+          IsHomePhoneACellExchange: "",
+          CellPhone: "(802) 897-2566",
+          WorkPhone: "",
+          IsWorkPhoneACellExchange: "",
+          Phone: "(332) 794-5172",
+          OptInPhone: "",
+          OptInStatus: "",
+          OptInPhoneType: "",
+          CongressionalDistrict: "001",
+          StateHouse: "004",
+          StateSenate: "002",
+          Party: "R",
+          PollingLocation: "",
+          PollingAddress: "",
+          PollingCity: "",
+          cell: "+18028972566",
+          zip: "35341",
+          external_id: "21681436"
+        }
+      ];
+
+      customFields = [
+        ...new Set([...Object.keys(contacts[0]), ...Object.keys(contacts[1])])
+      ];
+
+      expected = [
+        {
+          cell: "+18314016718",
+          custom_fields: JSON.stringify({
+            CanvassFileRequestID: "1286",
+            VanID: "20700354",
+            Address: "241 Ozno Sq, Pomizivi, TN 13358",
+            firstName: "Marion",
+            lastName: "Cook",
+            StreetAddress: "241 Ozno Sq",
+            City: "Pomizivi",
+            State: "TN",
+            ZipOrPostal: "",
+            County: "Suffolk",
+            Employer: "",
+            Occupation: "",
+            Email: "",
+            HomePhone: "",
+            IsHomePhoneACellExchange: "",
+            CellPhone: "(831) 401-6718",
+            WorkPhone: "",
+            IsWorkPhoneACellExchange: "",
+            Phone: "(670) 427-8081",
+            OptInPhone: "",
+            OptInStatus: "",
+            OptInPhoneType: "",
+            CongressionalDistrict: "",
+            StateHouse: "004",
+            StateSenate: "002",
+            Party: "R",
+            PollingLocation: "",
+            PollingAddress: "",
+            PollingCity: "",
+            cell: "+18314016718",
+            zip: "13358",
+            external_id: "20700354"
+          }),
+          external_id: "20700354",
+          first_name: "Marion",
+          last_name: "Cook",
+          zip: "13358"
+        },
+        {
+          cell: "+18028972566",
+          custom_fields: JSON.stringify({
+            CanvassFileRequestID: "1286",
+            VanID: "21681436",
+            Address: "902 Hamze Pl, Biuhke, SC 35341",
+            firstName: "Bill",
+            lastName: "Fiore",
+            StreetAddress: "902 Hamze Pl",
+            City: "Biuhke",
+            State: "SC",
+            ZipOrPostal: "",
+            County: "",
+            Employer: "",
+            Occupation: "",
+            Email: "",
+            HomePhone: "",
+            IsHomePhoneACellExchange: "",
+            CellPhone: "(802) 897-2566",
+            WorkPhone: "",
+            IsWorkPhoneACellExchange: "",
+            Phone: "(332) 794-5172",
+            OptInPhone: "",
+            OptInStatus: "",
+            OptInPhoneType: "",
+            CongressionalDistrict: "001",
+            StateHouse: "004",
+            StateSenate: "002",
+            Party: "R",
+            PollingLocation: "",
+            PollingAddress: "",
+            PollingCity: "",
+            cell: "+18028972566",
+            zip: "35341",
+            external_id: "21681436"
+          }),
+          external_id: "21681436",
+          first_name: "Bill",
+          last_name: "Fiore",
+          zip: "35341"
+        }
+      ];
+    });
+
+    it("returns a contact with a key for each required field and a custom_fields key containing an object with all the custom fields", async () => {
+      const contactsWithCustomFields = organizationCustomFields(
+        contacts,
+        customFields
+      );
+      expect(contactsWithCustomFields).toEqual(expected);
+    });
+
+    describe("when there are no custom fields", () => {
+      beforeEach(async () => {
+        customFields = [];
+        expected = [
+          {
+            cell: "+18314016718",
+            custom_fields: JSON.stringify({}),
+            external_id: "20700354",
+            first_name: "Marion",
+            last_name: "Cook",
+            zip: "13358"
+          },
+          {
+            cell: "+18028972566",
+            custom_fields: JSON.stringify({}),
+            external_id: "21681436",
+            first_name: "Bill",
+            last_name: "Fiore",
+            zip: "35341"
+          }
+        ];
+      });
+
+      it("includes only required fields", async () => {
+        const contactsWithoutCustomFields = organizationCustomFields(
+          contacts,
+          customFields
+        );
+        expect(contactsWithoutCustomFields).toEqual(expected);
+      });
+    });
+
+    describe("when there are no contcts", () => {
+      beforeEach(async () => {
+        customFields = [];
+        contacts = [];
+        expected = [];
+      });
+
+      it("returns an empty array", async () => {
+        const contactsWithoutCustomFields = organizationCustomFields(
+          contacts,
+          customFields
+        );
+        expect(contactsWithoutCustomFields).toEqual(expected);
       });
     });
   });

--- a/src/integrations/contact-loaders/csv-upload/react-component.js
+++ b/src/integrations/contact-loaders/csv-upload/react-component.js
@@ -6,11 +6,41 @@ import Form from "react-formal";
 import Subheader from "material-ui/Subheader";
 import Divider from "material-ui/Divider";
 import { ListItem, List } from "material-ui/List";
-import { parseCSV, gzip } from "../../../lib";
+import {
+  parseCSV,
+  gzip,
+  organizationCustomFields,
+  requiredUploadFields
+} from "../../../lib";
 import CampaignFormSectionHeading from "../../../components/CampaignFormSectionHeading";
 import { StyleSheet, css } from "aphrodite";
 import theme from "../../../styles/theme";
 import yup from "yup";
+import humps from "humps";
+
+export const ensureCamelCaseRequiredHeaders = columnHeader => {
+  /*
+   * This function changes:
+   *  first_name to firstName
+   *  last_name to lastName
+   *  FirstName to firstName
+   *  LastName to lastName
+   *
+   * It changes no other fields.
+   *
+   * If other fields that could be either snake_case or camelCase
+   * are added to `requiredUploadFields` it will do the same for them.
+   * */
+  const camelizedColumnHeader = humps.camelize(columnHeader);
+  if (
+    requiredUploadFields.includes(camelizedColumnHeader) &&
+    camelizedColumnHeader !== columnHeader
+  ) {
+    return camelizedColumnHeader;
+  }
+
+  return columnHeader;
+};
 
 const innerStyles = {
   button: {
@@ -51,19 +81,19 @@ export class CampaignContactsForm extends React.Component {
     event.preventDefault();
     const file = event.target.files[0];
     this.setState({ uploading: true }, () => {
-      parseCSV(file, ({ contacts, customFields, validationStats, error }) => {
-        if (error) {
-          this.handleUploadError(error);
-        } else if (contacts.length === 0) {
-          this.handleUploadError("Upload at least one contact");
-        } else if (contacts.length > 0) {
-          this.handleUploadSuccess(
-            validationStats,
-            this.organizationCustomFields(contacts, customFields),
-            customFields
-          );
-        }
-      });
+      parseCSV(
+        file,
+        ({ contacts, customFields, validationStats, error }) => {
+          if (error) {
+            this.handleUploadError(error);
+          } else if (contacts.length === 0) {
+            this.handleUploadError("Upload at least one contact");
+          } else if (contacts.length > 0) {
+            this.handleUploadSuccess(validationStats, contacts, customFields);
+          }
+        },
+        { headerTransformer: ensureCamelCaseRequiredHeaders }
+      );
     });
   };
 
@@ -73,26 +103,6 @@ export class CampaignContactsForm extends React.Component {
       uploading: false,
       contactUploadError: error,
       contacts: null
-    });
-  }
-
-  organizationCustomFields(contacts, customFieldsList) {
-    return contacts.map(contact => {
-      const customFields = {};
-      const contactInput = {
-        cell: contact.cell,
-        first_name: contact.firstName,
-        last_name: contact.lastName,
-        zip: contact.zip || "",
-        external_id: contact.external_id || ""
-      };
-      customFieldsList.forEach(key => {
-        if (contact.hasOwnProperty(key)) {
-          customFields[key] = contact[key];
-        }
-      });
-      contactInput.custom_fields = JSON.stringify(customFields);
-      return contactInput;
     });
   }
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -40,4 +40,8 @@ export {
 } from "./permissions";
 
 export { gzip, gunzip } from "./gzip";
-export { parseCSV } from "./parse_csv.js";
+export {
+  parseCSV,
+  requiredUploadFields,
+  organizationCustomFields
+} from "./parse_csv.js";

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -1,9 +1,8 @@
 import Papa from "papaparse";
 import _ from "lodash";
 import { getFormattedPhoneNumber, getFormattedZip } from "../lib";
-import humps from "humps";
 
-const requiredUploadFields = ["firstName", "lastName", "cell"];
+export const requiredUploadFields = ["firstName", "lastName", "cell"];
 const topLevelUploadFields = [
   "firstName",
   "lastName",
@@ -54,36 +53,67 @@ const getValidatedData = data => {
   };
 };
 
-const ensureCamelCaseRequiredHeaders = columnHeader => {
-  /*
-   * This function changes:
-   *  first_name to firstName
-   *  last_name to lastName
-   *
-   * It changes no other fields.
-   *
-   * If other fields that could be either snake_case or camelCase
-   * are added to `requiredUploadFields` it will do the same for them.
-   * */
-  const camelizedColumnHeader = humps.camelize(columnHeader);
-  if (
-    requiredUploadFields.includes(camelizedColumnHeader) &&
-    camelizedColumnHeader !== columnHeader
-  ) {
-    return camelizedColumnHeader;
-  }
-
-  return columnHeader;
+export const organizationCustomFields = (contacts, customFieldsList) => {
+  return contacts.map(contact => {
+    const customFields = {};
+    const contactInput = {
+      cell: contact.cell,
+      first_name: contact.firstName,
+      last_name: contact.lastName,
+      zip: contact.zip || "",
+      external_id: contact.external_id || ""
+    };
+    customFieldsList.forEach(key => {
+      if (contact.hasOwnProperty(key)) {
+        customFields[key] = contact[key];
+      }
+    });
+    contactInput.custom_fields = JSON.stringify(customFields);
+    return contactInput;
+  });
 };
 
-export const parseCSV = (file, callback) => {
+export const parseCSV = (file, onCompleteCallback, options) => {
+  // options is a custom object that currently supports two properties
+  // rowTransformer -- a function that gets called on each row in the file
+  //   after it is parsed. It takes 2 parameters, an array of fields and
+  //   the object that results from parsing the row. It returns an object
+  //   after transformation. The function can do lookups, field mappings,
+  //   remove fields, add fields, etc. If it adds fields, it should push
+  //   them onto the fields array in the first parameter.
+  // headerTransformer -- a function that gets called once after the
+  //   header row is parsed. It takes one parameter, the header name, and
+  //   returns the header that should be used for the column. An example
+  //   would be to transform first_name to firstName, which is a required
+  //   field in Spoke.
+  const { rowTransformer, headerTransformer } = options || {};
   Papa.parse(file, {
     header: true,
-    transformHeader: ensureCamelCaseRequiredHeaders,
+    ...(headerTransformer && { transformHeader: headerTransformer }),
+    skipEmptyLines: true,
     // eslint-disable-next-line no-shadow, no-unused-vars
-    complete: ({ data, meta, errors }, file) => {
+    complete: ({ data: parserData, meta, errors }, file) => {
       const fields = meta.fields;
       const missingFields = [];
+
+      let data = parserData;
+      let transformerResults = {
+        rows: [],
+        fields: []
+      };
+      if (rowTransformer) {
+        transformerResults = parserData.reduce((results, originalRow) => {
+          const { row, addedFields } = rowTransformer(fields, originalRow);
+          results.rows.push(row);
+          addedFields.forEach(field => {
+            if (!fields.includes(field)) {
+              fields.push(field);
+            }
+          });
+          return results;
+        }, transformerResults);
+        data = transformerResults.rows;
+      }
 
       for (const field of requiredUploadFields) {
         if (fields.indexOf(field) === -1) {
@@ -93,7 +123,7 @@ export const parseCSV = (file, callback) => {
 
       if (missingFields.length > 0) {
         const error = `Missing fields: ${missingFields.join(", ")}`;
-        callback({ error });
+        onCompleteCallback({ error });
       } else {
         const { validationStats, validatedData } = getValidatedData(data);
 
@@ -101,10 +131,15 @@ export const parseCSV = (file, callback) => {
           field => topLevelUploadFields.indexOf(field) === -1
         );
 
-        callback({
+        const contactsWithCustomFields = organizationCustomFields(
+          validatedData,
+          customFields
+        );
+
+        onCompleteCallback({
           customFields,
           validationStats,
-          contacts: validatedData
+          contacts: contactsWithCustomFields
         });
       }
     }


### PR DESCRIPTION
# Description
* This PR refactors parseCSV and code related to it
    * It moves:
        * code that will be used by other contact-loader integrations out of csv-upload/react-component.js and into lib/parse_csv.js
        * code that is only used by csv-upload/react-component.js out of lib/parse_csv.js
    * It introduces a third parameter to parseCSV, an options object that currently supports 2 optional keys:
        * rowTransformer -- a function that gets called on each row in the file after it is parsed.  It takes 2 parameters, an array of fields and the object that results from parsing the row.  It returns an object after transformation.  The function can do lookups, field mappings, remove fields, add fields, etc.  If it adds fields, it should push them onto the fields array in the first parameter.
        * headerTransformer -- a function that gets called once after the header row is parsed.  It takes one parameter, the header name, and returns the header that should be used for the column.  An example would be to transform first_name to firstName, which is a required field in Spoke.
    * It adds tests.

It's longer than 300 lines because I added a lot of tests.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [N/A] ~If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [N/A] ~I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A] ~My PR is labeled [WIP] if it is in progress~
