### PR TITLE
completeContactLoad sets fields to 0 instead of null

### DIFF
--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -577,3 +577,24 @@ export const getConversations = async (
   const result = await runGql(conversationsQuery, variables, user);
   return result;
 };
+
+export const createJob = async (campaign, overrides) => {
+  const job = {
+    campaign_id: campaign.id,
+    payload: "fake_payload",
+    queue_name: "1:fake_queue_name",
+    job_type: "fake_job_type",
+    locks_queue: true,
+    assigned: true,
+    status: 0,
+    ...(overrides && overrides)
+  };
+
+  const [job_id] = await r
+    .knex("job_request")
+    .returning("id")
+    .insert(job);
+  job.id = job_id;
+
+  return job;
+};

--- a/__test__/workers/jobs.test.js
+++ b/__test__/workers/jobs.test.js
@@ -120,8 +120,7 @@ describe("completeContactLoad", () => {
       id: 1,
       ingest_data_reference: "fake_ingest_data_reference",
       ingest_method: "fake_job_type",
-      ingest_result: "fake_ingest_result",
-      ingest_success: 1
+      ingest_result: "fake_ingest_result"
     };
   });
 
@@ -133,12 +132,17 @@ describe("completeContactLoad", () => {
       "fake_ingest_result"
     );
 
-    const campaignAdminRecord = await r
+    const campaignAdminResult = await r
       .knex("campaign_admin")
       .where({ campaign_id: campaign.id });
 
-    expect(campaignAdminRecord[0]).toEqual(
+    expect(campaignAdminResult[0]).toEqual(
       expect.objectContaining(expectedCampaignAdminFields)
+    );
+
+    // This will be true on postgres and 1 on sqlite
+    expect([1, true].includes(campaignAdminResult[0].ingest_success)).toEqual(
+      true
     );
   });
 });

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -247,8 +247,8 @@ export async function completeContactLoad(
   const campaign = await Campaign.get(campaignId);
   const organization = await Organization.get(campaign.organization_id);
 
-  let deleteOptOutCells;
-  let deleteDuplicateCells;
+  let deleteOptOutCells = null;
+  let deleteDuplicateCells = null;
   const knexOptOutDeleteResult = await r
     .knex("campaign_contact")
     .whereIn("cell", getOptOutSubQuery(campaign.organization_id))
@@ -295,12 +295,8 @@ export async function completeContactLoad(
     .knex("campaign_admin")
     .where("campaign_id", campaignId)
     .update({
-      deleted_optouts_count:
-        deleteOptOutCells || deleteOptOutCells === 0 ? deleteOptOutCells : null,
-      duplicate_contacts_count:
-        deleteDuplicateCells || deleteDuplicateCells === 0
-          ? deleteDuplicateCells
-          : null,
+      deleted_optouts_count: deleteOptOutCells,
+      duplicate_contacts_count: deleteDuplicateCells,
       contacts_count: finalContactCount,
       ingest_method: job.job_type.replace(/^ingest./, ""),
       ingest_success: true,

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -295,8 +295,12 @@ export async function completeContactLoad(
     .knex("campaign_admin")
     .where("campaign_id", campaignId)
     .update({
-      deleted_optouts_count: deleteOptOutCells || null,
-      duplicate_contacts_count: deleteDuplicateCells || null,
+      deleted_optouts_count:
+        deleteOptOutCells || deleteOptOutCells === 0 ? deleteOptOutCells : null,
+      duplicate_contacts_count:
+        deleteDuplicateCells || deleteDuplicateCells === 0
+          ? deleteDuplicateCells
+          : null,
       contacts_count: finalContactCount,
       ingest_method: job.job_type.replace(/^ingest./, ""),
       ingest_success: true,


### PR DESCRIPTION
## Description

completeContactLoad was setting the columns deleted_optouts_count and duplicate_contacts_count in campaign_admin to null when they should have been set to 0.

Also added a happy-path test for completeContactLoad.

# Checklist:

- [N/A] ~I have manually tested my changes on desktop and mobile~
- [x] The test suite passes locally with my changes
- [N/A] ~If my change is a UI change, I have attached a screenshot to the description section of this pull request~
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [N/A] ~I have made any necessary changes to the documentation~
- [x] I have added tests that prove my fix is effective or that my feature works
- [N/A] ~My PR is labeled [WIP] if it is in progress~
