### PR TITLE
Fix Apollo client store id collisions caused by custom id function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ coverage/
 *.rdb
 package-lock.json
 CONFIG_FILE.json
+scratch/

--- a/src/network/apollo-client-singleton.js
+++ b/src/network/apollo-client-singleton.js
@@ -36,7 +36,12 @@ const networkInterface = addQueryMerging(responseMiddlewareNetworkInterface);
 
 const ApolloClientSingleton = new ApolloClient({
   networkInterface,
-  shouldBatch: true,
-  dataIdFromObject: result => result.id
+  shouldBatch: true
 });
+
+// For debugging
+if (typeof window !== "undefined") {
+  window.ApolloClient = ApolloClientSingleton;
+}
+
 export default ApolloClientSingleton;


### PR DESCRIPTION
This was causing a bunch of subtle bugs, especially on a brand
new instance where user, contact, and campaign ids are all in the
same range of integers. Apollo client keeps query and mutation results
in a flat local store and the custom function was causing it
to just use the id as the key for that store (see screenshots). I assume
this worked great with RethinkDB which I think issues uuids for ids,
but causes collisions when using auto-increment ids.

For example, when user 1 texts contact 1 in campaign 1, the Apollo store
contains an object with those three objects merged. Custom field substitution
breaks because both campaign and campaign_contact have a field called
customFields, but of different types. firstName sometimes gets swapped for
texterFirstName depending on the order in which user and campaign_contact
are fetched, but it didn't happen for the attached screenshots.

The fix is simply to remove the custom dataIdFromObject function.

Note: Newer versions of Apollo client use __typename to prefix keys,
but this version uses the full query for example:
"$ROOT_QUERY.assignment({\"id\":\"1\"})" is the key for the assignment
we fetch with that query, whereas newer versions of Apollo would use
"Assignment.1" or something like that. This is important because
it prevents Apollo from merging the results of queries and mutations
together, and thus requires queries to be re-run more than they
would need to be in newer versions. This commit breaks that behavior
in the current frontend but, at least on the WFP fork, nothing seemed
to be relying on query merging so this change fixed more bugs than
it introduced.

Before:
![ApolloStoreCollision-Before](https://user-images.githubusercontent.com/663093/77598479-510cb500-6ed8-11ea-954a-c6edb595557d.png)

After:
![Screenshot from 2020-03-25 20-15-50](https://user-images.githubusercontent.com/663093/77598520-6a156600-6ed8-11ea-8ac2-f696c19801f1.png)


