### PR TITLE
cmd or ctrl + click opens campaign in new tab

### DIFF
--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -9,7 +9,7 @@ import ArchiveIcon from "material-ui/svg-icons/content/archive";
 import UnarchiveIcon from "material-ui/svg-icons/content/unarchive";
 import IconButton from "material-ui/IconButton";
 import Checkbox from "material-ui/Checkbox";
-import { withRouter } from "react-router";
+import { withRouter, Link } from "react-router";
 import theme from "../styles/theme";
 import Chip from "../components/Chip";
 import loadData from "./hoc/load-data";
@@ -144,33 +144,21 @@ export class CampaignList extends React.Component {
       </span>
     );
 
-    const campaignUrl = `/admin/${this.props.organizationId}/campaigns/${campaign.id}`;
-    return (
+    const campaignListItem = (
       <ListItem
         {...dataTest("campaignRow")}
         style={listItemStyle}
         key={campaign.id}
         primaryText={primaryText}
-        onTouchTap={event => {
-          // if selectMultiple is true, then the checkbox is showing and checked is set to the status of that checkbox.
-          // Otherwise it is set to be a node and is still truthy
-          const {
-            checked
-          } = event.currentTarget.firstElementChild.firstElementChild;
-
+        onTouchTap={({
+          currentTarget: {
+            firstElementChild: {
+              firstElementChild: { checked }
+            }
+          }
+        }) => {
           if (selectMultiple) {
             this.props.handleChecked({ campaignId: campaign.id, checked });
-          } else {
-            if (event.nativeEvent.metaKey || event.nativeEvent.ctrlKey) {
-              // in this case, open in new tab
-              return !isStarted
-                ? window.open(`${campaignUrl}/edit`, "_blank")
-                : window.open(campaignUrl, "_blank");
-            } else {
-              return !isStarted
-                ? this.props.router.push(`${campaignUrl}/edit`)
-                : this.props.router.push(campaignUrl);
-            }
           }
         }}
         secondaryText={secondaryText}
@@ -181,7 +169,20 @@ export class CampaignList extends React.Component {
             : null
         }
         leftCheckbox={selectMultiple ? <Checkbox /> : null}
-      ></ListItem>
+      />
+    );
+
+    const campaignUrl = `/admin/${this.props.organizationId}/campaigns/${campaign.id}`;
+    return selectMultiple ? (
+      campaignListItem
+    ) : (
+      <Link
+        key={campaign.id}
+        style={{ textDecoration: "none" }}
+        to={!isStarted ? `${campaignUrl}/edit` : campaignUrl}
+      >
+        {campaignListItem}
+      </Link>
     );
   }
 

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -152,8 +152,6 @@ export class CampaignList extends React.Component {
         key={campaign.id}
         primaryText={primaryText}
         onTouchTap={event => {
-          event.persist();
-
           // if selectMultiple is true, then the checkbox is showing and checked is set to the status of that checkbox.
           // Otherwise it is set to be a node and is still truthy
           const {

--- a/src/containers/CampaignList.jsx
+++ b/src/containers/CampaignList.jsx
@@ -151,19 +151,28 @@ export class CampaignList extends React.Component {
         style={listItemStyle}
         key={campaign.id}
         primaryText={primaryText}
-        onTouchTap={({
-          currentTarget: {
-            firstElementChild: {
-              firstElementChild: { checked }
-            }
-          }
-        }) => {
+        onTouchTap={event => {
+          event.persist();
+
+          // if selectMultiple is true, then the checkbox is showing and checked is set to the status of that checkbox.
+          // Otherwise it is set to be a node and is still truthy
+          const {
+            checked
+          } = event.currentTarget.firstElementChild.firstElementChild;
+
           if (selectMultiple) {
             this.props.handleChecked({ campaignId: campaign.id, checked });
           } else {
-            return !isStarted
-              ? this.props.router.push(`${campaignUrl}/edit`)
-              : this.props.router.push(campaignUrl);
+            if (event.nativeEvent.metaKey || event.nativeEvent.ctrlKey) {
+              // in this case, open in new tab
+              return !isStarted
+                ? window.open(`${campaignUrl}/edit`, "_blank")
+                : window.open(campaignUrl, "_blank");
+            } else {
+              return !isStarted
+                ? this.props.router.push(`${campaignUrl}/edit`)
+                : this.props.router.push(campaignUrl);
+            }
           }
         }}
         secondaryText={secondaryText}


### PR DESCRIPTION
# Fixes # 1470

## Description

*Problem*
When admins click a campaign card in the admin campaign list view, it opens in the same tab. This means that if an admin wants to scroll down the list and open a bunch of campaigns in tabs it's not very easy to do quickly.

*Solution*
Admins can cmd+click (or ctrl+click on windows) to open campaigns in tabs to help with their workflow.


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
