### PR TITLE
Update the RFC PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/architecture-proposal.md
+++ b/.github/ISSUE_TEMPLATE/architecture-proposal.md
@@ -1,5 +1,5 @@
 ---
-name: Architecture Proposal
+name: Project Proposal
 about: Submit an RFC for a large scale project or a reconciliation with a fork
 title: 'RFC: <your-proposal-title>'
 labels: idea (underspec'd)
@@ -30,7 +30,7 @@ The template leans towards projects that are supported by an organization. We do
 *Which org is backing this plan? If there isn't one yet, do you have one in mind you're in contact with?*
 
 #### Developer allocated
-*Who is on deck to do this work? Is there anyone else in the team who should be mentioned here?*
+*Who is on deck to do this work? Is there anyone else in the team who should be mentioned here? Who is already planning to work on this, and is anyone else needed? Who is the point of contact?*
 
 #### Planned timeline
 *What do you anticipate the feature timeline being?*
@@ -40,6 +40,9 @@ The template leans towards projects that are supported by an organization. We do
 
 #### Any other links to details about the plan (maybe a Google Doc link, or other place where folks have commented)
 *Google docs or other platforms might be better for line by line commenting. If you're coordinating somewhere else in addition to here, paste a link! Remember that github allows anyone to view, so don't post a link with edit permissions*
+
+#### Existing github issues that this RFC will address
+*Write a list of any open issues that this RFC will close or modify*
 
 ## Additional Context:
 *Anything else that would be helpful to share should go here*

--- a/.github/ISSUE_TEMPLATE/architecture-proposal.md
+++ b/.github/ISSUE_TEMPLATE/architecture-proposal.md
@@ -11,16 +11,35 @@ assignees: ''
 RFC stands for "Request for Comment" and is the starting place for a community-wide discussion for new architecture changes, fork reconciliations, or other large scale concerns.
 
 Filling out this issue template allows folks to comment asynchronously, but if the discussion merits more in depth conversation, consider calling a meeting in our slack channel to discuss as a group.
+
+The template leans towards projects that are supported by an organization. We do this to help with the community buy in part of the process since the organizations are the users.
 -->
 
-## Proposal:
+## Proposal
 *Give a summary of what you'd like to add or change*
 
-## Motivation:
+## Motivation
 *Explain why you think we should make this addition or change*
 
-## Detailed Design:
-*Be as specific as you can about how this should be implemented. Include snippets, or links to branches running this code if you have them.*
+## Detailed Design
+*Be as specific as you can about how this should be implemented. Include snippets, or links to branches running this code if you have them*
+
+## Project Plan Information
+
+#### Sponsor Organization (will test alphas/betas)
+*Which org is backing this plan? If there isn't one yet, do you have one in mind you're in contact with?*
+
+#### Developer allocated
+*Who is on deck to do this work? Is there anyone else in the team who should be mentioned here?*
+
+#### Planned timeline
+*What do you anticipate the feature timeline being?*
+
+#### Files/File-sections touched
+*What code will be needed?*
+
+#### Any other links to details about the plan (maybe a Google Doc link, or other place where folks have commented)
+*Google docs or other platforms might be better for line by line commenting. If you're coordinating somewhere else in addition to here, paste a link! Remember that github allows anyone to view, so don't post a link with edit permissions*
 
 ## Additional Context:
 *Anything else that would be helpful to share should go here*


### PR DESCRIPTION
## Description
Add a lot more fields gearing the template towards a more structured discussion.

## Open Question
Should this template be renamed from "Architecture Proposal"? Maybe... "Project Proposal"?