### PR TITLE
contact-loaders: allow per-organization setting for CONTACT_LOADERS

### DIFF
--- a/src/integrations/contact-loaders/index.js
+++ b/src/integrations/contact-loaders/index.js
@@ -75,10 +75,15 @@ export async function getIngestMethod(name, organization, user) {
 }
 
 export async function getAvailableIngestMethods(organization, user) {
+  const enabledIngestMethods = (
+    getConfig("CONTACT_LOADERS", organization) ||
+    "csv-upload,test-fakedata,datawarehouse"
+  ).split(",");
+
   const ingestMethods = await Promise.all(
-    Object.keys(CONFIGURED_INGEST_METHODS).map(name =>
-      getIngestMethod(name, organization, user)
-    )
+    enabledIngestMethods
+      .filter(name => name in CONFIGURED_INGEST_METHODS)
+      .map(name => getIngestMethod(name, organization, user))
   );
   return ingestMethods.filter(x => x);
 }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2,7 +2,6 @@ import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
 import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
-import { organizationCache } from "../models/cacheable_queries/organization";
 
 import { gzip, makeTree } from "../../lib";
 import { capitalizeWord } from "./lib/utils";
@@ -627,7 +626,7 @@ const rootMutations = {
       organization.features = JSON.stringify(featuresJSON);
 
       await organization.save();
-      await organizationCache.clear(organizationId);
+      await cacheableData.organization.clear(organizationId);
 
       return await Organization.get(organizationId);
     },


### PR DESCRIPTION
# Org-specific contact loaders

## Description

While we can currently set CONTACT_LOADERS universally, it would be good to allow us to be able to manually set the list per-organization.  This allows a CONTACT_LOADERS value in organization.features JSON data which can be a subset of the system-level CONTACT_LOADERS value.  (It cannot be a superset with this PR, thoughts?)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
