### PR TITLE
dev-tools: Increase consistency of development entrypoints

### DIFF
--- a/dev-tools/babel-run
+++ b/dev-tools/babel-run
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
-require('babel-register')
-require('babel-polyfill')
-require('../' + process.argv[2])
+require("dotenv").config();
+require("babel-register");
+require("babel-polyfill");
+require("../" + process.argv[2]);

--- a/dev-tools/babel-run-debug
+++ b/dev-tools/babel-run-debug
@@ -1,5 +1,6 @@
 #!/bin/sh
 ":" //# comment; exec /usr/bin/env node --inspect "$0" "$@"
+require("dotenv").config();
 require('babel-register')
 require('babel-polyfill')
 require('../' + process.argv[2])

--- a/dev-tools/babel-run-with-env.js
+++ b/dev-tools/babel-run-with-env.js
@@ -1,5 +1,0 @@
-#!/usr/bin/env node
-require("dotenv").config();
-require("babel-register");
-require("babel-polyfill");
-require("../" + process.argv[2]);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "knex": "knex --knexfile ./knexfile.env.js",
     "clean": "rm -rf $OUTPUT_DIR",
     "lint": "eslint --fix --ext js --ext jsx src",
-    "process-message-csv": "./dev-tools/babel-run-with-env.js ./src/workers/process-message-csv.js",
+    "process-message-csv": "./dev-tools/babel-run ./src/workers/process-message-csv.js",
     "prod-build-client": "webpack --config ./webpack/config.js",
     "prod-build-server": "babel ./src  -d ./build/server --source-maps --copy-files; babel ./migrations -d ./build/server/migrations/ --source-maps --copy-files",
     "prod-build": "npm run clean && npm run prod-build-client && npm run prod-build-server",


### PR DESCRIPTION
This changes the development entry points to consistently use dotenv to load values from `.env`.