### PR TITLE
Add title to campaign edit

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -508,6 +508,7 @@ class AdminCampaignEdit extends React.Component {
           fontSize: 16
         }}
       >
+        <h2>{this.props.campaignData.campaign.title}</h2>
         {this.state.startingCampaign ? (
           <div
             style={{

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -503,7 +503,9 @@ class AdminCampaignEdit extends React.Component {
 
     return (
       <div>
-        <h2>{this.props.campaignData.campaign.title}</h2>
+        {this.props.campaignData.campaign.title && (
+          <h2>{this.props.campaignData.campaign.title}</h2>
+        )}
         <div
           style={{
             marginBottom: 15,

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -502,32 +502,34 @@ class AdminCampaignEdit extends React.Component {
     );
 
     return (
-      <div
-        style={{
-          marginBottom: 15,
-          fontSize: 16
-        }}
-      >
+      <div>
         <h2>{this.props.campaignData.campaign.title}</h2>
-        {this.state.startingCampaign ? (
-          <div
-            style={{
-              color: theme.colors.gray,
-              fontWeight: 800
-            }}
-          >
-            <CircularProgress
-              size={0.5}
+        <div
+          style={{
+            marginBottom: 15,
+            fontSize: 16
+          }}
+        >
+          {this.state.startingCampaign ? (
+            <div
               style={{
-                verticalAlign: "middle",
-                display: "inline-block"
+                color: theme.colors.gray,
+                fontWeight: 800
               }}
-            />
-            Starting your campaign...
-          </div>
-        ) : (
-          notStarting
-        )}
+            >
+              <CircularProgress
+                size={0.5}
+                style={{
+                  verticalAlign: "middle",
+                  display: "inline-block"
+                }}
+              />
+              Starting your campaign...
+            </div>
+          ) : (
+            notStarting
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
# Fixes #840 

## Description

As above, a simple one liner to add the campaign title to the campaign edit view. Title updates if a valid title is submitted successfully in the "Basics" section.

![image](https://user-images.githubusercontent.com/12539396/80037686-ec2d8600-84a8-11ea-8bd1-33aca8333d55.png)