### PR TITLE
track campaign.errorCount in cache

### DIFF
--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -17,6 +17,7 @@ export const schema = `
     contactsCount: Int
     assignedCount: Int
     messagedCount: Int
+    errorCount: Int
   }
 
   type IngestMethod {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -290,7 +290,8 @@ export const resolvers = {
         // 0 should still diffrentiate from null
         assignedCount: stats.assignedCount > -1 ? stats.assignedCount : null,
         // messagedCount won't be defined until some messages are sent
-        messagedCount: stats.assignedCount ? stats.messagedCount || 0 : null
+        messagedCount: stats.assignedCount ? stats.messagedCount || 0 : null,
+        errorCount: stats.errorCount || null
       };
     },
     texters: async (campaign, _, { user }) => {

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -370,10 +370,16 @@ const campaignContactCache = {
       // console.log('lookupByCell cache', cell, service, messageServiceSid, cellData)
       if (cellData) {
         // eslint-disable-next-line camelcase
-        const [campaign_contact_id, _, timezone_offset] = cellData.split(":");
+        const [
+          campaign_contact_id,
+          _,
+          timezone_offset,
+          ...rest
+        ] = cellData.split(":");
         return {
           campaign_contact_id: Number(campaign_contact_id),
-          timezone_offset
+          timezone_offset,
+          campaign_id: rest.length ? rest[0] : undefined
         };
       }
       if (bailWithoutCache) {
@@ -494,7 +500,12 @@ const campaignContactCache = {
           // delay expiration for contacts we continue to update
           .set(
             cellKey,
-            [contact.id, "", contact.timezone_offset || ""].join(":")
+            [
+              contact.id,
+              "",
+              contact.timezone_offset || "",
+              contact.campaign_id || ""
+            ].join(":")
           )
           // delay expiration for contacts we continue to update
           .expire(contactKey, 43200)

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -160,12 +160,19 @@ const campaignCache = {
           infoCacheKey(id),
           "messagedCount"
         );
+        campaignObj.errorCount = await r.redis.hgetAsync(
+          infoCacheKey(id),
+          "errorCount"
+        );
         // console.log('campaign cache', cacheKey(id), campaignObj, campaignData)
         const campaign = modelWithExtraProps(campaignObj, Campaign, [
           "customFields",
           "interactionSteps",
           "contactTimezones",
-          "contactsCount"
+          "contactsCount",
+          "assignedCount",
+          "messagedCount",
+          "errorCount"
         ]);
         return campaign;
       }
@@ -207,13 +214,15 @@ const campaignCache = {
       }
     }
   },
-  incrMessaged: async id => {
+  incrCount: async (id, countType) => {
+    // countType={"messagedCount", "errorCount"}
+    console.log("incrCount", id, countType, CONTACT_CACHE_ENABLED);
     if (r.redis && CONTACT_CACHE_ENABLED) {
       try {
         const infoKey = infoCacheKey(id);
         await r.redis
           .multi()
-          .hincrby(infoKey, "messagedCount", 1)
+          .hincrby(infoKey, countType, 1)
           .expire(infoKey, 43200)
           .execAsync();
       } catch (err) {


### PR DESCRIPTION
# Just like messagedCount and assignedCount, let's track errorCount in cache for fast reporting

## Description

In order to be able to quickly see how many errors have occurred per-campaign, we should cache this value.  This PR moves deliveryReport into the cacheableData to simplify twilio.js further and then increments errorCount just like in the past.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
