### PR TITLE
Action handler client choice data and availability caching

### DIFF
--- a/__test__/integrations/action-handlers/index.test.js
+++ b/__test__/integrations/action-handlers/index.test.js
@@ -1,0 +1,454 @@
+import { r, createLoaders } from "../../../src/server/models";
+import {
+  setupTest,
+  cleanupTest,
+  createStartedCampaign
+} from "../../test_helpers";
+import * as ActionHandlers from "../../../src/integrations/action-handlers";
+const uuidv4 = require("uuid").v4;
+const TestAction = require("../../../src/integrations/action-handlers/test-action");
+const ComplexTestAction = require("../../../src/integrations/action-handlers/complex-test-action");
+
+describe("action-handlers/index", () => {
+  let organization;
+  let user;
+  let campaign;
+  let savedEnvironment;
+
+  beforeAll(async () => {
+    savedEnvironment = { ...process.env };
+
+    await setupTest();
+
+    const startedCampaign = await createStartedCampaign();
+    ({
+      testOrganization: {
+        data: { createOrganization: organization }
+      },
+      testCampaign: campaign,
+      testAdminUser: user
+    } = startedCampaign);
+  });
+
+  afterAll(async () => {
+    await cleanupTest();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  beforeEach(async () => {
+    jest.restoreAllMocks();
+    if (r.redis) {
+      r.redis.flushdb();
+    }
+  });
+
+  afterEach(async () => {
+    const toReset = ["CACHE_PREFIX", "ACTION_HANDLERS"];
+
+    toReset.forEach(thingToReset => {
+      if (!savedEnvironment[thingToReset]) {
+        delete process.env[thingToReset];
+      } else {
+        process.env[thingToReset] = savedEnvironment[thingToReset];
+      }
+    });
+  });
+
+  describe("#availabilityCacheKey", () => {
+    it("returns what we expect", async () => {
+      const cacheKey = ActionHandlers.availabilityCacheKey(
+        "grateful-dead",
+        organization,
+        2
+      );
+      expect(cacheKey).toEqual(
+        `${process.env.CACHE_PREFIX || ""}action-avail-grateful-dead-1-2`
+      );
+    });
+
+    describe("when CACHE_PREFIX is set in the environment", () => {
+      beforeEach(async () => {
+        process.env.CACHE_PREFIX = process.env.CACHE_PREFIX || "my-org";
+      });
+
+      it("returns what we expect", async () => {
+        const cacheKey = ActionHandlers.availabilityCacheKey(
+          "grateful-dead",
+          organization,
+          2
+        );
+        expect(cacheKey).toEqual(
+          `${process.env.CACHE_PREFIX}action-avail-grateful-dead-1-2`
+        );
+      });
+    });
+  });
+
+  describe("#choiceDataCacheKey", () => {
+    it("returns what we expect", async () => {
+      const cacheKey = ActionHandlers.choiceDataCacheKey(
+        "grateful-dead",
+        organization,
+        "1978.04.17"
+      );
+      expect(cacheKey).toEqual(
+        `${process.env.CACHE_PREFIX ||
+          ""}action-choices-grateful-dead-1978.04.17`
+      );
+    });
+
+    describe("when CACHE_PREFIX is set in the environment", () => {
+      beforeEach(async () => {
+        process.env.CACHE_PREFIX = process.env.CACHE_PREFIX || "my-org";
+      });
+
+      it("returns what we expect", async () => {
+        const cacheKey = ActionHandlers.choiceDataCacheKey(
+          "grateful-dead",
+          organization,
+          "1978.04.17"
+        );
+        expect(cacheKey).toEqual(
+          `${process.env.CACHE_PREFIX ||
+            ""}action-choices-grateful-dead-1978.04.17`
+        );
+      });
+    });
+  });
+
+  describe("#getActionHandlers", () => {
+    it("loads test-action and complex-test-action", async () => {
+      const handlers = ActionHandlers.getActionHandlers(organization);
+      expect(handlers).toEqual({
+        "test-action": TestAction,
+        "complex-test-action": ComplexTestAction
+      });
+    });
+
+    describe("when ACTION_HANDLERS are specified in the environment", () => {
+      it("returns the specified handler", async () => {
+        process.env.ACTION_HANDLERS = "test-action";
+        const handlers = ActionHandlers.getActionHandlers(organization);
+        expect(handlers).toEqual({ "test-action": TestAction });
+      });
+
+      describe("when there is more than one action handler", () => {
+        it("returns both of them", async () => {
+          process.env.ACTION_HANDLERS = "test-action,complex-test-action";
+          const handlers = ActionHandlers.getActionHandlers(organization);
+          expect(handlers).toEqual({
+            "test-action": TestAction,
+            "complex-test-action": ComplexTestAction
+          });
+        });
+
+        describe("and one doesn't exist in the directory", () => {
+          it("returns the one that exists", async () => {
+            process.env.ACTION_HANDLERS = "test-action,missing-test-action";
+            const handlers = ActionHandlers.getActionHandlers(organization);
+            expect(handlers).toEqual({ "test-action": TestAction });
+          });
+        });
+
+        describe("and none exist in the directory", () => {
+          it("returns the one that exists", async () => {
+            process.env.ACTION_HANDLERS = "missing-test-action";
+            const handlers = ActionHandlers.getActionHandlers(organization);
+            expect(handlers).toEqual({});
+          });
+        });
+      });
+    });
+  });
+
+  describe("#getSetCacheableResult", () => {
+    let fallbackFunction;
+    let cacheKey;
+    beforeEach(async () => {
+      cacheKey = uuidv4();
+      fallbackFunction = jest.fn().mockResolvedValue({
+        data: "hey now",
+        expiresSeconds: 1000
+      });
+    });
+
+    describe("redis is not configured", () => {
+      it("calls the fallback function", async () => {
+        const returned = await ActionHandlers.getSetCacheableResult(
+          cacheKey,
+          fallbackFunction
+        );
+
+        expect(returned).toEqual({
+          data: "hey now",
+          expiresSeconds: 1000
+        });
+        expect(fallbackFunction.mock.calls).toEqual([[]]);
+      });
+    });
+
+    describe("redis is configured", () => {
+      beforeAll(async () => {
+        cacheKey = uuidv4();
+      });
+      it("calls the fallback function once", async () => {
+        // don't run this test if redis is not configured
+        if (!r.redis) {
+          return;
+        }
+
+        let returned = await ActionHandlers.getSetCacheableResult(
+          cacheKey,
+          fallbackFunction
+        );
+        expect(returned).toEqual({
+          data: "hey now",
+          expiresSeconds: 1000
+        });
+        expect(fallbackFunction.mock.calls).toEqual([[]]);
+
+        returned = await ActionHandlers.getSetCacheableResult(
+          cacheKey,
+          fallbackFunction
+        );
+        expect(returned).toEqual({
+          data: "hey now",
+          expiresSeconds: 1000
+        });
+        expect(fallbackFunction.mock.calls).toEqual([[]]);
+      });
+
+      describe("when the fallback function doesn't return expiresSeconds", () => {
+        beforeEach(async () => {
+          fallbackFunction = jest.fn().mockResolvedValue({
+            data: "hey now"
+          });
+        });
+        it("calls the fallback function twice", async () => {
+          // don't run this test if redis is not configured
+          if (!r.redis) {
+            return;
+          }
+
+          let returned = await ActionHandlers.getSetCacheableResult(
+            cacheKey,
+            fallbackFunction
+          );
+          expect(returned).toEqual({
+            data: "hey now"
+          });
+          expect(fallbackFunction.mock.calls).toEqual([[]]);
+
+          returned = await ActionHandlers.getSetCacheableResult(
+            cacheKey,
+            fallbackFunction
+          );
+          expect(returned).toEqual({
+            data: "hey now"
+          });
+          expect(fallbackFunction.mock.calls).toEqual([[], []]);
+        });
+      });
+    });
+  });
+
+  describe("#getActionHandlerAvailability", () => {
+    beforeEach(async () => {
+      jest
+        .spyOn(TestAction, "available")
+        .mockResolvedValue({ result: "fake_result" });
+    });
+    it("calls actionHandler.available", async () => {
+      const returned = await ActionHandlers.getActionHandlerAvailability(
+        "test-action",
+        TestAction,
+        organization,
+        user
+      );
+
+      expect(returned).toEqual("fake_result");
+      expect(TestAction.available.mock.calls).toEqual([[organization, user]]);
+    });
+  });
+
+  describe("#rawActionHandler", () => {
+    it("returns the handler", async () => {
+      expect(ActionHandlers.rawActionHandler("test-action")).toEqual(
+        TestAction
+      );
+    });
+
+    describe("when the handler doesn't exist", () => {
+      it("doesn't return the handler", async () => {
+        expect(ActionHandlers.rawActionHandler("not-a-thing")).toEqual(
+          undefined
+        );
+      });
+    });
+  });
+
+  describe("#rawAllActionHandlers", () => {
+    it("returns the handler", async () => {
+      expect(ActionHandlers.rawAllActionHandlers()).toEqual({
+        "test-action": TestAction,
+        "complex-test-action": ComplexTestAction
+      });
+    });
+  });
+
+  describe("#getActionHandler", () => {
+    it("returns the handler", async () => {
+      const returned = await ActionHandlers.getActionHandler(
+        "test-action",
+        organization,
+        user
+      );
+
+      expect(returned).toEqual(TestAction);
+    });
+
+    describe("when the handler doesn't exist", () => {
+      it("returns nothing", async () => {
+        const returned = await ActionHandlers.getActionHandler(
+          "not-a-handler",
+          organization,
+          user
+        );
+
+        expect(returned).toBe(false);
+      });
+
+      describe("when the handler is unavailable", () => {
+        beforeEach(async () => {
+          jest
+            .spyOn(ComplexTestAction, "available")
+            .mockResolvedValue({ result: false });
+        });
+
+        it("doesn't return it", async () => {
+          const returned = await ActionHandlers.getActionHandler(
+            "complex-test-action",
+            organization,
+            user
+          );
+
+          expect(returned).toBe(false);
+        });
+      });
+    });
+  });
+
+  describe("#getAvailableActionHandlers", () => {
+    it("returns all the handlers", async () => {
+      const returned = await ActionHandlers.getAvailableActionHandlers(
+        organization,
+        user
+      );
+
+      expect(returned).toHaveLength(2);
+      expect(returned).toEqual(
+        expect.arrayContaining([TestAction, ComplexTestAction])
+      );
+    });
+
+    describe("when one of the action handlers is unavailable", () => {
+      beforeEach(async () => {
+        jest
+          .spyOn(ComplexTestAction, "available")
+          .mockResolvedValue({ result: false });
+      });
+
+      it("returns the action handler that is available", async () => {
+        const returned = await ActionHandlers.getAvailableActionHandlers(
+          organization,
+          user
+        );
+
+        expect(returned).toHaveLength(1);
+        expect(returned).toEqual(expect.arrayContaining([TestAction]));
+      });
+    });
+  });
+
+  describe("#getActionChoiceData", () => {
+    let loaders;
+    let expectedReturn;
+
+    beforeEach(async () => {
+      loaders = createLoaders();
+
+      expectedReturn = {
+        items: [
+          {
+            details: '{"hex":"#B22222","rgb":{"r":178,"g":34,"b":34}}',
+            name: "firebrick"
+          },
+          {
+            details: '{"hex":"#4B0082","rgb":{"r":75,"g":0,"b":130}}',
+            name: "indigo"
+          }
+        ]
+      };
+
+      jest.spyOn(ComplexTestAction, "getClientChoiceData");
+      jest.spyOn(ComplexTestAction, "clientChoiceDataCacheKey");
+    });
+
+    it("returns actionChoiceData", async () => {
+      const returned = await ActionHandlers.getActionChoiceData(
+        ComplexTestAction,
+        organization,
+        campaign,
+        user,
+        loaders
+      );
+
+      const parsed = JSON.parse(returned);
+
+      expect(parsed).toEqual(expectedReturn);
+
+      expect(ComplexTestAction.clientChoiceDataCacheKey.mock.calls).toEqual([
+        [organization, campaign, user, loaders]
+      ]);
+
+      expect(ComplexTestAction.getClientChoiceData.mock.calls).toEqual([
+        [organization, campaign, user, loaders]
+      ]);
+
+      // handles the second call from the cache
+      const secondCallReturned = await ActionHandlers.getActionChoiceData(
+        ComplexTestAction,
+        organization,
+        campaign,
+        user,
+        loaders
+      );
+
+      const secondCallParsed = JSON.parse(secondCallReturned);
+
+      expect(secondCallParsed).toEqual(expectedReturn);
+
+      expect(ComplexTestAction.clientChoiceDataCacheKey.mock.calls).toEqual([
+        [organization, campaign, user, loaders],
+        [organization, campaign, user, loaders]
+      ]);
+
+      expect(ComplexTestAction.getClientChoiceData.mock.calls).toEqual([
+        [organization, campaign, user, loaders],
+        ...(!r.redis && [[organization, campaign, user, loaders]])
+      ]);
+    });
+
+    describe("when the handler doesn't have action choice data", () => {
+      it("returns an empty object", async () => {
+        const returned = await ActionHandlers.getActionChoiceData(
+          TestAction,
+          organization,
+          campaign,
+          user,
+          loaders
+        );
+        expect(returned).toEqual("{}");
+      });
+    });
+  });
+});

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -350,7 +350,6 @@ export function buildScript(steps = 2) {
             : "Step Script " + step,
         answerOption: "hmm" + step,
         answerActions: "",
-        answerActionsData: "",
         parentInteractionId: step > 0 ? "new" + (step - 1) : null,
         isDeleted: false,
         interactionSteps: createSteps(step + 1, max)

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -350,6 +350,7 @@ export function buildScript(steps = 2) {
             : "Step Script " + step,
         answerOption: "hmm" + step,
         answerActions: "",
+        answerActionsData: "",
         parentInteractionId: step > 0 ? "new" + (step - 1) : null,
         isDeleted: false,
         interactionSteps: createSteps(step + 1, max)

--- a/migrations/20200328004744_add_answer_actions_data.js
+++ b/migrations/20200328004744_add_answer_actions_data.js
@@ -1,0 +1,13 @@
+// Add answer_actions_data column to interaction_step
+exports.up = function(knex) {
+  return knex.schema.alterTable("interaction_step", table => {
+    table.text("answer_actions_data").nullable();
+  });
+};
+
+// Drop answer_actions_data column from interaction_step
+exports.down = function(knex) {
+  return knex.schema.alterTable("interaction_step", table => {
+    table.dropColumn("answer_actions_data");
+  });
+};

--- a/src/api/interaction-step.js
+++ b/src/api/interaction-step.js
@@ -8,6 +8,7 @@ export const schema = `
     parentInteractionId: String
     isDeleted: Boolean
     answerActions: String
+    answerActionsData: String
     questionResponse(campaignContactId: String): QuestionResponse
   }
 `;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -86,6 +86,7 @@ const rootSchema = gql`
     script: String
     answerOption: String
     answerActions: String
+    answerActionsData: String
     parentInteractionId: String
     isDeleted: Boolean
     interactionSteps: [InteractionStepInput]

--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -50,6 +50,7 @@ export default class CampaignInteractionStepsForm extends React.Component {
             answerOption: "",
             script: "",
             answerActions: "",
+            answerActionsData: "",
             isDeleted: false
           }
         ],
@@ -96,6 +97,7 @@ export default class CampaignInteractionStepsForm extends React.Component {
             script: "",
             answerOption: "",
             answerActions: "",
+            answerActionsData: "",
             isDeleted: false
           }
         ]

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -59,6 +59,7 @@ const campaignInfoFragment = `
     script
     answerOption
     answerActions
+    answerActionsData
     parentInteractionId
     isDeleted
   }

--- a/src/integrations/action-handlers/actionkit-rsvp.js
+++ b/src/integrations/action-handlers/actionkit-rsvp.js
@@ -2,6 +2,7 @@ import request from "request";
 import { r } from "../../server/models";
 import crypto from "crypto";
 
+export const name = "actionkit-rsvp";
 export const displayName = () => "ActionKit Event RSVP";
 
 export const instructions = () =>
@@ -13,29 +14,36 @@ export const instructions = () =>
   `;
 
 export async function available(organizationId) {
+  let isAvailable = false;
   if (process.env.AK_BASEURL && process.env.AK_SECRET) {
-    return true;
+    isAvailable = true;
+  } else {
+    const org = await r
+      .knex("organization")
+      .where("id", organizationId)
+      .select("features");
+    const features = JSON.parse(org.features || "{}");
+    let needed = [];
+    if (!process.env.AK_BASEURL && !features.AK_BASEURL) {
+      needed.push("AK_BASEURL");
+    }
+    if (!process.env.AK_SECRET && !features.AK_SECRET) {
+      needed.push("AK_SECRET");
+    }
+    if (needed.length) {
+      console.error(
+        "actionkit-rsvp unavailable because " +
+          needed.join(", ") +
+          " must be set (either in environment variables or json value for organization)"
+      );
+    }
+    isAvailable = !!needed.length;
   }
-  const org = await r
-    .knex("organization")
-    .where("id", organizationId)
-    .select("features");
-  const features = JSON.parse(org.features || "{}");
-  let needed = [];
-  if (!process.env.AK_BASEURL && !features.AK_BASEURL) {
-    needed.push("AK_BASEURL");
-  }
-  if (!process.env.AK_SECRET && !features.AK_SECRET) {
-    needed.push("AK_SECRET");
-  }
-  if (needed.length) {
-    console.error(
-      "actionkit-rsvp unavailable because " +
-        needed.join(", ") +
-        " must be set (either in environment variables or json value for organization)"
-    );
-  }
-  return !!needed.length;
+
+  return {
+    result: isAvailable,
+    expiresSeconds: 60
+  };
 }
 
 export const akidGenerate = function(ak_secret, cleartext) {

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -1,16 +1,25 @@
 import request from "request";
 import { r } from "../../server/models";
 
-export const name = "test-action";
+export const name = "complex-test-action";
 
 // What the user sees as the option
-export const displayName = () => "Test Action";
+export const displayName = () => "Complex Test Action";
 
 // The Help text for the user after selecting the action
 export const instructions = () =>
   `
   This action is for testing and as a code-template for new actions.
   `;
+
+export function clientChoiceDataCacheKey(
+  organization,
+  campaign,
+  user,
+  loaders
+) {
+  return `${organization.id}`;
+}
 
 // return true, if the action is usable and available for the organizationId
 // Sometimes this means certain variables/credentials must be setup
@@ -46,4 +55,35 @@ export async function processAction(
     .knex("campaign_contact")
     .where("campaign_contact.id", campaignContactId)
     .update("custom_fields", JSON.stringify(customFields));
+}
+
+export async function getClientChoiceData(organization, user) {
+  const items = [
+    {
+      name: "firebrick",
+      details: JSON.stringify({
+        hex: "#B22222",
+        rgb: {
+          r: 178,
+          g: 34,
+          b: 34
+        }
+      })
+    },
+    {
+      name: "indigo",
+      details: JSON.stringify({
+        hex: "#4B0082",
+        rgb: {
+          r: 75,
+          g: 0,
+          b: 130
+        }
+      })
+    }
+  ];
+  return {
+    data: `${JSON.stringify({ items })}`,
+    expiresSeconds: 300
+  };
 }

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -1,0 +1,122 @@
+import { getConfig } from "../../server/api/lib/config";
+import { r } from "../../server/models";
+import { log } from "../../lib";
+
+export const availabilityCacheKey = (name, organization, userId) =>
+  `${getConfig("CACHE_PREFIX", organization) || ""}action-avail-${name}-${
+    organization.id
+  }-${userId}`;
+
+export const choiceDataCacheKey = (name, organization, suffix) =>
+  `${getConfig("CACHE_PREFIX", organization) ||
+    ""}action-choices-${name}-${suffix}`;
+
+export function getActionHandlers(organization) {
+  const enabledActionHandlers = (
+    getConfig("ACTION_HANDLERS", organization) ||
+    "test-action,complex-test-action"
+  ).split(",");
+  const actionHandlers = {};
+  enabledActionHandlers.forEach(name => {
+    try {
+      const c = require(`./${name}.js`);
+      actionHandlers[name] = c;
+    } catch (err) {
+      log.error(
+        `ACTION_HANDLERS failed to load actionhandler ${name} -- ${err}`
+      );
+    }
+  });
+  return actionHandlers;
+}
+
+// TODO(lmp) how do we get organization into this?
+const CONFIGURED_ACTION_HANDLERS = getActionHandlers();
+
+export async function getSetCacheableResult(cacheKey, fallbackFunc) {
+  if (r.redis) {
+    const cacheRes = await r.redis.getAsync(cacheKey);
+    if (cacheRes) {
+      return JSON.parse(cacheRes);
+    }
+  }
+  const slowRes = await fallbackFunc();
+  if (r.redis && slowRes && slowRes.expiresSeconds) {
+    await r.redis
+      .multi()
+      .set(cacheKey, JSON.stringify(slowRes))
+      .expire(cacheKey, slowRes.expiresSeconds)
+      .execAsync();
+  }
+  return slowRes;
+}
+
+export async function getActionHandlerAvailability(
+  name,
+  actionHandler,
+  organization,
+  user
+) {
+  return (await getSetCacheableResult(
+    availabilityCacheKey(name, organization, user.id),
+    async () => actionHandler.available(organization, user)
+  )).result;
+}
+
+export function rawActionHandler(name) {
+  /// RARE: You should almost always use getActionHandler() below,
+  /// unless workflow has already tested availability for the org-user
+  return CONFIGURED_ACTION_HANDLERS[name];
+}
+
+export function rawAllActionHandlers() {
+  return CONFIGURED_ACTION_HANDLERS;
+}
+
+export async function getActionHandler(name, organization, user) {
+  let isAvail;
+  if (name in CONFIGURED_ACTION_HANDLERS) {
+    isAvail = await getActionHandlerAvailability(
+      name,
+      CONFIGURED_ACTION_HANDLERS[name],
+      organization,
+      user
+    );
+  }
+  return !!isAvail && CONFIGURED_ACTION_HANDLERS[name];
+}
+
+export async function getAvailableActionHandlers(organization, user) {
+  const actionHandlers = await Promise.all(
+    Object.keys(CONFIGURED_ACTION_HANDLERS).map(name =>
+      getActionHandler(name, organization, user)
+    )
+  );
+  return actionHandlers.filter(x => x);
+}
+
+export async function getActionChoiceData(
+  actionHandler,
+  organization,
+  campaign,
+  user,
+  loaders
+) {
+  const cacheKeyFunc =
+    actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);
+  const clientChoiceDataFunc =
+    actionHandler.getClientChoiceData ||
+    (() => ({
+      data: "{}"
+    }));
+  const cacheKey = choiceDataCacheKey(
+    actionHandler.name,
+    organization,
+    cacheKeyFunc(organization, campaign, user, loaders)
+  );
+  return (
+    (await getSetCacheableResult(cacheKey, async () =>
+      clientChoiceDataFunc(organization, campaign, user, loaders)
+    )) || {}
+  ).data;
+}

--- a/src/integrations/action-handlers/mobilecommons-signup.js
+++ b/src/integrations/action-handlers/mobilecommons-signup.js
@@ -2,6 +2,9 @@ import request from "request";
 import aws from "aws-sdk";
 import { r } from "../../server/models";
 import { actionKitSignup } from "./helper-ak-sync.js";
+
+export const name = "mobilecommons-signup";
+
 // What the user sees as the option
 export const displayName = () => "Mobile Commons Signup";
 
@@ -21,10 +24,10 @@ export const instructions = () =>
   "This option triggers a new user request to Upland Mobile Commons when selected.";
 
 export async function available(organizationId) {
-  if (organizationId && umcConfigured) {
-    return true;
-  }
-  return false;
+  return {
+    result: organizationId && umcConfigured,
+    expiresSeconds: 60
+  };
 }
 
 export async function processAction(

--- a/src/integrations/action-handlers/revere-signup.js
+++ b/src/integrations/action-handlers/revere-signup.js
@@ -4,6 +4,9 @@ import { r } from "../../server/models";
 import { actionKitSignup } from "./helper-ak-sync.js";
 
 const sqs = new aws.SQS();
+
+export const name = "revere-signup";
+
 // What the user sees as the option
 export const displayName = () => "Revere Signup";
 
@@ -20,10 +23,10 @@ export const instructions = () =>
   "This option triggers a new user request to Revere when selected.";
 
 export async function available(organizationId) {
-  if (organizationId && listId && mobileApiKey) {
-    return true;
-  }
-  return false;
+  return {
+    result: organizationId && listId && mobileApiKey,
+    expiresSeconds: 60
+  };
 }
 
 export async function processAction(

--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -122,6 +122,7 @@ export function assembleAnswerOptions(allInteractionSteps) {
           nextInteractionStep: interactionStep,
           value: interactionStep.answer_option,
           action: interactionStep.answer_actions,
+          action_data: interactionStep.answer_actions_data,
           interaction_step_id: interactionStep.id,
           parent_interaction_step: interactionStep.parent_interaction_id
         });

--- a/src/server/api/interaction-step.js
+++ b/src/server/api/interaction-step.js
@@ -9,6 +9,7 @@ export const resolvers = {
         "script",
         "answerOption",
         "answerActions",
+        "answerActionsData",
         "parentInteractionId",
         "isDeleted"
       ],

--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -247,6 +247,7 @@ const saveInteractionsHierarchyNode = async (
       script: interactionsHierarchyNode.script.join("\n") || "",
       answer_option: interactionsHierarchyNode.answer || "",
       answer_actions: "",
+      answer_actions_data: "",
       campaign_id: campaignId,
       is_deleted: false
     })
@@ -363,9 +364,11 @@ const importScriptFromDocument = async (campaignId, scriptUrl) => {
   let result;
   try {
     result = await getDocument(documentId);
-  } catch(err) {
-    console.error('ImportScript Failed', err);
-    throw new Error(`Retrieving Google doc failed due to access, secret config, or invalid google url`);
+  } catch (err) {
+    console.error("ImportScript Failed", err);
+    throw new Error(
+      `Retrieving Google doc failed due to access, secret config, or invalid google url`
+    );
   }
   const document = result.data.body.content;
   const sections = getSections(document);

--- a/src/server/api/question.js
+++ b/src/server/api/question.js
@@ -14,6 +14,7 @@ export const resolvers = {
         .map({
           value: r.row("answer_option"),
           action: r.row("answer_actions"),
+          actionData: r.row("answer_actions_data"),
           interaction_step_id: r.row("id"),
           parent_interaction_step: r.row("parent_interaction_id")
         }),

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -267,6 +267,7 @@ async function updateInteractionSteps(
         script: is.script,
         answer_option: is.answerOption,
         answer_actions: is.answerActions,
+        answer_actions_data: is.answerActionsData,
         campaign_id: campaignId,
         is_deleted: false
       });
@@ -290,6 +291,7 @@ async function updateInteractionSteps(
             script: is.script,
             answer_option: is.answerOption,
             answer_actions: is.answerActions,
+            answer_actions_data: is.answerActionsData,
             is_deleted: is.isDeleted
           });
       }
@@ -701,6 +703,7 @@ const rootMutations = {
             script: interaction.script,
             answerOption: interaction.answer_option,
             answerActions: interaction.answer_actions,
+            answerActionsData: interaction.answer_actions_data,
             isDeleted: interaction.is_deleted,
             campaign_id: newCampaignId,
             parentInteractionId: "new" + interaction.parent_interaction_id
@@ -713,6 +716,7 @@ const rootMutations = {
             script: interaction.script,
             answerOption: interaction.answer_option,
             answerActions: interaction.answer_actions,
+            answerActionsData: interaction.answer_actions_data,
             isDeleted: interaction.is_deleted,
             campaign_id: newCampaignId,
             parentInteractionId: interaction.parent_interaction_id

--- a/src/server/models/interaction-step.js
+++ b/src/server/models/interaction-step.js
@@ -26,6 +26,7 @@ const InteractionStep = thinky.createModel(
       parent_interaction_id: optionalString().foreign("interaction_step"),
       answer_option: optionalString(), // (was 'value')
       answer_actions: optionalString(),
+      answer_actions_data: optionalString(),
       is_deleted: type
         .boolean()
         .default(false)


### PR DESCRIPTION
# Fixes #1512

## Description

This PR introduces a a small framework for action handlers. 

Included:

- A wrapper around action handlers that takes care of caching, in order to avoid expensive calls to external services to ascertain availability and retrieve client choice data
- Updates to existing action handlers to make them compliant with the framework
- A new trivial reference implementation called `complex-test-action` that demonstrates the implementation of `getClientChoiceData`
- Updates to action handler documentation **(This is the small part that's still WIP)**


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
