### PR TITLE
Add permissions checks to importCampaignScript and updateQuestionResp…

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1105,8 +1105,10 @@ const rootMutations = {
     updateQuestionResponses: async (
       _,
       { questionResponses, campaignContactId },
-      { loaders }
+      { loaders, user }
     ) => {
+      // TODO: check that the user has TEXTER role for the campaign
+      await authRequired(user);
       const count = questionResponses.length;
 
       for (let i = 0; i < count; i++) {
@@ -1230,8 +1232,9 @@ const rootMutations = {
         newTexterUserId
       );
     },
-    importCampaignScript: async (_, { campaignId, url }, { loaders }) => {
+    importCampaignScript: async (_, { campaignId, url }, { loaders, user }) => {
       const campaign = await loaders.campaign.load(campaignId);
+      await accessRequired(user, campaignId.organization_id, "ADMIN", true);
       if (campaign.is_started || campaign.is_archived) {
         throw new GraphQLError(
           "Cannot import a campaign script for a campaign that is started or archived"

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1107,8 +1107,14 @@ const rootMutations = {
       { questionResponses, campaignContactId },
       { loaders, user }
     ) => {
-      // TODO: check that the user has TEXTER role for the campaign
-      await authRequired(user);
+      const contact = await loaders.campaignContact.load(campaignContactId);
+      const campaign = await loaders.campaign.load(contact.campaign_id);
+      await assignmentRequiredOrAdminRole(
+        user,
+        campaign.organization_id,
+        contact.assignment_id,
+        contact
+      );
       const count = questionResponses.length;
 
       for (let i = 0; i < count; i++) {
@@ -1162,8 +1168,7 @@ const rootMutations = {
       // update cache
       await cacheableData.questionResponse.clearQuery(campaignContactId);
 
-      const contact = loaders.campaignContact.load(campaignContactId);
-      return contact;
+      return loaders.campaignContact.load(campaignContactId);
     },
     reassignCampaignContacts: async (
       _,


### PR DESCRIPTION
…onses

## Description

I noticed this while working on something else, updateQuestionResponses could be tightened up to require TEXTER access or an assignment.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
