### PR TITLE
Show contact upload progress with contact loaders

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -431,9 +431,8 @@ class AdminCampaignEdit extends React.Component {
     let jobId = null;
     if (pendingJobs.length > 0) {
       if (section.title === "Contacts") {
-        relatedJob = pendingJobs.filter(
-          job =>
-            job.jobType === "upload_contacts" || job.jobType === "contact_sql"
+        relatedJob = pendingJobs.filter(job =>
+          job.jobType.startsWith("ingest")
         )[0];
       } else if (section.title === "Texters") {
         relatedJob = pendingJobs.filter(


### PR DESCRIPTION
## Description

It looks like the job types changed with contact loader changes, this brings back the progress indicator on the campaign edit page.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
