### PR TITLE
Preserve Question Responses created_at across updates.

### DIFF
--- a/__test__/server/models/question-response.test.js
+++ b/__test__/server/models/question-response.test.js
@@ -1,0 +1,59 @@
+import {
+  createStartedCampaign,
+  createScript,
+  setupTest,
+  cleanupTest,
+  sleep
+} from "../../test_helpers";
+import { r, cacheableData } from "../../../src/server/models";
+
+describe("questionResponse cacheableData methods", async () => {
+  let initData;
+  beforeEach(async () => {
+    await setupTest();
+    initData = await createStartedCampaign();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  it("save and load", async () => {
+    const cid = initData.testContacts[0].id;
+    await createScript(
+      initData.testAdminUser,
+      initData.testCampaign,
+      null,
+      3,
+      2
+    );
+    const interactionSteps = await r.knex("interaction_step").select();
+    await cacheableData.questionResponse.save(cid, [
+      { interactionStepId: "1", value: "hmm1" }
+    ]);
+    let questionResponses = await r.knex("question_response").select();
+    expect(questionResponses.length).toBe(1);
+    expect(questionResponses[0].value).toBe("hmm1");
+    expect(questionResponses[0].interaction_step_id).toBe(1);
+    let firstCreatedAt = questionResponses[0].created_at;
+    // cached
+    questionResponses = await cacheableData.questionResponse.query(cid, true);
+    expect(questionResponses.length).toBe(1);
+    expect(questionResponses[0].value).toBe("hmm1");
+    expect(questionResponses[0].interaction_step_id).toBe(1);
+    await sleep(20);
+    // change value adding one
+    await cacheableData.questionResponse.save(cid, [
+      { interactionStepId: "1", value: "hmm1" },
+      { interactionStepId: "2", value: "1hmm2" }
+    ]);
+    questionResponses = await r.knex("question_response").select();
+    expect(questionResponses.length).toBe(2);
+    expect(questionResponses[0].value).toBe("hmm1");
+    expect(questionResponses[0].interaction_step_id).toBe(1);
+    expect(Number(questionResponses[0].created_at)).toBe(
+      Number(firstCreatedAt)
+    );
+  });
+});

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -8,7 +8,7 @@ _May 2020:_ Version 5.5
     - We put a lot of work into this interface to accomodate upcoming features, radically improve the mobile (and generally cross-screen support) and address some issues that regularly come up for texters.
     - Please send your experience reports in testing
     - More context can be seen at [RFC: New Texter UI](https://github.com/MoveOnOrg/Spoke/pull/1522)
-  - EXPERIMENTAL_TAGS: Tagging users instead of just saving question responses is a very common request, and we have a great volunteer team developing these features. This first step is creating an admin interface to create the tags. There will be more to come, but you can preview and test this development by enabling the environment variable. Thanks to @aschneit and @filafb and TKTK
+  - EXPERIMENTAL_TAGS: Tagging users instead of just saving question responses is a very common request, and we have a great volunteer team developing these features. This first step is creating an admin interface to create the tags. There will be more to come, but you can preview and test this development by enabling the environment variable. Thanks to @aschneit and @filafb!
 
 (a cypress stub was also merged into main for e2e tests recently)
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1105,8 +1105,10 @@ const rootMutations = {
     updateQuestionResponses: async (
       _,
       { questionResponses, campaignContactId },
-      { loaders }
+      { loaders, user }
     ) => {
+      // TODO: check that the user has TEXTER role for the campaign
+      await authRequired(user);
       const count = questionResponses.length;
 
       for (let i = 0; i < count; i++) {
@@ -1230,8 +1232,9 @@ const rootMutations = {
         newTexterUserId
       );
     },
-    importCampaignScript: async (_, { campaignId, url }, { loaders }) => {
+    importCampaignScript: async (_, { campaignId, url }, { loaders, user }) => {
       const campaign = await loaders.campaign.load(campaignId);
+      await accessRequired(user, campaignId.organization_id, "ADMIN", true);
       if (campaign.is_started || campaign.is_archived) {
         throw new GraphQLError(
           "Cannot import a campaign script for a campaign that is started or archived"

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1107,8 +1107,14 @@ const rootMutations = {
       { questionResponses, campaignContactId },
       { loaders, user }
     ) => {
-      // TODO: check that the user has TEXTER role for the campaign
-      await authRequired(user);
+      const contact = await loaders.campaignContact.load(campaignContactId);
+      const campaign = await loaders.campaign.load(contact.campaign_id);
+      await assignmentRequiredOrAdminRole(
+        user,
+        campaign.organization_id,
+        contact.assignment_id,
+        contact
+      );
       const count = questionResponses.length;
 
       for (let i = 0; i < count; i++) {
@@ -1162,8 +1168,7 @@ const rootMutations = {
       // update cache
       await cacheableData.questionResponse.clearQuery(campaignContactId);
 
-      const contact = loaders.campaignContact.load(campaignContactId);
-      return contact;
+      return loaders.campaignContact.load(campaignContactId);
     },
     reassignCampaignContacts: async (
       _,

--- a/src/server/models/cacheable_queries/README.md
+++ b/src/server/models/cacheable_queries/README.md
@@ -122,6 +122,9 @@ manually referencing a key inline.  All root keys are prefixed by the environmen
   * KEY `cell-${cell}-${messageServiceSid}`
     * value=`{contact_id}::{timezone_offset}`
     * This is saved on the sending of the first message, for easy lookup of the contact info when a response comes in from the contact.  This is done through the api `.updateStatus(contact, newStatus)`. You can access the data from `.lookupByCell(cell, service, messageServiceSid)`
+* questionResponse (only when `REDIS_CONTACT_CACHE=1`)
+  * KEY `qresponse-${contactId}`
+    * stores JSON array of `[{interaction_step_id, value}, ....]`
 * message (only when `REDIS_CONTACT_CACHE=1`)
   * LIST `messages-${contactId}`
     * Includes all message data

--- a/src/server/models/cacheable_queries/question-response.js
+++ b/src/server/models/cacheable_queries/question-response.js
@@ -1,16 +1,31 @@
 import { r } from "../../models";
 
 /*
-HASH: response-<campaignContactId>
-key = question_response.interaction_step_id
-value = question_response.value
+KEY: qresponse-<campaignContactId>
+value = JSON-string array: [{value, interaction_step_id}...]
 */
 
 const responseCacheKey = campaignContactId =>
-  `${process.env.CACHE_PREFIX || ""}response-${campaignContactId}`;
+  `${process.env.CACHE_PREFIX || ""}qresponse-${campaignContactId}`;
 
 const CONTACT_CACHE_ENABLED =
   process.env.REDIS_CONTACT_CACHE || global.REDIS_CONTACT_CACHE;
+
+const loadToCache = async campaignContactId => {
+  const questionResponseValues = await r
+    .knex("question_response")
+    .where("question_response.campaign_contact_id", campaignContactId)
+    .select("value", "interaction_step_id");
+  if (r.redis && CONTACT_CACHE_ENABLED) {
+    const cacheKey = responseCacheKey(campaignContactId);
+    await r.redis
+      .multi()
+      .set(cacheKey, JSON.stringify(questionResponseValues))
+      .expire(cacheKey, 43200)
+      .execAsync();
+  }
+  return questionResponseValues;
+};
 
 const questionResponseCache = {
   query: async (campaignContactId, minimalObj) => {
@@ -19,23 +34,12 @@ const questionResponseCache = {
     // server/api/campaign-contact
     if (r.redis && CONTACT_CACHE_ENABLED && minimalObj) {
       const cacheKey = responseCacheKey(campaignContactId);
-      const [exists, cachedResponse] = await r.redis
-        .multi()
-        .exists(cacheKey)
-        .hgetall(cacheKey)
-        .execAsync();
-      if (exists && cachedResponse) {
-        const formattedResponse = Object.keys(cachedResponse).map(key => ({
-          interaction_step_id: key,
-          value: cachedResponse[key]
-        }));
-        return formattedResponse;
+      const cachedResponse = await r.redis.getAsync(cacheKey);
+      if (cachedResponse) {
+        return JSON.parse(cachedResponse);
       }
     }
-    return await r
-      .knex("question_response")
-      .where("question_response.campaign_contact_id", campaignContactId)
-      .select("value", "interaction_step_id");
+    return await loadToCache(campaignContactId);
   },
   clearQuery: async campaignContactId => {
     // console.log('clearing questionresponse cache', campaignContactId)
@@ -43,28 +47,83 @@ const questionResponseCache = {
       await r.redis.delAsync(responseCacheKey(campaignContactId));
     }
   },
-  reloadQuery: async campaignContactId => {
+  save: async (campaignContactId, questionResponses) => {
+    // This is a bit elaborate because we want to preserve the created_at time
+    // Otherwise, we could just delete all and recreate
+    if (!campaignContactId) {
+      return; // guard for delete command
+    }
+    const deleteQuery = r
+      .knex("question_response")
+      .where("campaign_contact_id", campaignContactId)
+      .delete();
+    if (!questionResponses.length) {
+      await deleteQuery;
+    } else {
+      try {
+        await r.knex.transaction(async trx => {
+          const dbResponses = await r
+            .knex("question_response")
+            .transacting(trx)
+            .forUpdate()
+            .where("question_response.campaign_contact_id", campaignContactId)
+            .select("value", "interaction_step_id");
+          const insertQuestionResponses = [];
+          const updateStepIds = [];
+          const newIds = {};
+          questionResponses.forEach(qr => {
+            newIds[qr.interactionStepId] = 1;
+            const existing = dbResponses.filter(
+              db => db.interaction_step_id === Number(qr.interactionStepId)
+            );
+            const newObj = {
+              campaign_contact_id: campaignContactId,
+              interaction_step_id: qr.interactionStepId,
+              value: qr.value
+            };
+            if (!existing.length) {
+              insertQuestionResponses.push(newObj);
+            } else if (existing[0].value !== qr.value) {
+              updateStepIds.push(qr.interactionStepId);
+              // will be both deleted and inserted
+              insertQuestionResponses.push(newObj);
+            }
+          });
+          const deletes = dbResponses
+            .map(db => db.interaction_step_id)
+            .filter(id => !(id in newIds));
+          deletes.push(...updateStepIds);
+          if (deletes.length) {
+            await deleteQuery.whereIn("interaction_step_id", deletes);
+          }
+          if (insertQuestionResponses.length) {
+            await r.knex("question_response").insert(insertQuestionResponses);
+          }
+        });
+      } catch (error) {
+        console.log("questionResponse cache transaction error", error);
+      }
+    }
     if (r.redis && CONTACT_CACHE_ENABLED) {
-      const questionResponseValues = await r
-        .knex("question_response")
-        .where("question_response.campaign_contact_id", campaignContactId)
-        .select("value", "interaction_step_id");
-
-      const valueInteractionArray = questionResponseValues.reduce(
-        (acc, qrv) => {
-          acc.push(qrv.interaction_step_id, qrv.value);
-          return acc;
-        },
-        []
-      );
-
       const cacheKey = responseCacheKey(campaignContactId);
       await r.redis
         .multi()
-        .del(cacheKey)
-        .hmset(cacheKey, ...valueInteractionArray)
+        .set(
+          cacheKey,
+          JSON.stringify(
+            questionResponses.map(qr => ({
+              value: qr.value,
+              interaction_step_id: Number(qr.interactionStepId)
+            }))
+          )
+        )
         .expire(cacheKey, 43200)
         .execAsync();
+    }
+  },
+  reloadQuery: async campaignContactId => {
+    if (r.redis && CONTACT_CACHE_ENABLED) {
+      await loadToCache(campaignContactId);
     }
   }
 };


### PR DESCRIPTION
# Adds a method for questionResponses to be updated without changing created_at

## Description

In the current updateQuestionResponses method, all question response records for a contact are deleted and then recreated.  This is simple and effective.  However, for some reports, it's useful to be able to keep the created_at date, so it can be matched against a message it was chosen for/from.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
