### PR TITLE
github: Add 10m timeouts to each jest job

### DIFF
--- a/.github/workflows/jest-tests.yaml
+++ b/.github/workflows/jest-tests.yaml
@@ -5,6 +5,7 @@ on: push
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     strategy:
       matrix:
         node-version: [10.x, 11.x, 12.x]
@@ -38,6 +39,7 @@ jobs:
     - run: yarn test
   test-rediscache:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       redis:
         image: redis
@@ -68,6 +70,7 @@ jobs:
     - run: yarn test-rediscache
   test-sqlite:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       redis:
         image: redis
@@ -89,6 +92,7 @@ jobs:
     - run: yarn test-sqlite
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     services:
       redis:
         image: redis


### PR DESCRIPTION
Fixes #1546 

## Description
This adds a 10m timeout to get much faster feedback and prevents wasting resources.

This does not address why the coverage job is failing to end cleanly.