### PR TITLE
Run coverage with --runInBand to avoid weird problems

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test-rediscache": "REDIS_URL=redis://localhost:6379 CACHE_PREFIX=test REDIS_CONTACT_CACHE=1 jest --runInBand --forceExit --detectOpenHandles",
     "test-e2e": "jest --runInBand --config jest.config.e2e.js",
     "test-sqlite": "jest --config jest.config.sqlite.js --runInBand --forceExit --detectOpenHandles",
-    "test-coverage": "jest --coverage --detectOpenHandles",
+    "test-coverage": "jest --coverage --detectOpenHandles --runInBand",
     "test-coverage-bothbackends": "jest --runInBand --config jest.config.sqlite.js -- __test__/backend.test.js && jest --coverage",
     "knex": "knex --knexfile ./knexfile.env.js",
     "clean": "rm -rf $OUTPUT_DIR",


### PR DESCRIPTION
## Description

I was seeing coverage fail to run (both in CI and locally) and --runInBand seems to fix it.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
