### PR TITLE
Migration To Add Roles VETTED_TEXTER, ORG_SUPERADMIN, SUSPENDED

### DIFF
--- a/migrations/20190207220000_init_db.js
+++ b/migrations/20190207220000_init_db.js
@@ -297,13 +297,13 @@ const initialize = async (knex, Promise) => {
         t.increments("id");
         t.integer("user_id").notNullable();
         t.integer("organization_id").notNullable();
-        t.enu("role", [
-          "OWNER",
-          "ADMIN",
-          "SUPERVOLUNTEER",
-          "TEXTER"
-        ]).notNullable();
 
+        const roles = ["OWNER", "ADMIN", "SUPERVOLUNTEER", "TEXTER"];
+        // In `20200512143258_add_user_roles` we use raw SQL to add some roles for Postgres DBs. For Sqlite DBs we init with all the values because that same raw SQL won't work.
+        if (isSqlite) {
+          roles.push("VETTED_TEXTER", "ORG_SUPERADMIN", "SUSPENDED");
+        }
+        t.enu("role", roles).notNullable();
         t.index("user_id");
         t.foreign("user_id").references("user.id");
         t.index("organization_id");

--- a/migrations/20200512143258_add_user_roles.js
+++ b/migrations/20200512143258_add_user_roles.js
@@ -1,0 +1,35 @@
+// Add VETTED_TEXTER, ORG_SUPERADMIN, and SUSPENDED as a values in the `role` enumeration
+exports.up = (knex, Promise) => {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  if (isSqlite) {
+    return Promise.resolve();
+  }
+  return knex.schema.raw(`
+    ALTER TABLE "user_organization" DROP CONSTRAINT "user_organization_role_check";
+    ALTER TABLE "user_organization" ADD CONSTRAINT "user_organization_role_check" CHECK (role IN (
+      'OWNER'::text,
+      'ADMIN'::text,
+      'SUPERVOLUNTEER'::text,
+      'TEXTER'::text,
+      'VETTED_TEXTER'::text,
+      'ORG_SUPERADMIN'::text,
+      'SUSPENDED'::text
+    ))
+  `);
+};
+
+exports.down = (knex, Promise) => {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  if (isSqlite) {
+    return Promise.resolve();
+  }
+  return knex.schema.raw(`
+    ALTER TABLE "user_organization" DROP CONSTRAINT "user_organization_role_check";
+    ALTER TABLE "user_organization" ADD CONSTRAINT "user_organization_role_check" CHECK (role IN (
+      'OWNER'::text,
+      'ADMIN'::text,
+      'SUPERVOLUNTEER'::text,
+      'TEXTER'::text
+    ))
+`);
+};

--- a/src/server/models/user-organization.js
+++ b/src/server/models/user-organization.js
@@ -13,7 +13,15 @@ const UserOrganization = thinky.createModel(
       id: type.string(),
       user_id: requiredString(),
       organization_id: requiredString(),
-      role: requiredString().enum("OWNER", "ADMIN", "SUPERVOLUNTEER", "TEXTER")
+      role: requiredString().enum(
+        "OWNER",
+        "ADMIN",
+        "SUPERVOLUNTEER",
+        "TEXTER",
+        "VETTED_TEXTER",
+        "ORG_SUPERADMIN",
+        "SUSPENDED"
+      )
     })
     .allowExtra(false),
   { noAutoCreation: true, dependencies: [User, Organization] }


### PR DESCRIPTION
# Step one of https://github.com/MoveOnOrg/Spoke/issues/1487

## Description
We want to enable deletion of a user from the People page. We decided to implement this as setting a user to the `SUSPENDED` role, which will be kind of like a soft-delete. This is the first step in that implementation, which is adding the new `SUSPENDED` role to the enumeration of possible values for `role` in the DB. While we're adding roles, we're adding two new roles `VETTED_TEXTER` and `ORG_SUPERADMIN`
per this discussion: https://progressivehacknight.slack.com/archives/C72UMMAGP/p1589376686004000

Nothing is exposed as of this Pull Request, and there are no tests yet to verify the migration worked. I tested locally and it worked on Postgres and Sqlite. Tests pass locally and on github.

There is a failure on this branch, but the same failure appears on this branch, which is essentially the same as `main` except for a trivial change to the README. https://github.com/JeremyParker/Spoke/tree/testing-the-tests Therefore, I believe the failure is unrelated to these changes.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
