### PR TITLE
Required text inputs on the campaign basics tab

### DIFF
--- a/src/components/CampaignBasicsForm.jsx
+++ b/src/components/CampaignBasicsForm.jsx
@@ -70,21 +70,21 @@ export default class CampaignBasicsForm extends React.Component {
           <Form.Field
             {...dataTest("title")}
             name="title"
-            label="Title"
+            label="Title (required)"
             hintText="e.g. Election Day 2016"
             fullWidth
           />
           <Form.Field
             {...dataTest("description")}
             name="description"
-            label="Description"
+            label="Description (required)"
             hintText="Get out the vote"
             fullWidth
           />
           <Form.Field
             {...dataTest("dueBy")}
             name="dueBy"
-            label="Due date"
+            label="Due date (required)"
             type="date"
             locale="en-US"
             shouldDisableDate={date => moment(date).diff(moment()) < 0}


### PR DESCRIPTION
# Fixes #1433

## Description

We don't have any indicators that certain fields in campaign basics admin tab are required until an admin clicks the submit button and it fails. This adds "(required)" to the required fields.

I'd also love for description to not be required. I could add that to this PR. Is there a reason that description is required?

### Screenshot
<img width="710" alt="Screen Shot 2020-05-20 at 8 19 05 PM" src="https://user-images.githubusercontent.com/3953117/82509925-39683c00-9ad7-11ea-9c4e-08891c8d6cce.png">


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
