### PR TITLE
Spoke 6.0 send message bugfix

### DIFF
--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -294,7 +294,7 @@ const mapMutationsToProps = ({ ownProps }) => ({
       limit,
       addToOrganizationMessagingService
     },
-    refetchQueries: ["getdata"]
+    refetchQueries: ["getOrganizationData"]
   })
 });
 

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -118,6 +118,12 @@ const createLoaders = () => loaders;
 
 const r = thinky.r;
 
+if (process.env.ENABLE_KNEX_TRACING === "true") {
+  r.knex.on("query", ({ sql, bindings }) =>
+    console.debug("TRACE:", sql, bindings)
+  );
+}
+
 export {
   loaders,
   createLoaders,


### PR DESCRIPTION
## Description

Fixes broken message sending caused by the Twilio lib refactor and message service fetching when using campaign messaging services.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
