### PR TITLE
Don't write function in schema.js for imported mutation implementations

### DIFF
--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -426,20 +426,16 @@ export async function sendMessage(campaignContactId, user, message) {
 }
 
 export async function bulkSendMessages(assignmentId, user) {
-  const rootValue = {};
   const query = `
     mutation bulkSendMessage($assignmentId: Int!) {
         bulkSendMessages(assignmentId: $assignmentId) {
           id
         }
       }`;
-  const context = getContext({
-    user
-  });
   const variables = {
     assignmentId
   };
-  return await graphql(mySchema, query, rootValue, context, variables);
+  return runGql(query, variables, user);
 }
 
 export function buildScript(steps = 2, choices = 1) {
@@ -685,8 +681,7 @@ export const getConversations = async (
         }
       `;
 
-  const result = await runGql(conversationsQuery, variables, user);
-  return result;
+  return runGql(conversationsQuery, variables, user);
 };
 
 export const createJob = async (campaign, overrides) => {

--- a/src/server/api/mutations/bulkSendMessages.js
+++ b/src/server/api/mutations/bulkSendMessages.js
@@ -8,7 +8,11 @@ import { getTopMostParent, log } from "../../../lib";
 
 import { sendMessage, findNewCampaignContact } from "./index";
 
-export const bulkSendMessages = async (assignmentId, loaders, user) => {
+export const bulkSendMessages = async (
+  _,
+  { assignmentId },
+  { loaders, user }
+) => {
   if (!process.env.ALLOW_SEND_ALL || !process.env.NOT_IN_USA) {
     log.error("Not allowed to send all messages at once");
     throw new GraphQLError({
@@ -21,9 +25,13 @@ export const bulkSendMessages = async (assignmentId, loaders, user) => {
 
   // Assign some contacts
   await findNewCampaignContact(
-    assignmentId,
-    Number(process.env.BULK_SEND_CHUNK_SIZE) - 1,
-    user
+    undefined,
+    {
+      assignment,
+      assignmentId,
+      numberContacts: Number(process.env.BULK_SEND_CHUNK_SIZE) - 1
+    },
+    { user }
   );
 
   const contacts = await r
@@ -51,7 +59,7 @@ export const bulkSendMessages = async (assignmentId, loaders, user) => {
   const texter = camelCaseKeys(await User.get(assignment.user_id));
   const customFields = Object.keys(JSON.parse(contacts[0].custom_fields));
 
-  const contactMessages = await contacts.map(async contact => {
+  const promises = contacts.map(async contact => {
     contact.customFields = contact.custom_fields;
     const text = applyScript({
       contact: camelCaseKeys(contact),
@@ -66,8 +74,13 @@ export const bulkSendMessages = async (assignmentId, loaders, user) => {
       text,
       assignmentId
     };
-    await sendMessage(contactMessage, contact.id, loaders, user);
+    return sendMessage(
+      undefined,
+      { message: contactMessage, campaignContactId: contact.id },
+      { loaders, user }
+    );
   });
 
+  const contactMessages = await Promise.all(promises);
   return contactMessages;
 };

--- a/src/server/api/mutations/findNewCampaignContact.js
+++ b/src/server/api/mutations/findNewCampaignContact.js
@@ -1,19 +1,15 @@
-import {
-  log
-} from "../../../lib";
-import {
-  Assignment,
-  Campaign,
-  r
-} from "../../models";
-import {
-  assignmentRequired
-} from "../errors";
+import { log } from "../../../lib";
+import { Assignment, Campaign, r } from "../../models";
+import { assignmentRequired } from "../errors";
 
-
-export const findNewCampaignContact = async (assignmentId, numberContacts, user) => {
+export const findNewCampaignContact = async (
+  _,
+  { assignment: assignmentParameter, assignmentId, numberContacts },
+  { user }
+) => {
   /* This attempts to find a new contact for the assignment, in the case that useDynamicAssigment == true */
-  const assignment = await Assignment.get(assignmentId);
+  const assignment =
+    assignmentParameter || (await Assignment.get(assignmentId));
   await assignmentRequired(user, assignmentId, assignment);
 
   const campaign = await Campaign.get(assignment.campaign_id);
@@ -55,13 +51,13 @@ export const findNewCampaignContact = async (assignmentId, numberContacts, user)
       "id",
       "in",
       r
-      .knex("campaign_contact")
-      .where({
-        assignment_id: null,
-        campaign_id: campaign.id
-      })
-      .limit(numberContacts)
-      .select("id")
+        .knex("campaign_contact")
+        .where({
+          assignment_id: null,
+          campaign_id: campaign.id
+        })
+        .limit(numberContacts)
+        .select("id")
     )
     .update({
       assignment_id: assignmentId

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -11,10 +11,9 @@ const JOBS_SAME_PROCESS = !!(
 );
 
 export const sendMessage = async (
-  message,
-  campaignContactId,
-  loaders,
-  user
+  _,
+  { message, campaignContactId },
+  { loaders, user }
 ) => {
   let contact = await loaders.campaignContact.load(campaignContactId);
   const campaign = await loaders.campaign.load(contact.campaign_id);

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -64,10 +64,10 @@ import { symmetricEncrypt } from "./lib/crypto";
 import Twilio from "twilio";
 
 import {
-  sendMessage,
   bulkSendMessages,
+  buyPhoneNumbers,
   findNewCampaignContact,
-  buyPhoneNumbers
+  sendMessage
 } from "./mutations";
 
 const ActionHandlers = require("../../integrations/action-handlers");
@@ -321,7 +321,10 @@ async function updateInteractionSteps(
 
 const rootMutations = {
   RootMutation: {
+    bulkSendMessages,
     buyPhoneNumbers,
+    findNewCampaignContact,
+    sendMessage,
     userAgreeTerms: async (_, { userId }, { user, loaders }) => {
       if (user.id === Number(userId)) {
         return user.terms ? user : null;
@@ -1046,14 +1049,6 @@ const rootMutations = {
       }
       return contacts;
     },
-    findNewCampaignContact: async (
-      _,
-      { assignmentId, numberContacts },
-      { user }
-    ) => {
-      return await findNewCampaignContact(assignmentId, numberContacts, user);
-    },
-
     createOptOut: async (
       _,
       { optOut, campaignContactId },
@@ -1095,16 +1090,6 @@ const rootMutations = {
       loaders.campaignContact.clear(campaignContactId.toString());
 
       return loaders.campaignContact.load(campaignContactId);
-    },
-    bulkSendMessages: async (_, { assignmentId }, { loaders, user }) => {
-      return await bulkSendMessages(assignmentId, loaders, user);
-    },
-    sendMessage: async (
-      _,
-      { message, campaignContactId },
-      { loaders, user }
-    ) => {
-      return await sendMessage(message, campaignContactId, loaders, user);
     },
     deleteQuestionResponses: async (
       _,


### PR DESCRIPTION
## Description

Refactor `sendMessages`, `bulkSendMessages` and `findNewContact` to the new pattern of importing the mutation and including it using object member shorthand  in `[rootMutations](https://github.com/lperson/Spoke/blob/71617231131632cbe135f961c667d24e3f1e5658/src/server/api/schema.js#L322-L328)`.

This is what the beginning of `rootMutations` looks like now.  The first four mutations were imported, and I adjusted the parameters of the imported mutations to match what we expect when graphql calls the mutation.

```
const rootMutations = {
  RootMutation: {
    bulkSendMessages,
    buyPhoneNumbers,
    findNewCampaignContact,
    sendMessage,
```



# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
