### PR TITLE
Sidebox org settings

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -88,6 +88,10 @@ const rootSchema = gql`
     timezone: String
   }
 
+  input OrganizationInput {
+    texterUIConfig: TexterUIConfigInput
+  }
+
   input MessageInput {
     text: String
     contactNumber: Phone
@@ -226,6 +230,10 @@ const rootSchema = gql`
     createInvite(invite: InviteInput!): Invite
     createCampaign(campaign: CampaignInput!): Campaign
     editCampaign(id: String!, campaign: CampaignInput!): Campaign
+    editOrganization(
+      id: String!
+      organization: OrganizationInput!
+    ): Organization
     deleteJob(campaignId: String!, id: String!): JobRequest
     copyCampaign(id: String!): Campaign
     exportCampaign(id: String!): JobRequest

--- a/src/components/CampaignTexterUIForm.jsx
+++ b/src/components/CampaignTexterUIForm.jsx
@@ -117,7 +117,6 @@ export default class CampaignTexterUIForm extends React.Component {
 }
 
 CampaignTexterUIForm.propTypes = {
-  sideboxOptions: type.string,
   formValues: type.object,
   organization: type.object,
   onChange: type.func,

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -336,32 +336,34 @@ class Settings extends React.Component {
         </Card>
         <div>{this.renderTextingHoursForm()}</div>
         {window.TWILIO_MULTI_ORG && this.renderTwilioAuthForm()}
-        <Card>
-          <CardHeader
-            title="Texter UI Defaults"
-            style={{ backgroundColor: theme.colors.green }}
-          />
-          <CardText>
-            <CampaignTexterUIForm
-              formValues={this.props.data.organization}
-              organization={this.props.data.organization}
-              sideboxOptions={
-                this.props.data.organization.texterUIConfig.sideboxOptions
-              }
-              onSubmit={async () => {
-                const { texterUIConfig } = this.state;
-                await this.props.mutations.editOrganization({ texterUIConfig });
-                this.setState({ texterUIConfig: null });
-              }}
-              onChange={formValues => {
-                console.log("change", formValues);
-                this.setState(formValues);
-              }}
-              saveLabel="Save Texter UI Campaign Defaults"
-              saveDisabled={!this.state.texterUIConfig}
+        {this.props.data.organization &&
+        this.props.data.organization.texterUIConfig.sideboxChoices.length ? (
+          <Card>
+            <CardHeader
+              title="Texter UI Defaults"
+              style={{ backgroundColor: theme.colors.green }}
             />
-          </CardText>
-        </Card>
+            <CardText>
+              <CampaignTexterUIForm
+                formValues={this.props.data.organization}
+                organization={this.props.data.organization}
+                onSubmit={async () => {
+                  const { texterUIConfig } = this.state;
+                  await this.props.mutations.editOrganization({
+                    texterUIConfig
+                  });
+                  this.setState({ texterUIConfig: null });
+                }}
+                onChange={formValues => {
+                  console.log("change", formValues);
+                  this.setState(formValues);
+                }}
+                saveLabel="Save Texter UI Campaign Defaults"
+                saveDisabled={!this.state.texterUIConfig}
+              />
+            </CardText>
+          </Card>
+        ) : null}
       </div>
     );
   }

--- a/src/integrations/texter-sideboxes/components.js
+++ b/src/integrations/texter-sideboxes/components.js
@@ -1,7 +1,8 @@
 function getComponents() {
-  const enabledComponents = (
-    global.TEXTER_SIDEBOXES || "contact-reference"
-  ).split(",");
+  const enabledComponents =
+    "TEXTER_SIDEBOXES" in global
+      ? (global.TEXTER_SIDEBOXES && global.TEXTER_SIDEBOXES.split(",")) || []
+      : [];
   const components = {};
   enabledComponents.forEach(componentName => {
     try {

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -1,0 +1,35 @@
+import { getConfig, getFeatures } from "../lib/config";
+import { accessRequired } from "../errors";
+import { r, cacheableData } from "../../models";
+
+export const editOrganization = async (
+  _,
+  { id, organization },
+  { loaders, user }
+) => {
+  await accessRequired(user, id, "OWNER", true);
+  const orgRecord = cacheableData.organization.load(id);
+  const features = getFeatures(orgRecord);
+  const changes = {};
+
+  if (organization.texterUIConfig) {
+    // update texterUIConfig
+    features.TEXTER_UI_SETTINGS = organization.texterUIConfig.options;
+    changes["features"] = features;
+  }
+
+  if (Object.keys(changes).length) {
+    if (changes.features) {
+      changes.features = JSON.stringify(changes.features);
+    }
+    await r
+      .knex("organization")
+      .where("id", id)
+      .update(changes);
+  }
+
+  await cacheableData.organization.clear(id);
+  return loaders.organization.load(id);
+};
+
+export default editOrganization;

--- a/src/server/api/mutations/index.js
+++ b/src/server/api/mutations/index.js
@@ -1,17 +1,19 @@
-import { sendMessage } from "./sendMessage";
 import { bulkSendMessages } from "./bulkSendMessages";
+import { buyPhoneNumbers } from "./buyPhoneNumbers";
+import { editOrganization } from "./editOrganization";
 import { findNewCampaignContact } from "./findNewCampaignContact";
+import { joinOrganization } from "./joinOrganization";
+import { sendMessage } from "./sendMessage";
 import { updateContactTags } from "./updateContactTags";
 import { updateQuestionResponses } from "./updateQuestionResponses";
-import { buyPhoneNumbers } from "./buyPhoneNumbers";
-import { joinOrganization } from "./joinOrganization";
 
 export {
-  sendMessage,
   bulkSendMessages,
+  buyPhoneNumbers,
+  editOrganization,
   findNewCampaignContact,
   joinOrganization,
+  sendMessage,
   updateContactTags,
-  updateQuestionResponses,
-  buyPhoneNumbers
+  updateQuestionResponses
 };

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -84,7 +84,8 @@ export const resolvers = {
       await accessRequired(user, organization.id, "OWNER");
       const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
       // note this is global, since we need the set that's globally enabled/allowed to choose from
-      const sideboxChoices = (getConfig("TEXTER_SIDEBOXES") || "").split(",");
+      const sideboxConfig = getConfig("TEXTER_SIDEBOXES");
+      const sideboxChoices = (sideboxConfig && sideboxConfig.split(",")) || [];
       return {
         options,
         sideboxChoices

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -82,7 +82,7 @@ export const resolvers = {
     textingHoursEnd: organization => organization.texting_hours_end,
     texterUIConfig: async (organization, _, { user }) => {
       await accessRequired(user, organization.id, "OWNER");
-      const options = getConfig("TEXTER_UI_SETTINGS", organization);
+      const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
       // note this is global, since we need the set that's globally enabled/allowed to choose from
       const sideboxChoices = (getConfig("TEXTER_SIDEBOXES") || "").split(",");
       return {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -67,6 +67,7 @@ import {
   buyPhoneNumbers,
   findNewCampaignContact,
   joinOrganization,
+  editOrganization,
   sendMessage,
   updateContactTags,
   updateQuestionResponses
@@ -337,6 +338,7 @@ const rootMutations = {
   RootMutation: {
     bulkSendMessages,
     buyPhoneNumbers,
+    editOrganization,
     findNewCampaignContact,
     joinOrganization,
     sendMessage,


### PR DESCRIPTION
Allows default settings for texter sideboxes inside org settings for campaigns.

## Description

This also creates a more generic `editOrganization` mutation that we should consider moving some of the other org saving mutations into and use the pattern that's in AdminCampaignEdit.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
