### PR TITLE
Return to request-scoped data loaders

### DIFF
--- a/__test__/integrations/action-handlers/index.test.js
+++ b/__test__/integrations/action-handlers/index.test.js
@@ -1,4 +1,4 @@
-import { r, createLoaders } from "../../../src/server/models";
+import { r } from "../../../src/server/models";
 import each from "jest-each";
 import {
   setupTest,
@@ -532,12 +532,9 @@ describe("action-handlers/index", () => {
   });
 
   describe("#getActionChoiceData", () => {
-    let loaders;
     let expectedReturn;
 
     beforeEach(async () => {
-      loaders = createLoaders();
-
       expectedReturn = [
         {
           details: '{"hex":"#B22222","rgb":{"r":178,"g":34,"b":34}}',
@@ -557,38 +554,36 @@ describe("action-handlers/index", () => {
       const returned = await ActionHandlers.getActionChoiceData(
         ComplexTestAction,
         organization,
-        user,
-        loaders
+        user
       );
 
       expect(returned).toEqual(expectedReturn);
 
       expect(ComplexTestAction.clientChoiceDataCacheKey.mock.calls).toEqual([
-        [organization, user, loaders]
+        [organization, user]
       ]);
 
       expect(ComplexTestAction.getClientChoiceData.mock.calls).toEqual([
-        [organization, user, loaders]
+        [organization, user]
       ]);
 
       // handles the second call from the cache
       const secondCallReturned = await ActionHandlers.getActionChoiceData(
         ComplexTestAction,
         organization,
-        user,
-        loaders
+        user
       );
 
       expect(secondCallReturned).toEqual(expectedReturn);
 
       expect(ComplexTestAction.clientChoiceDataCacheKey.mock.calls).toEqual([
-        [organization, user, loaders],
-        [organization, user, loaders]
+        [organization, user],
+        [organization, user]
       ]);
 
       expect(ComplexTestAction.getClientChoiceData.mock.calls).toEqual([
-        [organization, user, loaders],
-        ...(!r.redis && [[organization, user, loaders]])
+        [organization, user],
+        ...(!r.redis && [[organization, user]])
       ]);
     });
 
@@ -597,8 +592,7 @@ describe("action-handlers/index", () => {
         const returned = await ActionHandlers.getActionChoiceData(
           TestAction,
           organization,
-          user,
-          loaders
+          user
         );
         expect(returned).toEqual([]);
       });
@@ -621,8 +615,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             { id: 99 },
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual(expectedReturn);
           expect(ActionHandlers.getSetCacheableResult.mock.calls).toEqual([
@@ -642,8 +635,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
         });
@@ -659,8 +651,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
         });
@@ -677,8 +668,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
         });
@@ -695,8 +685,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
         });
@@ -714,8 +703,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
           expect(log.error.mock.calls).toEqual([
@@ -740,8 +728,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual(expectedReturn);
           expect(log.error.mock.calls).toEqual([
@@ -769,8 +756,7 @@ describe("action-handlers/index", () => {
           const returned = await ActionHandlers.getActionChoiceData(
             fakeAction,
             organization,
-            user,
-            loaders
+            user
           );
           expect(returned).toEqual([]);
           expect(log.error.mock.calls).toEqual([

--- a/__test__/server/api/campaign/updateQuestionResponses.test.js
+++ b/__test__/server/api/campaign/updateQuestionResponses.test.js
@@ -16,7 +16,7 @@ import * as Mutations from "../../../../src/server/api/mutations/";
 const ActionHandlers = require("../../../../src/integrations/action-handlers");
 const ComplexTestActionHandler = require("../../../../src/integrations/action-handlers/complex-test-action");
 
-import { r, loaders, cacheableData } from "../../../../src/server/models";
+import { r, cacheableData, createLoaders } from "../../../../src/server/models";
 const errors = require("../../../../src/server/api/errors");
 
 import React from "react";
@@ -46,7 +46,7 @@ describe("mutations.updateQuestionResponses", () => {
   let questionResponses;
   let questionResponseValuesDatabaseSql;
   let organization;
-
+  const loaders = createLoaders();
   beforeEach(async () => {
     await cleanupTest();
     await setupTest();

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -23,7 +23,7 @@ export function serverAdministratorInstructions() {
   };
 }
 
-export function clientChoiceDataCacheKey(organization, user, loaders) {
+export function clientChoiceDataCacheKey(organization, user) {
   return `${organization.id}`;
 }
 

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -142,12 +142,7 @@ export async function getAvailableActionHandlers(organization, user) {
   return actionHandlers.filter(x => x);
 }
 
-export async function getActionChoiceData(
-  actionHandler,
-  organization,
-  user,
-  loaders
-) {
+export async function getActionChoiceData(actionHandler, organization, user) {
   const cacheKeyFunc =
     actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);
   const clientChoiceDataFunc =
@@ -158,7 +153,7 @@ export async function getActionChoiceData(
     cacheKey = exports.choiceDataCacheKey(
       actionHandler.name,
       organization,
-      cacheKeyFunc(organization, user, loaders)
+      cacheKeyFunc(organization, user)
     );
   } catch (caughtException) {
     log.error(
@@ -170,7 +165,7 @@ export async function getActionChoiceData(
   try {
     returned =
       (await exports.getSetCacheableResult(cacheKey, async () =>
-        clientChoiceDataFunc(organization, user, loaders)
+        clientChoiceDataFunc(organization, user)
       )) || {};
   } catch (caughtException) {
     log.error(

--- a/src/integrations/contact-loaders/csv-upload/index.js
+++ b/src/integrations/contact-loaders/csv-upload/index.js
@@ -44,12 +44,7 @@ export function clientChoiceDataCacheKey(organization, campaign, user) {
   return "";
 }
 
-export async function getClientChoiceData(
-  organization,
-  campaign,
-  user,
-  loaders
-) {
+export async function getClientChoiceData(organization, campaign, user) {
   /// data to be sent to the admin client to present options to the component or similar
   /// The react-component will be sent this data as a property
   /// return a json object which will be cached for expiresSeconds long

--- a/src/integrations/contact-loaders/datawarehouse/index.js
+++ b/src/integrations/contact-loaders/datawarehouse/index.js
@@ -67,12 +67,7 @@ export function clientChoiceDataCacheKey(organization, campaign, user) {
   return ""; // independent of org, campaign, and user since it's about availability
 }
 
-export async function getClientChoiceData(
-  organization,
-  campaign,
-  user,
-  loaders
-) {
+export async function getClientChoiceData(organization, campaign, user) {
   /// data to be sent to the admin client to present options to the component or similar
   /// The react-component will be sent this data as a property
   /// return a json object which will be cached for expiresSeconds long

--- a/src/integrations/contact-loaders/index.js
+++ b/src/integrations/contact-loaders/index.js
@@ -94,18 +94,17 @@ export async function getMethodChoiceData(
   ingestMethod,
   organization,
   campaign,
-  user,
-  loaders
+  user
 ) {
   const cacheFunc =
     ingestMethod.clientChoiceDataCacheKey || (org => `${org.id}`);
   const cacheKey = choiceDataCacheKey(
     ingestMethod.name,
-    cacheFunc(organization, campaign, user, loaders)
+    cacheFunc(organization, campaign, user)
   );
   return (
     await getSetCacheableResult(cacheKey, async () =>
-      ingestMethod.getClientChoiceData(organization, campaign, user, loaders)
+      ingestMethod.getClientChoiceData(organization, campaign, user)
     )
   ).data;
 }

--- a/src/integrations/contact-loaders/ngpvan/index.js
+++ b/src/integrations/contact-loaders/ngpvan/index.js
@@ -98,12 +98,7 @@ export function clientChoiceDataCacheKey(organization, campaign, user) {
   return `${organization.id}`;
 }
 
-export async function getClientChoiceData(
-  organization,
-  campaign,
-  user,
-  loaders
-) {
+export async function getClientChoiceData(organization, campaign, user) {
   let responseJson;
 
   try {

--- a/src/integrations/contact-loaders/test-fakedata/index.js
+++ b/src/integrations/contact-loaders/test-fakedata/index.js
@@ -48,12 +48,7 @@ export function clientChoiceDataCacheKey(organization, campaign, user) {
   return `${organization.id}-${campaign.id}`;
 }
 
-export async function getClientChoiceData(
-  organization,
-  campaign,
-  user,
-  loaders
-) {
+export async function getClientChoiceData(organization, campaign, user) {
   /// data to be sent to the admin client to present options to the component or similar
   /// The react-component will be sent this data as a property
   /// return a json object which will be cached for expiresSeconds long

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import { Assignment, r, cacheableData, loaders } from "../models";
+import { Assignment, r, cacheableData } from "../models";
 import { addWhereClauseForContactsFilterMessageStatusIrrespectiveOfPastDue } from "./assignment";
 import { addCampaignsFilterToQuery } from "./campaign";
 import { log } from "../../lib";
@@ -382,7 +382,6 @@ export async function reassignConversations(
       // to be refreshed. We also update the assignment in the cache
       await Promise.all(
         campaignContactIds.map(async campaignContactId => {
-          loaders.campaignContact.clear(campaignContactId.toString());
           await cacheableData.campaignContact.updateAssignmentCache(
             campaignContactId,
             assignmentId,

--- a/src/server/api/mutations/bulkSendMessages.js
+++ b/src/server/api/mutations/bulkSendMessages.js
@@ -81,6 +81,5 @@ export const bulkSendMessages = async (
     );
   });
 
-  const contactMessages = await Promise.all(promises);
-  return contactMessages;
+  return await Promise.all(promises);
 };

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -1,7 +1,7 @@
 import serviceMap from "../lib/services";
 import { accessRequired } from "../errors";
 import { getConfig } from "../lib/config";
-import { JobRequest } from "../../models";
+import { cacheableData, JobRequest } from "../../models";
 import { buyPhoneNumbers as buyNumbersJob } from "../../../workers/jobs";
 
 const JOBS_SAME_PROCESS = !!(
@@ -11,10 +11,10 @@ const JOBS_SAME_PROCESS = !!(
 export const buyPhoneNumbers = async (
   _,
   { organizationId, areaCode, limit, addToOrganizationMessagingService },
-  { loaders, user }
+  { user }
 ) => {
   await accessRequired(user, organizationId, "OWNER");
-  const org = await loaders.organization.load(organizationId);
+  const org = await cacheableData.organization.load(organizationId);
   if (!getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true })) {
     throw new Error("Phone inventory management is not enabled");
   }

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -1,14 +1,10 @@
-import { getConfig, getFeatures } from "../lib/config";
+import { getFeatures } from "../lib/config";
 import { accessRequired } from "../errors";
 import { r, cacheableData } from "../../models";
 
-export const editOrganization = async (
-  _,
-  { id, organization },
-  { loaders, user }
-) => {
+export const editOrganization = async (_, { id, organization }, { user }) => {
   await accessRequired(user, id, "OWNER", true);
-  const orgRecord = cacheableData.organization.load(id);
+  const orgRecord = await cacheableData.organization.load(id);
   const features = getFeatures(orgRecord);
   const changes = {};
 
@@ -29,7 +25,5 @@ export const editOrganization = async (
   }
 
   await cacheableData.organization.clear(id);
-  return loaders.organization.load(id);
+  return await cacheableData.organization.load(id);
 };
-
-export default editOrganization;

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -1,7 +1,6 @@
 import { GraphQLError } from "graphql/error";
 
-import { log } from "../../../lib";
-import { Message, r, cacheableData } from "../../models";
+import { Message, cacheableData } from "../../models";
 import serviceMap from "../lib/services";
 
 import { getSendBeforeTimeUtc } from "../../../lib/timezones";
@@ -15,7 +14,8 @@ export const sendMessage = async (
   { message, campaignContactId },
   { loaders, user }
 ) => {
-  let contact = await loaders.campaignContact.load(campaignContactId);
+  // contact is mutated, so we don't use a loader
+  let contact = await cacheableData.campaignContact.load(campaignContactId);
   const campaign = await loaders.campaign.load(contact.campaign_id);
   if (
     contact.assignment_id !== parseInt(message.assignmentId) ||

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -1,4 +1,4 @@
-import { r, loaders, CampaignContact } from "../../models";
+import { r, CampaignContact } from "../../models";
 import campaignCache from "./campaign";
 import optOutCache from "./opt-out";
 import organizationCache from "./organization";
@@ -219,11 +219,6 @@ const getMessageStatus = async (id, contactObj) => {
   return contact && contact.message_status;
 };
 
-const clearMemoizedCache = id => {
-  loaders.campaignContact.clear(String(id));
-  loaders.campaignContact.clear(Number(id));
-};
-
 const campaignContactCache = {
   clear: async (id, campaignId) => {
     if (r.redis) {
@@ -232,7 +227,6 @@ const campaignContactCache = {
         await r.redis.hdelAsync(contactAssignmentKey(id), id);
       }
     }
-    clearMemoizedCache(id);
   },
   load: async (id, opts) => {
     if (r.redis && CONTACT_CACHE_ENABLED) {
@@ -293,7 +287,6 @@ const campaignContactCache = {
       return;
     }
     console.log("campaign-contact loadMany", campaign.id);
-    loaders.campaignContact.clearAll();
     // 1. load the data
     let query = r
       .knex("campaign_contact")
@@ -432,7 +425,6 @@ const campaignContactCache = {
       assignment_id: newAssignmentId,
       user_id: newUserId
     });
-    clearMemoizedCache(contactId);
   },
   updateCampaignAssignmentCache: async (campaignId, contactIds) => {
     try {
@@ -528,7 +520,6 @@ const campaignContactCache = {
         await redisQuery.execAsync();
         //await updateAssignmentContact(contact, newStatus);
       }
-      clearMemoizedCache(contact.id);
     } catch (err) {
       console.log(
         "contact updateStatus Error",

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -1,4 +1,4 @@
-import { r, loaders, Campaign } from "../../models";
+import { r, Campaign } from "../../models";
 import { modelWithExtraProps } from "./lib";
 import { assembleAnswerOptions } from "../../../lib/interaction-step-helpers";
 import { getFeatures } from "../../api/lib/config";
@@ -63,7 +63,6 @@ const clear = async (id, campaign) => {
     // console.log('clearing campaign cache')
     await r.redis.delAsync(cacheKey(id));
   }
-  loaders.campaign.clear(id);
 };
 
 const loadDeep = async id => {
@@ -77,7 +76,6 @@ const loadDeep = async id => {
     if (campaign.is_archived) {
       // console.log('campaign is_archived')
       // do not cache archived campaigns
-      loaders.campaign.clear(id);
       return campaign;
     }
     // console.log('campaign loaddeep', campaign)
@@ -101,9 +99,6 @@ const loadDeep = async id => {
       .expire(infoCacheKey(id), 43200)
       .execAsync();
   }
-  // console.log('clearing campaign', id, typeof id, loaders.campaign)
-  loaders.campaign.clear(String(id));
-  loaders.campaign.clear(Number(id));
   return null;
 };
 
@@ -184,10 +179,7 @@ const campaignCache = {
         return campaign;
       }
     }
-    if (opts && opts.forceLoad) {
-      loaders.campaign.clear(String(id));
-      loaders.campaign.clear(Number(id));
-    }
+
     return await Campaign.get(id);
   },
   reload: loadDeep,

--- a/src/server/models/cacheable_queries/organization.js
+++ b/src/server/models/cacheable_queries/organization.js
@@ -1,4 +1,4 @@
-import { r, loaders } from "../../models";
+import { r } from "../../models";
 import { getConfig, hasConfig } from "../../api/lib/config";
 import { symmetricDecrypt } from "../../api/lib/crypto";
 
@@ -9,8 +9,6 @@ const organizationCache = {
     if (r.redis) {
       await r.redis.delAsync(cacheKey(id));
     }
-    loaders.organization.clear(String(id));
-    loaders.organization.clear(Number(id));
   },
   getMessageServiceSid: async (organization, contact, messageText) => {
     // Note organization won't always be available, so we'll need to conditionally look it up based on contact

--- a/src/server/models/cacheable_queries/user.js
+++ b/src/server/models/cacheable_queries/user.js
@@ -1,5 +1,5 @@
 import DataLoader from "dataloader";
-import { r, loaders } from "../../models";
+import { r } from "../../models";
 import { isRoleGreater } from "../../../lib/permissions";
 
 /*
@@ -231,8 +231,6 @@ const userCache = {
         await r.redis.delAsync(userAuthKey(authId));
       }
     }
-    loaders.user.clear(Number(userId));
-    loaders.user.clear(String(userId));
   }
 };
 

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -88,7 +88,7 @@ function dropTables() {
   });
 }
 
-const loaders = {
+const createLoaders = () => ({
   // Note: loaders with cacheObj should also run loaders.XX.clear(id)
   //  on clear on the cache as well.
   assignment: createLoader(Assignment),
@@ -112,9 +112,7 @@ const loaders = {
   questionResponse: createLoader(QuestionResponse),
   userCell: createLoader(UserCell),
   userOrganization: createLoader(UserOrganization)
-};
-
-const createLoaders = () => loaders;
+});
 
 const r = thinky.r;
 
@@ -125,7 +123,6 @@ if (process.env.ENABLE_KNEX_TRACING === "true") {
 }
 
 export {
-  loaders,
   createLoaders,
   r,
   cacheableData,


### PR DESCRIPTION
Data loaders cache objects in memory indefinitely, which could cause
any number of issues due to stale reads. The code is full of partial
work-arounds, but none of them can guarantee data freshness without
returning to request-scoped loaders. This change does that
and removes some of of the work-arounds since they are no longer necessary.
I also cleaned up some unnecessary usage of loaders in mutations but left most
intact, even though they don't really offer any advantage over calling
cacheableData.

Note: this PR will probably noticeably increase Redis / PG usage
for some deployments, though probably not that much on Lambda.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
