### PR TITLE
Add a logout button for orgless users, fix data loading on login

### DIFF
--- a/src/containers/Home.jsx
+++ b/src/containers/Home.jsx
@@ -89,6 +89,15 @@ class Home extends React.Component {
             If you got sent a link by somebody to start texting, ask that person
             to send you the link to join their organization. Then, come back
             here and start texting!
+            <br />
+            <br />
+            <a
+              id="logout"
+              className={css(styles.link_dark_bg)}
+              href="/logout-callback"
+            >
+              Logout
+            </a>
           </div>
         </div>
       );
@@ -153,7 +162,10 @@ const queries = {
           }
         }
       }
-    `
+    `,
+    options: ownProps => ({
+      fetchPolicy: "network-only"
+    })
   }
 };
 


### PR DESCRIPTION
Allows users with no organization to logout and sign in as a different user.
The force fetch fixes an occasional issue with login when using local auth introduced with the apollo-client upgrade.

![Screenshot from 2020-06-09 14-33-11](https://user-images.githubusercontent.com/663093/84186219-39b48100-aa5e-11ea-8a8d-45cf947c501a.png)

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
