### PR TITLE
Remove broken message received notifications

### DIFF
--- a/src/server/notifications.js
+++ b/src/server/notifications.js
@@ -1,10 +1,9 @@
-import { r, Assignment, Campaign, User, Organization } from "./models";
+import { r, Campaign, User, Organization } from "./models";
 import { log } from "../lib";
 import { sendEmail } from "./mail";
 
 export const Notifications = {
   CAMPAIGN_STARTED: "campaign.started",
-  ASSIGNMENT_MESSAGE_RECEIVED: "assignment.message.received",
   ASSIGNMENT_CREATED: "assignment.created",
   ASSIGNMENT_UPDATED: "assignment.updated"
 };
@@ -70,51 +69,11 @@ export const sendUserNotification = async notification => {
         Notifications.ASSIGNMENT_CREATED
       );
     }
-  } else if (type === Notifications.ASSIGNMENT_MESSAGE_RECEIVED) {
-    console.log("sendUserNotification", notification);
-    const assignment = await Assignment.get(notification.assignmentId);
-    const campaign = await Campaign.get(assignment.campaign_id);
-    const campaignContact = await r
-      .table("campaign_contact")
-      .getAll(notification.contactNumber, { index: "cell" })
-      .filter({ campaign_id: campaign.id })
-      .limit(1)(0);
-
-    if (!campaignContact.is_opted_out && !campaign.is_archived) {
-      const user = await User.get(assignment.user_id);
-      const organization = await Organization.get(campaign.organization_id);
-      const orgOwner = await getOrganizationOwner(organization.id);
-
-      try {
-        await sendEmail({
-          to: user.email,
-          replyTo: orgOwner.email,
-          subject: `[${organization.name}] [${campaign.title}] New reply`,
-          text: `Someone responded to your message. See all your replies here: \n\n${process.env.BASE_URL}/app/${campaign.organization_id}/todos/${notification.assignmentId}/reply`
-        });
-      } catch (e) {
-        log.error(e);
-      }
-    }
   } else if (type === Notifications.ASSIGNMENT_CREATED) {
     const { assignment } = notification;
     await sendAssignmentUserNotification(assignment, type);
   }
 };
-
-const setupIncomingReplyNotification = () =>
-  r
-    .table("message")
-    .changes()
-    .then(function(message) {
-      if (!message.old_val && message.new_val.is_from_contact) {
-        sendUserNotification({
-          type: Notifications.ASSIGNMENT_MESSAGE_RECEIVED,
-          assignmentId: message.new_val.assignment_id,
-          contactNumber: message.new_val.contact_number
-        });
-      }
-    });
 
 const setupNewAssignmentNotification = () =>
   r
@@ -134,7 +93,6 @@ let notificationObserversSetup = false;
 export const setupUserNotificationObservers = () => {
   if (!notificationObserversSetup) {
     notificationObserversSetup = true;
-    setupIncomingReplyNotification();
     setupNewAssignmentNotification();
   }
 };


### PR DESCRIPTION
These notifications don't work because assignment_id is no longer written to the message table so the notification code throws the following exception:
```
ERROR	Unhandled Promise Rejection	
{
    "errorType": "Runtime.UnhandledPromiseRejection",
    "errorMessage": "ReqlRuntimeError: Cannot convert `undefined` with r.expr() in:\nr.table(\"assignment\").get(undefined)\n                          ^^^^^^^^^ \n",
    "reason": {
        "errorType": "ReqlRuntimeError",
        "errorMessage": "Cannot convert `undefined` with r.expr() in:\nr.table(\"assignment\").get(undefined)\n                          ^^^^^^^^^ \n",
        "msg": "Cannot convert `undefined` with r.expr()",
        "message": "Cannot convert `undefined` with r.expr() in:\nr.table(\"assignment\").get(undefined)\n                          ^^^^^^^^^ \n",
        "frames": [
            1
        ],
        "stack": [
            "ReqlRuntimeError: Cannot convert `undefined` with r.expr() in:",
            "r.table(\"assignment\").get(undefined)",
            "                          ^^^^^^^^^ ",
            "",
            "    at Function.Term.run (/var/task/node_modules/rethinkdbdash/lib/term.js:43:17)",
            "    at Function.Term.then (/var/task/node_modules/rethinkdbdash/lib/term.js:2878:15)"
        ]
    },
    "promise": {},
    "stack": [
        "Runtime.UnhandledPromiseRejection: ReqlRuntimeError: Cannot convert `undefined` with r.expr() in:",
        "r.table(\"assignment\").get(undefined)",
        "                          ^^^^^^^^^ ",
        "",
        "    at process.on (/var/runtime/index.js:37:15)",
        "    at process.emit (events.js:198:13)",
        "    at process.EventEmitter.emit (domain.js:448:20)",
        "    at emitPromiseRejectionWarnings (internal/process/promises.js:140:18)",
        "    at process._tickCallback (internal/process/next_tick.js:69:34)"
    ]
}
```

Removing this notification actually solves a fairly serious bug because these exceptions occasionally cause us to drop incoming messages.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
