### PR TITLE
Fix convo link when there is only an initial message

### DIFF
--- a/src/components/IncomingMessageList/ConversationPreviewModal.jsx
+++ b/src/components/IncomingMessageList/ConversationPreviewModal.jsx
@@ -202,7 +202,7 @@ export class InnerConversationPreviewModal extends Component {
 
     const { host, protocol } = document.location;
     const { assignmentId, campaignContactId } = conversation || {};
-    const url = `${protocol}//${host}/app/${organizationId}/todos/${assignmentId}/allreplies?contact=${campaignContactId}`;
+    const url = `${protocol}//${host}/app/${organizationId}/todos/${assignmentId}/review?contact=${campaignContactId}`;
 
     const primaryActions = [
       <span>

--- a/src/integrations/texter-sideboxes/contact-reference/react-component.js
+++ b/src/integrations/texter-sideboxes/contact-reference/react-component.js
@@ -43,7 +43,7 @@ export class TexterSidebox extends React.Component {
     const settings = JSON.parse(campaign.texterUIConfig.options || "{}");
 
     const { host, protocol } = document.location;
-    const url = `${protocol}//${host}/app/${campaign.organization.id}/todos/${assignment.id}/allreplies?contact=${this.props.contact.id}`;
+    const url = `${protocol}//${host}/app/${campaign.organization.id}/todos/${assignment.id}/review?contact=${this.props.contact.id}`;
 
     const textContent = [
       <IconButton

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -152,6 +152,18 @@ export default function makeRoutes(requireAuth = () => {}) {
                 }}
               />
               <Route
+                path="review"
+                components={{
+                  fullScreen: props => (
+                    <TexterTodo
+                      {...props}
+                      messageStatus="needsMessage,needsResponse,convo,messaged,closed"
+                    />
+                  ),
+                  topNav: null
+                }}
+              />
+              <Route
                 path="all"
                 components={{
                   fullScreen: props => (


### PR DESCRIPTION
# Description

## Observed behavior

when there is only an initial message, a convo link such as this

`http://localhost:3000/app/1/todos/16/allreplies?contact=51793` 

results in this erroneous error message

![Screen Shot 2020-06-10 at 6 10 21 PM](https://user-images.githubusercontent.com/1637288/84346473-09fc9a80-ab7e-11ea-8cf8-0617bcfeb5f0.png)

## Desired behavior

We can have a link to any conversation, regardless of status

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
