### PR TITLE
Disable next/prev when in review mode

### DIFF
--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -228,11 +228,14 @@ export class ContactController extends React.Component {
   }
 
   hasPrevious() {
-    return this.state.currentContactIndex > 0;
+    return !this.props.reviewMode && this.state.currentContactIndex > 0;
   }
 
   hasNext() {
-    return this.state.currentContactIndex < this.contactCount() - 1;
+    return (
+      !this.props.reviewMode &&
+      this.state.currentContactIndex < this.contactCount() - 1
+    );
   }
 
   handleFinishContact = contactId => {
@@ -464,7 +467,8 @@ ContactController.propTypes = {
   assignContactsIfNeeded: PropTypes.func,
   organizationId: PropTypes.string,
   ChildComponent: PropTypes.func,
-  messageStatusFilter: PropTypes.string
+  messageStatusFilter: PropTypes.string,
+  reviewMode: PropTypes.bool
 };
 
 export default withRouter(ContactController);

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -211,6 +211,7 @@ export class TexterTodo extends React.Component {
         organizationId={this.props.params.organizationId}
         ChildComponent={AssignmentTexterContact}
         messageStatusFilter={this.props.messageStatus}
+        reviewMode={this.props.reviewMode}
       />
     );
   }
@@ -218,6 +219,7 @@ export class TexterTodo extends React.Component {
 
 TexterTodo.propTypes = {
   messageStatus: PropTypes.string,
+  reviewMode: PropTypes.bool,
   params: PropTypes.object,
   data: PropTypes.object,
   mutations: PropTypes.object,

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -158,6 +158,7 @@ export default function makeRoutes(requireAuth = () => {}) {
                     <TexterTodo
                       {...props}
                       messageStatus="needsMessage,needsResponse,convo,messaged,closed"
+                      reviewMode={true}
                     />
                   ),
                   topNav: null


### PR DESCRIPTION
When we've used a conversation permalink to see a conversation in the texter view, we should disable the next and previous buttons so we don't go stepping through conversations. The purpose of arriving in the texter view is to look at a single conversation, not to go from conversation to conversation. That is best done from the texter home screen.



# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
