### PR TITLE
Better permission checks on assignment-related mutations

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -1,6 +1,6 @@
 import { resolvers } from "../src/server/api/schema";
 import { schema } from "../src/api/schema";
-import { assignmentRequired } from "../src/server/api/errors";
+import { assignmentRequiredOrAdminRole } from "../src/server/api/errors";
 import { graphql } from "graphql";
 
 console.log("This is an intentional error");
@@ -500,34 +500,6 @@ describe("graphql test suite", async () => {
           { user: adminUser }
         );
         expect(results).toEqual(false);
-      });
-
-      test("test assignmentRequired access control", async () => {
-        const user = await createUser();
-
-        const assignment = await new Assignment({
-          user_id: user.id,
-          campaign_id: campaign.id
-        }).save();
-
-        const allowUser = await assignmentRequired(
-          user,
-          assignment.id,
-          assignment
-        );
-        expect(allowUser).toEqual(true);
-        const allowUserAssignmentId = await assignmentRequired(
-          user,
-          assignment.id
-        );
-        expect(allowUserAssignmentId.user_id).toEqual(user.id);
-        expect(allowUserAssignmentId.id).toEqual(assignment.id);
-        try {
-          const notAllowed = await assignmentRequired(user, -1);
-          throw new Exception("should throw BEFORE this exception");
-        } catch (err) {
-          expect(/not authorized/.test(String(err))).toEqual(true);
-        }
       });
     });
 

--- a/__test__/server/api/editOrganization.test.js
+++ b/__test__/server/api/editOrganization.test.js
@@ -1,0 +1,55 @@
+/* eslint-disable no-unused-expressions, consistent-return */
+import { r } from "../../../src/server/models/";
+import { getFeatures } from "../../../src/server/api/lib/config";
+import { getCampaignsQuery } from "../../../src/containers/AdminCampaignList";
+import { editOrganizationGql } from "../../../src/containers/Settings";
+import { GraphQLError } from "graphql/error";
+
+import {
+  cleanupTest,
+  createStartedCampaign,
+  runGql,
+  setupTest
+} from "../../test_helpers";
+
+describe("editOrganization", async () => {
+  let startedCampaign;
+
+  beforeEach(async () => {
+    // Set up an entire working campaign
+    await setupTest();
+    startedCampaign = await createStartedCampaign();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  describe("features", () => {
+    it("save and get", async () => {
+      const result = await runGql(
+        editOrganizationGql,
+        {
+          organizationId: startedCampaign.organizationId,
+          organizationChanges: {
+            texterUIConfig: {
+              options: `{"foo": "bar"}`
+            }
+          }
+        },
+        startedCampaign.testAdminUser
+      );
+      const [org] = await r
+        .knex("organization")
+        .where("id", startedCampaign.organizationId);
+      const features = getFeatures(org);
+      expect(typeof features.TEXTER_UI_SETTINGS).toBe("string");
+      expect(JSON.parse(features.TEXTER_UI_SETTINGS)).toEqual({ foo: "bar" });
+    });
+    // TODO:
+    // 1. get from cache
+    // 2. get from API
+    // 3. set features to something, and confirm existing ones are not overwritten
+  });
+});

--- a/__test__/server/api/errors.test.js
+++ b/__test__/server/api/errors.test.js
@@ -1,7 +1,6 @@
 import { r } from "../../../src/server/models/";
 import {
   authRequired,
-  assignmentRequired,
   assignmentRequiredOrAdminRole
 } from "../../../src/server/api/errors";
 
@@ -48,7 +47,7 @@ describe("errors.js", () => {
     });
   });
 
-  describe("#accessRequired", () => {
+  describe("#accessRequiredOrAdminRole", () => {
     it("accessRequired fails with missing orgId", async () => {
       let errored = false;
       try {
@@ -86,25 +85,66 @@ describe("errors.js", () => {
       }
       expect(errored).toBeTruthy();
     });
-  });
 
-  describe("#assignmentRequired", () => {
     it("returns truthy when a texter user has the assignment", async () => {
-      const assignment = await assignmentRequired(
+      const assignment = await assignmentRequiredOrAdminRole(
         startedCampaign.testTexterUser,
+        startedCampaign.organizationId,
         startedCampaign.assignmentId
       );
       expect(Boolean(assignment)).toBe(true);
       expect(assignment.campaign_id).toBe(1);
     });
 
+    it("when a user is superadmin with no assignment returns true", async () => {
+      expect(
+        await assignmentRequiredOrAdminRole(
+          startedCampaign.testSuperAdminUser,
+          startedCampaign.organizationId
+        )
+      ).toBe(true);
+    });
+
+    it("returns true if the user has the assignment", async () => {
+      expect(
+        await assignmentRequiredOrAdminRole(
+          startedCampaign.testTexterUser,
+          startedCampaign.organizationId,
+          startedCampaign.assignmentId,
+          null,
+          startedCampaign.assignment
+        )
+      ).toBe(true);
+    });
+
     describe("when the user does not have the assignment", () => {
+      it("throws an exception without assignment", async () => {
+        let error;
+        try {
+          await assignmentRequiredOrAdminRole(
+            startedCampaign.testTexterUser2,
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId
+          );
+        } catch (caught) {
+          error = caught;
+        }
+
+        expect(error).toBeDefined();
+        expect(error.message).toEqual(
+          "You are not authorized to access that resource."
+        );
+      });
+
       it("throws an exception", async () => {
         let error;
         try {
-          await assignmentRequired(
+          await assignmentRequiredOrAdminRole(
             startedCampaign.testTexterUser2,
-            startedCampaign.assignmentId
+            startedCampaign.organizationId,
+            startedCampaign.assignmentId,
+            null,
+            startedCampaign.assignment
           );
         } catch (caught) {
           error = caught;
@@ -117,99 +157,24 @@ describe("errors.js", () => {
       });
     });
 
-    describe("when a user is superadmin", () => {
-      it("returns true", async () => {
-        expect(
-          await assignmentRequired(
-            startedCampaign.testSuperAdminUser,
-            startedCampaign.assignmentId
-          )
-        ).toBe(true);
-      });
+    it("when the user is an admin returns true", async () => {
+      expect(
+        await assignmentRequiredOrAdminRole(
+          startedCampaign.testAdminUser,
+          startedCampaign.organizationId,
+          startedCampaign.assignmentId
+        )
+      ).toBe(true);
     });
 
-    describe("when an assignment is passed", () => {
-      it("returns true if the user has the assignment", async () => {
-        expect(
-          await assignmentRequired(
-            startedCampaign.testTexterUser,
-            startedCampaign.assignmentId,
-            startedCampaign.assignment
-          )
-        ).toBe(true);
-      });
-
-      describe("when the user does not have the assignment", () => {
-        it("throws an exception", async () => {
-          let error;
-          try {
-            await assignmentRequired(
-              startedCampaign.testTexterUser2,
-              startedCampaign.assignmentId,
-              startedCampaign.assignment
-            );
-          } catch (caught) {
-            error = caught;
-          }
-
-          expect(error).toBeDefined();
-          expect(error.message).toEqual(
-            "You are not authorized to access that resource."
-          );
-        });
-      });
-    });
-  });
-
-  describe("#assignmentRequiredOrAdminRole", () => {
-    let spy;
-
-    beforeEach(async () => {
-      spy = jest.spyOn(errors, "assignmentRequired").mockResolvedValue(true);
-    });
-
-    afterEach(async () => {
-      jest.restoreAllMocks();
-    });
-
-    it("calls assignmentRequired", async () => {
-      await assignmentRequiredOrAdminRole(
-        startedCampaign.testTexterUser,
-        startedCampaign.organizationId,
-        startedCampaign.assignmentId
-      );
-      expect(spy).toHaveBeenCalledWith(
-        startedCampaign.testTexterUser,
-        startedCampaign.assignmentId,
-        null,
-        undefined
-      );
-    });
-
-    describe("when the user is an admin", () => {
-      it("returns true", async () => {
-        expect(
-          await assignmentRequiredOrAdminRole(
-            startedCampaign.testAdminUser,
-            startedCampaign.organizationId,
-            startedCampaign.assignmentId
-          )
-        ).toBe(true);
-        expect(spy).not.toHaveBeenCalled();
-      });
-    });
-
-    describe("when the user is a superadmin", () => {
-      it("returns true", async () => {
-        expect(
-          await assignmentRequiredOrAdminRole(
-            startedCampaign.testSuperAdminUser,
-            startedCampaign.organizationId,
-            startedCampaign.assignmentId
-          )
-        ).toBe(true);
-        expect(spy).not.toHaveBeenCalled();
-      });
+    it("when the user is a superadmin returns true", async () => {
+      expect(
+        await assignmentRequiredOrAdminRole(
+          startedCampaign.testSuperAdminUser,
+          startedCampaign.organizationId,
+          startedCampaign.assignmentId
+        )
+      ).toBe(true);
     });
   });
 });

--- a/docs/EXPLANATION-development-guidelines.md
+++ b/docs/EXPLANATION-development-guidelines.md
@@ -162,8 +162,7 @@ we want to add a value to campaign info for that edit page. We might need to edi
 * Helper functions are in [server/api/errors.js](https://github.com/MoveOnOrg/Spoke/blob/main/src/server/api/errors.js) which should/will be optimized to use cached info, etc.  Each of them will throw an error and therefore cancel the request if the user doesn't have the appropriate access.
   * `authRequired(user)` establishes that the user is not anonymous
   * `accessRequired(user, orgId, role, allowSuperadmin = false)` will require the user to have a certain role or higher.  Pass in `true` to allowSuperadmin if superadmins should be allowed.  Generally they should be allowed to do things, but might as well be explicit.
-  * `assignmentRequired(user, assignmentId)` makes sure that the user has the assignment in question
-  * `superAdminRequired(user)` requires a super-admin user
+  * `assignmentRequiredOrAdminRole(user, organizationId, assignmentId)` makes sure that the user has the assignment in question and is a TEXTER or is an ADMIN.  (optional arguments after assignmentId are `contact, assignment` which if already available in the context can speed checking -- those arguments should be loaded manually, and never passed from the client, of course.
 
 
 ## Asynchronous tasks (workers)

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -405,25 +405,24 @@ const queries = {
   }
 };
 
+export const editOrganizationGql = gql`
+  mutation editOrganization(
+    $organizationId: String!
+    $organizationChanges: OrganizationInput!
+  ) {
+    editOrganization(id: $organizationId, organization: $organizationChanges) {
+      id
+      texterUIConfig {
+        options
+        sideboxChoices
+      }
+    }
+  }
+`;
+
 const mutations = {
   editOrganization: ownProps => organizationChanges => ({
-    mutation: gql`
-      mutation editOrganization(
-        $organizationId: String!
-        $organizationChanges: OrganizationInput!
-      ) {
-        editOrganization(
-          id: $organizationId
-          organization: $organizationChanges
-        ) {
-          id
-          texterUIConfig {
-            options
-            sideboxChoices
-          }
-        }
-      }
-    `,
+    mutation: editOrganizationGql,
     variables: {
       organizationId: ownProps.params.organizationId,
       organizationChanges

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -73,6 +73,7 @@ export const dataQueryString = `
         textingHoursStart
         textingHoursEnd
         textingHoursEnforced
+        batchSize
         organization {
           id
           tags(group: $tagGroup) {

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -115,6 +115,7 @@ export const dataQuery = gql`
           id
           title
           description
+          batchSize
           useDynamicAssignment
           hasUnassignedContactsForTexter
           introHtml

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -276,7 +276,7 @@ export async function getConversations(
   };
 }
 
-export async function getCampaignIdMessageIdsAndCampaignIdContactIdsMaps(
+export async function getCampaignIdContactIdsMaps(
   organizationId,
   campaignsFilter,
   assignmentsFilter,
@@ -284,8 +284,7 @@ export async function getCampaignIdMessageIdsAndCampaignIdContactIdsMaps(
 ) {
   let query = r.knex.select(
     "campaign_contact.id as cc_id",
-    "campaign.id as cmp_id",
-    "message.id as mess_id"
+    "campaign.id as cmp_id"
   );
 
   query = getConversationsJoinsAndWhereClause(
@@ -296,16 +295,11 @@ export async function getCampaignIdMessageIdsAndCampaignIdContactIdsMaps(
     contactsFilter
   );
 
-  query = query.leftJoin("message", table => {
-    table.on("message.campaign_contact_id", "=", "campaign_contact.id");
-  });
-
   query = query.orderBy("cc_id");
 
   const conversationRows = await query;
 
   const campaignIdContactIdsMap = new Map();
-  const campaignIdMessagesIdsMap = new Map();
 
   let ccId = undefined;
   for (const conversationRow of conversationRows) {
@@ -318,28 +312,16 @@ export async function getCampaignIdMessageIdsAndCampaignIdContactIdsMaps(
       }
 
       campaignIdContactIdsMap.get(conversationRow.cmp_id).push(ccId);
-
-      if (!campaignIdMessagesIdsMap.has(conversationRow.cmp_id)) {
-        campaignIdMessagesIdsMap.set(conversationRow.cmp_id, []);
-      }
-    }
-
-    if (conversationRow.mess_id) {
-      campaignIdMessagesIdsMap
-        .get(conversationRow.cmp_id)
-        .push(conversationRow.mess_id);
     }
   }
 
   return {
-    campaignIdContactIdsMap,
-    campaignIdMessagesIdsMap
+    campaignIdContactIdsMap
   };
 }
 
 export async function reassignConversations(
   campaignIdContactIdsMap,
-  campaignIdMessagesIdsMap,
   newTexterUserId
 ) {
   // ensure existence of assignments

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -30,23 +30,18 @@ export async function accessRequired(
   }
 }
 
-export async function assignmentRequired(
+export async function assignmentRequiredOrAdminRole(
   user,
+  orgId,
   assignmentId,
-  assignment,
-  contact
+  contact,
+  assignment
 ) {
   authRequired(user);
 
   if (user.is_superadmin) {
     return true;
   }
-  // console.log(
-  //   "createOptOut assignmentRequired",
-  //   user.id,
-  //   assignmentId,
-  //   contact
-  // );
   if (assignment && assignment.user_id === user.id) {
     // if we are passed the full assignment object, we can test directly
     return true;
@@ -60,12 +55,7 @@ export async function assignmentRequired(
     // check both to verify that the assignmentId-userId pair are accepted
     return true;
   }
-  // console.log(
-  //   "createOptOut assignmentRequired dbcall",
-  //   user.id,
-  //   assignmentId,
-  //   contact
-  // );
+
   const [userHasAssignment] = await r
     .knex("assignment")
     .where({
@@ -73,49 +63,15 @@ export async function assignmentRequired(
       id: assignmentId
     })
     .limit(1);
-  // console.log(
-  //   "createOptOut assignmentRequired dbcall post",
-  //   user.id,
-  //   assignmentId,
-  //   userHasAssignment
-  // );
-  if (!userHasAssignment) {
-    // undefined or null
+
+  const roleRequired = userHasAssignment ? "TEXTER" : "ADMIN";
+  const hasPermission = await cacheableData.user.userHasRole(
+    user,
+    orgId,
+    roleRequired
+  );
+  if (!hasPermission) {
     throw new GraphQLError("You are not authorized to access that resource.");
   }
-  return userHasAssignment;
-}
-
-export async function assignmentRequiredOrAdminRole(
-  user,
-  orgId,
-  assignmentId,
-  contact
-) {
-  authRequired(user);
-  // console.log(
-  //   "createOptOut assignmentRequiredOrAdminRole",
-  //   user.id,
-  //   orgId,
-  //   assignmentId
-  // );
-  const isAdmin = await cacheableData.user.userHasRole(user, orgId, "ADMIN");
-  // console.log(
-  //   "createOptOut assignmentRequiredOrAdminRole isAdmin",
-  //   user.id,
-  //   orgId,
-  //   assignmentId,
-  //   isAdmin
-  // );
-  if (isAdmin || user.is_superadmin) {
-    return true;
-  }
-  // console.log(
-  //   "createOptOut assignmentRequiredOrAdminRole assignmentRequiredCall",
-  //   user.id,
-  //   orgId
-  // );
-  // calling exports.assignmentRequired instead of just assignmentRequired
-  // is functionally identical but it allows us to mock assignmentRequired
-  return await exports.assignmentRequired(user, assignmentId, null, contact);
+  return userHasAssignment || true;
 }

--- a/src/server/api/errors.js
+++ b/src/server/api/errors.js
@@ -64,7 +64,7 @@ export async function assignmentRequiredOrAdminRole(
     })
     .limit(1);
 
-  const roleRequired = userHasAssignment ? "TEXTER" : "ADMIN";
+  const roleRequired = userHasAssignment ? "TEXTER" : "SUPERVOLUNTEER";
   const hasPermission = await cacheableData.user.userHasRole(
     user,
     orgId,

--- a/src/server/api/mutations/findNewCampaignContact.js
+++ b/src/server/api/mutations/findNewCampaignContact.js
@@ -1,18 +1,24 @@
 import { log } from "../../../lib";
-import { Assignment, Campaign, r } from "../../models";
-import { assignmentRequired } from "../errors";
+import { Assignment, Campaign, r, cacheableData } from "../../models";
+import { assignmentRequiredOrAdminRole } from "../errors";
 
 export const findNewCampaignContact = async (
   _,
   { assignment: assignmentParameter, assignmentId, numberContacts },
   { user }
 ) => {
-  /* This attempts to find a new contact for the assignment, in the case that useDynamicAssigment == true */
+  /* This attempts to find new contacts for the assignment, in the case that useDynamicAssigment == true */
   const assignment =
     assignmentParameter || (await Assignment.get(assignmentId));
-  await assignmentRequired(user, assignmentId, assignment);
+  const campaign = await cacheableData.campaign.load(assignment.campaign_id);
 
-  const campaign = await Campaign.get(assignment.campaign_id);
+  await assignmentRequiredOrAdminRole(
+    user,
+    campaign.organization_id,
+    assignmentId,
+    null,
+    assignment
+  );
 
   if (!campaign.use_dynamic_assignment || assignment.max_contacts === 0) {
     return {
@@ -24,13 +30,20 @@ export const findNewCampaignContact = async (
     r.knex("campaign_contact").where("assignment_id", assignmentId)
   );
 
-  numberContacts = numberContacts || 1;
+  numberContacts = Math.min(
+    numberContacts || campaign.batch_size || 1,
+    campaign.batch_size === null
+      ? 1 // if null, then probably a legacy campaign
+      : campaign.batch_size
+  );
+
   if (
     assignment.max_contacts &&
     contactsCount + numberContacts > assignment.max_contacts
   ) {
     numberContacts = assignment.max_contacts - contactsCount;
   }
+
   // Don't add more if they already have that many
   const result = await r.getCount(
     r.knex("campaign_contact").where({

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -36,14 +36,13 @@ import { resolvers as campaignContactResolvers } from "./campaign-contact";
 import { resolvers as cannedResponseResolvers } from "./canned-response";
 import {
   getConversations,
-  getCampaignIdMessageIdsAndCampaignIdContactIdsMaps,
+  getCampaignIdContactIdsMaps,
   reassignConversations,
   resolvers as conversationsResolver
 } from "./conversations";
 import {
   accessRequired,
   assignmentRequiredOrAdminRole,
-  assignmentRequired,
   authRequired
 } from "./errors";
 import { resolvers as interactionStepResolvers } from "./interaction-step";
@@ -731,6 +730,11 @@ const rootMutations = {
         "ADMIN",
         /* allowSuperadmin=*/ true
       );
+
+      const organization = cacheableData.organization.load(
+        campaign.organizationId
+      );
+
       const campaignInstance = new Campaign({
         organization_id: campaign.organizationId,
         creator_id: user.id,
@@ -740,6 +744,7 @@ const rootMutations = {
         is_started: false,
         is_archived: false,
         join_token: uuidv4(),
+        batch_size: Number(getConfig("DEFAULT_BATCHSIZE", organization) || 300),
         use_own_messaging_service: false
       });
       const newCampaign = await campaignInstance.save();
@@ -752,14 +757,22 @@ const rootMutations = {
       const campaign = await loaders.campaign.load(id);
       await accessRequired(user, campaign.organization_id, "ADMIN");
 
+      const organization = cacheableData.organization.load(
+        campaign.organization_id
+      );
+
       const campaignInstance = new Campaign({
         organization_id: campaign.organization_id,
         creator_id: user.id,
         title: "COPY - " + campaign.title,
         description: campaign.description,
         due_by: campaign.dueBy,
+        batch_size:
+          campaign.batch_size ||
+          Number(getConfig("DEFAULT_BATCHSIZE", organization) || 300),
         is_started: false,
-        is_archived: false
+        is_archived: false,
+        join_token: uuidv4()
       });
       const newCampaign = await campaignInstance.save();
       await r.knex("campaign_admin").insert({
@@ -1013,7 +1026,13 @@ const rootMutations = {
       const contact = await cacheableData.campaignContact.load(
         campaignContactId
       );
-      await assignmentRequired(user, contact.assignment_id, null, contact);
+      const organizationId = await cacheableData.campaignContact.orgId(contact);
+      await assignmentRequiredOrAdminRole(
+        user,
+        organizationId,
+        contact.assignment_id,
+        contact
+      );
       contact.message_status = messageStatus;
       await cacheableData.campaignContact.updateStatus(contact, messageStatus);
       return contact;
@@ -1029,10 +1048,12 @@ const rootMutations = {
       const firstContact = await cacheableData.campaignContact.load(
         contactIds[0]
       );
-      const campaign = await loaders.campaign.load(firstContact.campaign_id);
+      const organizationId = await cacheableData.campaignContact.orgId(
+        firstContact
+      );
       await assignmentRequiredOrAdminRole(
         user,
-        campaign.organization_id,
+        organizationId,
         assignmentId,
         firstContact
       );
@@ -1124,7 +1145,13 @@ const rootMutations = {
       const contact = await cacheableData.campaignContact.load(
         campaignContactId
       );
-      await assignmentRequired(user, contact.assignment_id, null, contact);
+      const organizationId = await cacheableData.campaignContact.orgId(contact);
+      await assignmentRequiredOrAdminRole(
+        user,
+        organizationId,
+        contact.assignment_id,
+        contact
+      );
       // TODO: maybe undo action_handler
       await r
         .knex("question_response")
@@ -1150,30 +1177,18 @@ const rootMutations = {
       // group contactIds by campaign
       // group messages by campaign
       const campaignIdContactIdsMap = new Map();
-      const campaignIdMessagesIdsMap = new Map();
       for (const campaignIdContactId of campaignIdsContactIds) {
-        const {
-          campaignId,
-          campaignContactId,
-          messageIds
-        } = campaignIdContactId;
+        const { campaignId, campaignContactId } = campaignIdContactId;
 
         if (!campaignIdContactIdsMap.has(campaignId)) {
           campaignIdContactIdsMap.set(campaignId, []);
         }
 
         campaignIdContactIdsMap.get(campaignId).push(campaignContactId);
-
-        if (!campaignIdMessagesIdsMap.has(campaignId)) {
-          campaignIdMessagesIdsMap.set(campaignId, []);
-        }
-
-        campaignIdMessagesIdsMap.get(campaignId).push(...messageIds);
       }
 
       return await reassignConversations(
         campaignIdContactIdsMap,
-        campaignIdMessagesIdsMap,
         newTexterUserId
       );
     },
@@ -1190,10 +1205,7 @@ const rootMutations = {
     ) => {
       // verify permissions
       await accessRequired(user, organizationId, "ADMIN", /* superadmin*/ true);
-      const {
-        campaignIdContactIdsMap,
-        campaignIdMessagesIdsMap
-      } = await getCampaignIdMessageIdsAndCampaignIdContactIdsMaps(
+      const { campaignIdContactIdsMap } = await getCampaignIdContactIdsMaps(
         organizationId,
         campaignsFilter,
         assignmentsFilter,
@@ -1202,7 +1214,6 @@ const rootMutations = {
 
       return await reassignConversations(
         campaignIdContactIdsMap,
-        campaignIdMessagesIdsMap,
         newTexterUserId
       );
     },

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -358,6 +358,9 @@ const campaignContactCache = {
     });
     console.log("contact loadMany finish stream", campaign.id);
   },
+  orgId: async contact =>
+    contact.organization_id ||
+    ((await campaignCache.load(contact.campaign_id)) || {}).organization_id,
   lookupByCell: async (cell, service, messageServiceSid, bailWithoutCache) => {
     // Used to lookup contact/campaign information by cell number for incoming messages
     // in order to map it to the existing campaign, since Twilio, etc "doesn't know"


### PR DESCRIPTION
This makes a couple of plumbing changes:
1. consolidating around assignmentRequiredOrAdminRole and removing assignmentRequired.
2. removes unnecessary messageId querying now that there is no longer a maintained assignment_id in message table
3. Fixes #1488

## Description
This cleans up some permission checks and plumbing.  It's in-service of more upcoming assignment-related mutations (e.g. releaseAssignment for https://github.com/MoveOnOrg/Spoke/issues/1533) and also explicitly checks for TEXTER role in service of https://github.com/MoveOnOrg/Spoke/pull/1562 (cc: @JeremyParker )

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
