### PR TITLE
releaseContacts endpoint and campaign cached counts improvements

### DIFF
--- a/.github/workflows/jest-tests.yaml
+++ b/.github/workflows/jest-tests.yaml
@@ -37,6 +37,37 @@ jobs:
           ${{ runner.os }}-${{ matrix.node-version }}-yarn-
     - run: yarn
     - run: yarn test
+  test-rediscache-contactcache:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    services:
+      redis:
+        image: redis
+        ports:
+        - 6379:6379
+      postgres:
+        image: postgres:10
+        env:
+          POSTGRES_USER: spoke_test
+          POSTGRES_PASSWORD: spoke_test
+          POSTGRES_DB: spoke_test
+        ports:
+        - 5432:5432
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      run: echo "::set-output name=dir::$(yarn cache dir)"
+    - uses: actions/cache@v1
+      id: yarn-cache
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-
+    - run: yarn
+    - run: yarn test-rediscache-contactcache
   test-rediscache:
     runs-on: ubuntu-latest
     timeout-minutes: 10

--- a/__test__/server/api/campaign/campaign.test.js
+++ b/__test__/server/api/campaign/campaign.test.js
@@ -1,5 +1,6 @@
 import gql from "graphql-tag";
 import { r } from "../../../../src/server/models";
+import { getConfig } from "../../../../src/server/api/lib/config";
 import { dataQuery as TexterTodoListQuery } from "../../../../src/containers/TexterTodoList";
 import { dataQuery as TexterTodoQuery } from "../../../../src/containers/TexterTodo";
 import { campaignDataQuery as AdminCampaignEditQuery } from "../../../../src/containers/AdminCampaignEdit";
@@ -417,7 +418,7 @@ it("should save campaign canned responses across copies and match saved data", a
 });
 
 describe("Caching", async () => {
-  if (r.redis) {
+  if (r.redis && getConfig("REDIS_CONTACT_CACHE")) {
     it("should not have any selects on a cached campaign when message sending", async () => {
       await createScript(testAdminUser, testCampaign);
       await startCampaign(testAdminUser, testCampaign);

--- a/__test__/server/api/lib/twilio.test.js
+++ b/__test__/server/api/lib/twilio.test.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-unused-expressions, consistent-return */
 import { r, Message, cacheableData } from "../../../../src/server/models/";
+import { getConfig } from "../../../../src/server/api/lib/config";
 import twilio, {
   postMessageSend,
   handleDeliveryReport
@@ -291,7 +292,7 @@ it("handleIncomingMessage should save message and update contact state", async (
     MessagingServiceSid: "fakeSid_MK123"
   });
 
-  if (r.redis) {
+  if (r.redis && getConfig("REDIS_CONTACT_CACHE")) {
     // IMPORTANT: this should be tested before we do SELECT statements below
     //   in the test itself to check the database
     const selectMethods = { select: 1, first: 1 };

--- a/__test__/workers/assign-texters.test.js
+++ b/__test__/workers/assign-texters.test.js
@@ -98,11 +98,11 @@ describe("test texter assignment in dynamic mode", () => {
   it("supports saving null or zero maxContacts", async () => {
     const zero = await r
       .knex("assignment")
-      .where({ campaign_id: testCampaign.id, user_id: "2" })
+      .where({ campaign_id: testCampaign.id, user_id: 2 })
       .select("max_contacts");
     const blank = await r
       .knex("assignment")
-      .where({ campaign_id: testCampaign.id, user_id: "1" })
+      .where({ campaign_id: testCampaign.id, user_id: 1 })
       .select("max_contacts");
     const maxContactsZero = zero[0]["max_contacts"];
     const maxContactsBlank = blank[0]["max_contacts"];

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "scripts": {
     "test": "jest --forceExit --runInBand --detectOpenHandles --verbose=false",
     "test-cache": "REDIS_FAKE=1 jest --runInBand --forceExit --detectOpenHandles",
-    "test-rediscache": "REDIS_URL=redis://localhost:6379 CACHE_PREFIX=test REDIS_CONTACT_CACHE=1 jest --runInBand --forceExit --detectOpenHandles",
+    "test-rediscache": "REDIS_URL=redis://localhost:6379 CACHE_PREFIX=test jest --runInBand --forceExit --detectOpenHandles",
+    "test-rediscache-contactcache": "REDIS_URL=redis://localhost:6379 CACHE_PREFIX=test REDIS_CONTACT_CACHE=1 jest --runInBand --forceExit --detectOpenHandles",
     "test-e2e": "jest --runInBand --config jest.config.e2e.js",
     "test-sqlite": "jest --config jest.config.sqlite.js --runInBand --forceExit --detectOpenHandles",
     "test-coverage": "jest --coverage --detectOpenHandles --runInBand",

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -312,6 +312,10 @@ const rootSchema = gql`
       assignmentId: String!
       numberContacts: Int!
     ): FoundContact
+    releaseContacts(
+      assignmentId: String!
+      releaseConversations: Boolean
+    ): Assignment
     userAgreeTerms(userId: String!): User
     reassignCampaignContacts(
       organizationId: String!

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -560,6 +560,35 @@ const mutations = {
       campaignContactId
     }
   }),
+  releaseContacts: ownProps => (assignmentId, releaseConversations) => ({
+    mutation: gql`
+      mutation releaseContacts(
+        $assignmentId: Int!
+        $contactsFilter: ContactsFilter!
+        $releaseConversations: Boolean
+      ) {
+        releaseContacts(
+          assignmentId: $assignmentId
+          releaseConversations: $releaseConversations
+        ) {
+          id
+          contacts(contactsFilter: $contactsFilter) {
+            id
+          }
+          allContactsCount: contactsCount
+        }
+      }
+    `,
+    variables: {
+      assignmentId,
+      releaseConversations,
+      contactsFilter: {
+        messageStatus: ownProps.messageStatusFilter,
+        isOptedOut: false,
+        validTimezone: true
+      }
+    }
+  }),
   bulkSendMessages: ownProps => assignmentId => ({
     mutation: gql`
       mutation bulkSendMessages($assignmentId: Int!) {

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -355,12 +355,14 @@ export const resolvers = {
       // must be cache-loaded or bust:
       const stats = await cacheableData.campaign.completionStats(campaign.id);
       return {
-        contactsCount: campaign.contactsCount || stats.contactsCount || null,
         // 0 should still diffrentiate from null
         assignedCount: stats.assignedCount > -1 ? stats.assignedCount : null,
+        contactsCount: campaign.contactsCount || stats.contactsCount || null,
+        errorCount: stats.errorCount || null,
         // messagedCount won't be defined until some messages are sent
         messagedCount: stats.assignedCount ? stats.messagedCount || 0 : null,
-        errorCount: stats.errorCount || null
+        needsResponseCount:
+          stats.needsResponseCount > -1 ? stats.needsResponseCount : null
       };
     },
     texters: async (campaign, _, { user }) => {

--- a/src/server/api/mutations/index.js
+++ b/src/server/api/mutations/index.js
@@ -3,6 +3,7 @@ import { buyPhoneNumbers } from "./buyPhoneNumbers";
 import { editOrganization } from "./editOrganization";
 import { findNewCampaignContact } from "./findNewCampaignContact";
 import { joinOrganization } from "./joinOrganization";
+import { releaseContacts } from "./releaseContacts";
 import { sendMessage } from "./sendMessage";
 import { updateContactTags } from "./updateContactTags";
 import { updateQuestionResponses } from "./updateQuestionResponses";
@@ -13,6 +14,7 @@ export {
   editOrganization,
   findNewCampaignContact,
   joinOrganization,
+  releaseContacts,
   sendMessage,
   updateContactTags,
   updateQuestionResponses

--- a/src/server/api/mutations/releaseContacts.js
+++ b/src/server/api/mutations/releaseContacts.js
@@ -1,0 +1,40 @@
+import { log } from "../../../lib";
+import { Assignment, r, cacheableData } from "../../models";
+import { assignmentRequiredOrAdminRole } from "../errors";
+
+export const releaseContacts = async (
+  _,
+  { assignmentId, releaseConversations },
+  { user }
+) => {
+  /* This releases contacts for an assignment, needsMessage by-default, and all if releaseConversations=true */
+  const assignment = await Assignment.get(assignmentId);
+  const campaign = await cacheableData.campaign.load(assignment.campaign_id);
+
+  await assignmentRequiredOrAdminRole(
+    user,
+    campaign.organization_id,
+    assignmentId,
+    null,
+    assignment
+  );
+
+  let releaseQuery = r
+    .knex("campaign_contact")
+    .where({
+      assignment_id: assignmentId,
+      campaign_id: assignment.campaign_id
+    });
+  if (!releaseConversations) {
+    releaseQuery = releaseQuery.where("message_status", "needsMessage");
+  }
+  const updateCount = await releaseQuery.update("assignment_id", null);
+  if (updateCount) {
+    await cacheableData.campaign.incrCount(
+      assignment.campaign_id,
+      "assignedCount",
+      -updateCount
+    );
+  }
+  return assignment;
+};

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -67,6 +67,7 @@ import {
   findNewCampaignContact,
   joinOrganization,
   editOrganization,
+  releaseContacts,
   sendMessage,
   updateContactTags,
   updateQuestionResponses
@@ -431,6 +432,7 @@ const rootMutations = {
     editOrganization,
     findNewCampaignContact,
     joinOrganization,
+    releaseContacts,
     sendMessage,
     userAgreeTerms: async (_, { userId }, { user }) => {
       if (user.id === Number(userId)) {


### PR DESCRIPTION
A part of https://github.com/MoveOnOrg/Spoke/issues/1533

* Also supports campaign stat counts on "regular" redis without REDIS_CONTACT_CACHE enabled
* Also adds testing for "regular" redis without contact cache'

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
