### PR TITLE
require contact response before exposing the message review view

### DIFF
--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -160,6 +160,7 @@ export class IncomingMessageList extends Component {
                 overflow: "hidden",
                 whiteSpace: "nowrap"
               }}
+              title={lastMessage.text}
             >
               <span
                 style={{ color: lastMessage.isFromContact ? "blue" : "black" }}

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -183,7 +183,7 @@ export class IncomingMessageList extends Component {
       },
       render: (columnKey, row) =>
         row.messages &&
-        row.messages.length > 0 && (
+        row.messages.length > 1 && (
           <div>
             <FlatButton
               onClick={event => {


### PR DESCRIPTION
# Fixes stage-main issue of an error coming up when clicking the conversation thread.

With the "last message" column there shouldn't be a reason to enter a conversation thread that doesn't have a contact response -- texters can't change the first message, so there's no feedback, etc to give yet.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
