### PR TITLE
User menu: route users to admin or texter based on role

### DIFF
--- a/__test__/containers/UserMenu.test.js
+++ b/__test__/containers/UserMenu.test.js
@@ -17,7 +17,13 @@ describe("UserMenu", () => {
         id: 1,
         displayName: "TestName",
         email: "test@test.com",
-        organizations: [
+        superVolOrganizations: [
+          {
+            id: 2,
+            name: "testOrg"
+          }
+        ],
+        texterOrganizations: [
           {
             id: 2,
             name: "testOrg"
@@ -46,7 +52,8 @@ describe("UserMenu", () => {
         id: 1,
         displayName: "TestName",
         email: "test@test.com",
-        organizations: [
+        superVolOrganizations: [],
+        texterOrganizations: [
           {
             id: 2,
             name: "testOrg"

--- a/src/containers/UserMenu.jsx
+++ b/src/containers/UserMenu.jsx
@@ -43,16 +43,20 @@ export class UserMenu extends Component {
 
   handleMenuChange = (event, value) => {
     this.handleRequestClose();
+    const { currentUser } = this.props.data;
     if (value === "logout") {
       window.AuthService.logout();
     } else if (value === "account") {
       const { orgId } = this.props;
-      const { currentUser } = this.props.data;
       if (orgId) {
         this.props.router.push(`/app/${orgId}/account/${currentUser.id}`);
       }
     } else {
-      this.props.router.push(`/admin/${value}`);
+      if (currentUser.superVolOrganizations.some(org => org.id === value)) {
+        this.props.router.push(`/admin/${value}`);
+      } else {
+        this.props.router.push(`/app/${value}/todos`);
+      }
     }
   };
 
@@ -88,6 +92,7 @@ export class UserMenu extends Component {
     if (!currentUser) {
       return <div />;
     }
+    const organizations = currentUser.texterOrganizations;
 
     return (
       <div>
@@ -117,7 +122,7 @@ export class UserMenu extends Component {
             </MenuItem>
             <Divider />
             <Subheader>Teams</Subheader>
-            {currentUser.organizations.map(organization => (
+            {organizations.map(organization => (
               <MenuItem
                 key={organization.id}
                 primaryText={organization.name}
@@ -161,7 +166,11 @@ export default graphql(
         id
         displayName
         email
-        organizations {
+        superVolOrganizations: organizations(role: "SUPERVOLUNTEER") {
+          id
+          name
+        }
+        texterOrganizations: organizations(role: "TEXTER") {
           id
           name
         }


### PR DESCRIPTION
Fixes issue where texters get a blank screen or an error page (as of 6.1) when they switch organizations because we attempt to route to /admin.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
