### PR TITLE
Bugfix: allow texters to view/edit their profiles

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -223,7 +223,7 @@ const rootSchema = gql`
       filterString: String
       filterBy: FilterPeopleBy
     ): UsersReturn
-    user(organizationId: ID!, userId: ID!): User
+    user(organizationId: ID!, userId: Int!): User
   }
 
   type RootMutation {

--- a/src/containers/UserEdit.jsx
+++ b/src/containers/UserEdit.jsx
@@ -37,7 +37,7 @@ const styles = StyleSheet.create({
 const fetchUser = async (organizationId, userId) =>
   apolloClient.query({
     query: gql`
-      query getEditedUser($organizationId: ID!, $userId: ID!) {
+      query getEditedUser($organizationId: ID!, $userId: Int!) {
         user(organizationId: $organizationId, userId: $userId) {
           id
           firstName


### PR DESCRIPTION
This was caused by `userId` being declared as `ID!` rather than
`Int!` in the GQL schema, which was causing the permissions check to
fail.

The apollo-server upgrade I'm working on enforces stricter typing and
will force us to handle ids consistently across the codebase.


- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
