### PR TITLE
Minor changes to fix script import ui

### DIFF
--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -512,7 +512,10 @@ export class AdminCampaignEdit extends React.Component {
               this.props.campaignData.campaign.id,
               url
             ),
-          hasPendingJob: pendingJobs.some(j => j.jobType === "import_script")
+          hasPendingJob: pendingJobs.some(
+            j => j.jobType === "import_script" && !j.resultMessage
+          ),
+          jobError: (pendingJobs[0] || {}).resultMessage
         },
         doNotSaveAfterSubmit: true
       });

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -945,8 +945,7 @@ const mutations = {
     variables: {
       campaignId,
       url
-    },
-    refetchQueries: () => ["getCampaign"]
+    }
   })
 };
 

--- a/src/containers/AdminScriptImport.jsx
+++ b/src/containers/AdminScriptImport.jsx
@@ -20,12 +20,18 @@ const styles = StyleSheet.create({
 export default class AdminScriptImport extends Component {
   static propTypes = {
     startImport: PropTypes.func,
-    hasPendingJob: PropTypes.bool
+    hasPendingJob: PropTypes.bool,
+    jobError: PropTypes.bool,
+    onSubmit: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      ...(!!props.jobError && {
+        error: `Error from last attempt: ${props.jobError}`
+      })
+    };
   }
 
   startImport = async () => {
@@ -33,6 +39,7 @@ export default class AdminScriptImport extends Component {
     if (res.errors) {
       this.setState({ error: res.errors.message });
     }
+    this.props.onSubmit();
   };
 
   handleUrlChange = (_eventId, newValue) => this.setState({ url: newValue });

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -287,8 +287,8 @@ export const resolvers = {
         true
       );
       return r
-        .table("job_request")
-        .filter({ campaign_id: campaign.id })
+        .knex("job_request")
+        .where({ campaign_id: campaign.id })
         .orderBy("updated_at", "desc");
     },
     ingestMethodsAvailable: async (campaign, _, { user, loaders }) => {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -39,7 +39,7 @@ const defensivelyDeleteOldJobsForCampaignJobType = async job => {
         retries += 1;
         await doDelete();
       } else
-        log.error(`Could not delete campaign/jobType. Err: ${err.message}`);
+        console.error(`Could not delete campaign/jobType. Err: ${err.message}`);
     }
   };
 
@@ -59,7 +59,7 @@ const defensivelyDeleteJob = async job => {
         if (retries < 5) {
           retries += 1;
           await deleteJob();
-        } else log.error(`Could not delete job. Err: ${err.message}`);
+        } else console.error(`Could not delete job. Err: ${err.message}`);
       }
     };
 
@@ -850,13 +850,13 @@ export async function importScript(job) {
   try {
     await defensivelyDeleteOldJobsForCampaignJobType(job);
     await importScriptFromDocument(payload.campaignId, payload.url); // TODO try/catch
-    log.info(`Script import complete ${payload.campaignId} ${payload.url}`);
+    console.log(`Script import complete ${payload.campaignId} ${payload.url}`);
   } catch (exception) {
     await r
       .knex("job_request")
       .where("id", job.id)
       .update({ result_message: exception.message });
-    log.warn(exception.message);
+    console.warn(exception.message);
     return;
   }
   defensivelyDeleteJob(job);


### PR DESCRIPTION
## Description

WFP reported that the script import button is forever disabled for a campaign after a failed import attempt. I noticed that we didn't give feedback in the UI after a failed attempt, which important for folks to diagnose why an import failed.

Changes affect only script import.

 * Display error from last import attempt, if any
 * Fix bug that caused import button to forever be disabled for a
   campaign after a failed import
 * Delete old jobs of type `import_script` for the campaign before
   starting a new script import

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
