### PR TITLE
fix unwanted pop ups when loading script editor ON SAFARI

### DIFF
--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -89,9 +89,6 @@ export default class GSScriptField extends GSFormField {
       <div>
         <TextField
           multiLine
-          onFocus={event => {
-            this.handleOpenDialog(event);
-          }}
           onTouchTap={event => {
             this.handleOpenDialog(event);
           }}

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -512,7 +512,10 @@ export class AdminCampaignEdit extends React.Component {
               this.props.campaignData.campaign.id,
               url
             ),
-          hasPendingJob: pendingJobs.some(j => j.jobType === "import_script")
+          hasPendingJob: pendingJobs.some(
+            j => j.jobType === "import_script" && !j.resultMessage
+          ),
+          jobError: (pendingJobs[0] || {}).resultMessage
         },
         doNotSaveAfterSubmit: true
       });

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -945,8 +945,7 @@ const mutations = {
     variables: {
       campaignId,
       url
-    },
-    refetchQueries: () => ["getCampaign"]
+    }
   })
 };
 

--- a/src/containers/AdminScriptImport.jsx
+++ b/src/containers/AdminScriptImport.jsx
@@ -20,12 +20,18 @@ const styles = StyleSheet.create({
 export default class AdminScriptImport extends Component {
   static propTypes = {
     startImport: PropTypes.func,
-    hasPendingJob: PropTypes.bool
+    hasPendingJob: PropTypes.bool,
+    jobError: PropTypes.bool,
+    onSubmit: PropTypes.bool
   };
 
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      ...(!!props.jobError && {
+        error: `Error from last attempt: ${props.jobError}`
+      })
+    };
   }
 
   startImport = async () => {
@@ -33,6 +39,7 @@ export default class AdminScriptImport extends Component {
     if (res.errors) {
       this.setState({ error: res.errors.message });
     }
+    this.props.onSubmit();
   };
 
   handleUrlChange = (_eventId, newValue) => this.setState({ url: newValue });

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -287,8 +287,8 @@ export const resolvers = {
         true
       );
       return r
-        .table("job_request")
-        .filter({ campaign_id: campaign.id })
+        .knex("job_request")
+        .where({ campaign_id: campaign.id })
         .orderBy("updated_at", "desc");
     },
     ingestMethodsAvailable: async (campaign, _, { user, loaders }) => {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -39,7 +39,7 @@ const defensivelyDeleteOldJobsForCampaignJobType = async job => {
         retries += 1;
         await doDelete();
       } else
-        log.error(`Could not delete campaign/jobType. Err: ${err.message}`);
+        console.error(`Could not delete campaign/jobType. Err: ${err.message}`);
     }
   };
 
@@ -59,7 +59,7 @@ const defensivelyDeleteJob = async job => {
         if (retries < 5) {
           retries += 1;
           await deleteJob();
-        } else log.error(`Could not delete job. Err: ${err.message}`);
+        } else console.error(`Could not delete job. Err: ${err.message}`);
       }
     };
 
@@ -850,13 +850,13 @@ export async function importScript(job) {
   try {
     await defensivelyDeleteOldJobsForCampaignJobType(job);
     await importScriptFromDocument(payload.campaignId, payload.url); // TODO try/catch
-    log.info(`Script import complete ${payload.campaignId} ${payload.url}`);
+    console.log(`Script import complete ${payload.campaignId} ${payload.url}`);
   } catch (exception) {
     await r
       .knex("job_request")
       .where("id", job.id)
       .update({ result_message: exception.message });
-    log.warn(exception.message);
+    console.warn(exception.message);
     return;
   }
   defensivelyDeleteJob(job);


### PR DESCRIPTION
This is described by users as "I need to step through every interaction step before I can do anything."

This was fixed in the WFP fork and never merged. It resurfaced when WFP started using Spoke 6 recently.

This happens only on safari on desktop and iOS.

Safari is causing onFocus to fire for the script in every interaction step after the first render. It's not clear to me why that was happening.

We were handling onFocus to cause the dialog to open and present the script editor, rather than handling it on the click. That seems unnecessary, because is anybody really going to tab from script to script and expect the dialog to open? Once it opens, they can't tab to the next step anyway.


## Description

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change, and any blockers that make your change a WIP_

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
