### PR TITLE
If a contact has no timezone, format local time using campaign's timezone.

### DIFF
--- a/src/components/AssignmentTexter/Toolbar.jsx
+++ b/src/components/AssignmentTexter/Toolbar.jsx
@@ -1,17 +1,16 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { StyleSheet, css } from "aphrodite";
-import { Toolbar, ToolbarGroup, ToolbarTitle } from "material-ui/Toolbar";
-import { getDisplayPhoneNumber } from "../../lib/phone-format";
+import { Toolbar } from "material-ui/Toolbar";
 import { getLocalTime, getContactTimezone } from "../../lib/timezones";
 import { getProcessEnvDstReferenceTimezone } from "../../lib/tz-helpers";
 import ActionFace from "material-ui/svg-icons/action/face";
 import IconButton from "material-ui/IconButton/IconButton";
-import { grey100 } from "material-ui/styles/colors";
 import ArrowBackIcon from "material-ui/svg-icons/navigation/arrow-back";
 import ArrowForwardIcon from "material-ui/svg-icons/navigation/arrow-forward";
 import NavigateHomeIcon from "material-ui/svg-icons/action/home";
 import SideboxOpenIcon from "material-ui/svg-icons/action/build";
+import momenttz from "moment-timezone";
 
 const inlineStyles = {
   toolbar: {
@@ -101,8 +100,8 @@ const ContactToolbar = function ContactToolbar(props) {
   let city = "";
   let state = "";
   let timezone = null;
-  let offset = 0;
-  let hasDST = false;
+  let offset;
+  let hasDST;
 
   if (location) {
     city = location.city;
@@ -129,7 +128,14 @@ const ContactToolbar = function ContactToolbar(props) {
     ? props.campaign.timezone
     : getProcessEnvDstReferenceTimezone();
 
-  const formattedLocalTime = getLocalTime(
+  let formattedLocalTime;
+  if (offset === undefined) {
+    const zone = momenttz.tz.zone(dstReferenceTimezone);
+    offset = zone.parse(Date.now()) / -60;
+    hasDST = false;
+  }
+
+  formattedLocalTime = getLocalTime(
     offset,
     hasDST,
     dstReferenceTimezone

--- a/src/components/AssignmentTexter/Toolbar.jsx
+++ b/src/components/AssignmentTexter/Toolbar.jsx
@@ -124,13 +124,9 @@ const ContactToolbar = function ContactToolbar(props) {
   }
   formattedLocation = `${formattedLocation}${city}`;
 
-  const dstReferenceTimezone = props.campaign.overrideOrganizationTextingHours
-    ? props.campaign.timezone
-    : getProcessEnvDstReferenceTimezone();
-
   let formattedLocalTime;
   if (offset === undefined) {
-    const zone = momenttz.tz.zone(dstReferenceTimezone);
+    const zone = momenttz.tz.zone(props.campaign.timezone);
     offset = zone.parse(Date.now()) / -60;
     hasDST = false;
   }
@@ -138,7 +134,7 @@ const ContactToolbar = function ContactToolbar(props) {
   formattedLocalTime = getLocalTime(
     offset,
     hasDST,
-    dstReferenceTimezone
+    props.campaign.timezone
   ).format("LT"); // format('h:mm a')
 
   return (

--- a/src/components/CampaignTextingHoursForm.jsx
+++ b/src/components/CampaignTextingHoursForm.jsx
@@ -55,8 +55,7 @@ export default class CampaignTextingHoursForm extends React.Component {
     initialValue,
     label,
     hint,
-    choices,
-    collection
+    choices
   ) {
     return (
       <Form.Field
@@ -198,16 +197,6 @@ export default class CampaignTextingHoursForm extends React.Component {
                   hourChoices,
                   hours
                 )}
-
-                {this.addAutocompleteFormField(
-                  "timezone",
-                  "timezoneSearchText",
-                  this.props.formValues.timezone,
-                  "Timezone to use for contacts without ZIP code and to determine daylight savings",
-                  "Start typing a timezone",
-                  timezoneChoices,
-                  timezones
-                )}
               </div>
             ) : (
               ""
@@ -215,6 +204,16 @@ export default class CampaignTextingHoursForm extends React.Component {
           </div>
         ) : (
           ""
+        )}
+
+        {this.addAutocompleteFormField(
+          "timezone",
+          "timezoneSearchText",
+          this.props.formValues.timezone,
+          "Timezone to use for contacts without ZIP code and to determine daylight savings",
+          "Start typing a timezone",
+          timezoneChoices,
+          timezones
         )}
 
         <Form.Button


### PR DESCRIPTION
The texter UI is meant to show the local time for the contact. Unfortunately, it has been displaying UTC if the contact has no timezone on their record in campaign_contact.

This PR will cause Spoke to use the campaign's timezone to determine the contact's local time to display on the texter UI.  The campaign's timezone defaults to `US/Eastern` because it had to default to something.

It also allows the campaign's timezone to be set regardless of whether "override organization texting hours` and `texting hours enforced` are set.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
