### PR TITLE
Use a default timezone moment understands when running on Lambda

### DIFF
--- a/src/lib/tz-helpers.js
+++ b/src/lib/tz-helpers.js
@@ -1,5 +1,6 @@
 export function getProcessEnvTz() {
-  return process.env.TZ;
+  // TZ is a reserved env var in Lambda and always returns :UTC
+  return process.env.TZ === ":UTC" ? "UTC" : process.env.TZ;
 }
 
 export function getProcessEnvDstReferenceTimezone() {


### PR DESCRIPTION
This should fix the following error in the logs when running on lambda:
`ERROR	Moment Timezone has no data for :UTC. See http://momentjs.com/timezone/docs/#/data-loading/.`

Lambda passes the value `:UTC` for the `TZ` env var. Because this is a reserved env var, we should probably switch to using a different one altogether.