### PR TITLE
Use DST_REFERENCE_TIMEZONE for campaigns that don't have a timezone

### DIFF
--- a/src/components/AssignmentTexter/Toolbar.jsx
+++ b/src/components/AssignmentTexter/Toolbar.jsx
@@ -124,18 +124,18 @@ const ContactToolbar = function ContactToolbar(props) {
   }
   formattedLocation = `${formattedLocation}${city}`;
 
+  const campaignTimezone =
+    props.campaign.timezone || getProcessEnvDstReferenceTimezone();
   let formattedLocalTime;
   if (offset === undefined) {
-    const zone = momenttz.tz.zone(props.campaign.timezone);
+    const zone = momenttz.tz.zone(campaignTimezone);
     offset = zone.parse(Date.now()) / -60;
     hasDST = false;
   }
 
-  formattedLocalTime = getLocalTime(
-    offset,
-    hasDST,
-    props.campaign.timezone
-  ).format("LT"); // format('h:mm a')
+  formattedLocalTime = getLocalTime(offset, hasDST, campaignTimezone).format(
+    "LT"
+  ); // format('h:mm a')
 
   return (
     <div>

--- a/src/lib/tz-helpers.js
+++ b/src/lib/tz-helpers.js
@@ -1,9 +1,15 @@
+import { isClient } from "./is-client";
+
 export function getProcessEnvTz() {
   // TZ is a reserved env var in Lambda and always returns :UTC
   return process.env.TZ === ":UTC" ? "UTC" : process.env.TZ;
 }
 
 export function getProcessEnvDstReferenceTimezone() {
+  if (isClient()) {
+    return window.DST_REFERENCE_TIMEZONE;
+  }
+
   return (
     process.env.DST_REFERENCE_TIMEZONE ||
     global.DST_REFERENCE_TIMEZONE ||


### PR DESCRIPTION
Falls back to DST_REFERENCE_TIMEZONE when neither the contact nor the campaign have a timezone. This broke the Demo texter, but campaign.timezone is nullable so this could break live campaigns. 