### PR TITLE
campaign error report (and faster texter stats)

### DIFF
--- a/src/api/assignment.js
+++ b/src/api/assignment.js
@@ -1,6 +1,7 @@
 export const schema = `
   input AssignmentsFilter {
     texterId: Int
+    stats: Boolean
   }
   type Assignment {
     id: ID

--- a/src/api/campaign.js
+++ b/src/api/campaign.js
@@ -20,10 +20,18 @@ export const schema = gql`
     sideboxChoices: [String]
   }
 
+  type ErrorStat {
+    code: String!
+    count: Int!
+    link: String
+    description: String
+  }
+
   type CampaignStats {
     sentMessagesCount: Int
     receivedMessagesCount: Int
     optOutsCount: Int
+    errorCounts: [ErrorStat]
   }
 
   type CampaignCompletionStats {

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -58,6 +58,24 @@ const headerValidator = () => {
   };
 };
 
+export const errorDescriptions = {
+  12400: "Internal (Twilio) Failure",
+  21211: "Invalid 'To' Phone Number",
+  21602: "Message body is required",
+  21610: "Attempt to send to unsubscribed recipient",
+  21611: "Source number has exceeded max number of queued messages",
+  21612: "Unreachable via SMS or MMS",
+  21614: "Invalid mobile number",
+  30001: "Queue overflow",
+  30002: "Account suspended",
+  30003: "Unreachable destination handset",
+  30004: "Message blocked",
+  30005: "Unknown destination handset",
+  30006: "Landline or unreachable carrier",
+  30007: "Message Delivery - Carrier violation",
+  30008: "Message Delivery - Unknown error"
+};
+
 async function convertMessagePartsToMessage(messageParts) {
   const firstPart = messageParts[0];
   const userNumber = firstPart.user_number;


### PR DESCRIPTION
## Description

* Shows error counts per-campaign
* speeds up assignment texter count report to make it a single aggregate query.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
![spoke-errorcounts](https://user-images.githubusercontent.com/52117/84734615-5de8f400-af6f-11ea-96a6-faf8ed9e4e77.png)
