### PR TITLE
heroku deploy: add redis addon by default with maxmemory-policy

### DIFF
--- a/app.json
+++ b/app.json
@@ -165,5 +165,14 @@
       "value": "true"
     }
   },
-  "addons": ["heroku-postgresql:hobby-dev", "mailgun:starter"]
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    {
+      "plan": "heroku-redis:hobby-dev",
+      "options": {
+        "maxmemory-policy": "volatile-lru"
+      }
+    },
+    "mailgun:starter"
+  ]
 }


### PR DESCRIPTION
Default to redis on when instantiating in Heroku along with a good maxmemory policy
