### PR TITLE
Correct A Line About How To Test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Generally, the first steps are:
 ### Working on an issue
 
 - Depending on the part of the codebase you are working on read relevant parts of [EXPLANATION-development-guidelines.md](./docs/EXPLANATION-development-guidelines.md) for some context and common gotchas.
-- While working on an issue, run existing tests to make sure they still work (`npm test` or `npm run test-sqlite` depending on your backend)
+- While working on an issue, run existing tests to make sure they still work (see [How To Run Tests](https://github.com/MoveOnOrg/Spoke/blob/main/docs/HOWTO-run_tests.md) documentation).
 - Please try adding a test
 
 ### Submitting your Pull Request


### PR DESCRIPTION

## Description

This change removes some outdated info and makes the docs more D.R.Y. by pointing to the authoritative source on how to test, rather than duplicating the information in summarized form. This should make the docs easier to maintain going forward.
