### PR TITLE
refactor message handlers a little

### DIFF
--- a/__test__/integrations/message-handlers/profanity-tagger.test.js
+++ b/__test__/integrations/message-handlers/profanity-tagger.test.js
@@ -39,11 +39,13 @@ describe("Message Hanlder: profanity-tagger", () => {
     const c = await createStartedCampaign();
     await r.knex("tag").insert([
       {
+        id: 1,
         name: "Contact Profanity",
         description: "mean contact",
         organization_id: c.organizationId
       },
       {
+        id: 2,
         name: "Texter language flag",
         description: "texter inappropriate",
         organization_id: c.organizationId
@@ -78,7 +80,8 @@ describe("Message Hanlder: profanity-tagger", () => {
         service: "fakeservice",
         messageservice_sid: "fakeservice",
         send_status: "DELIVERED"
-      }
+      },
+      organization: org
     });
 
     const text1 = await r
@@ -98,11 +101,13 @@ describe("Message Hanlder: profanity-tagger", () => {
     const c = await createStartedCampaign();
     await r.knex("tag").insert([
       {
+        id: 1,
         name: "Contact Profanity",
         description: "mean contact",
         organization_id: c.organizationId
       },
       {
+        id: 2,
         name: "Texter language flag",
         description: "texter inappropriate",
         organization_id: c.organizationId

--- a/__test__/server/api/updateContactTags.test.js
+++ b/__test__/server/api/updateContactTags.test.js
@@ -1,0 +1,199 @@
+/**
+r* @jest-environment jsdom
+ */
+import {
+  cleanupTest,
+  createStartedCampaign,
+  setupTest,
+  makeRunnableMutations
+} from "../../test_helpers";
+
+import { r } from "../../../src/server/models";
+
+import { operations as assignmentTexterOps } from "../../../src/containers/AssignmentTexterContact";
+
+const ComplexTestActionHandler = require("../../../src/integrations/action-handlers/complex-test-action");
+
+describe("mutations.updateContactTags", () => {
+  let campaign;
+  let texterUser;
+  let contacts;
+  let organization;
+  let tags;
+  let dbExpectedTags;
+  let gqlExpectedTags;
+  let wrappedMutations;
+
+  beforeEach(async () => {
+    await cleanupTest();
+    await setupTest();
+    jest.restoreAllMocks();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  beforeEach(async () => {
+    const startedCampaign = await createStartedCampaign();
+
+    ({
+      testOrganization: {
+        data: { createOrganization: organization }
+      },
+      testCampaign: campaign,
+      testTexterUser: texterUser,
+      testContacts: contacts
+    } = startedCampaign);
+
+    tags = [
+      {
+        id: 1,
+        name: "HELP!",
+        description: "Need help",
+        organization_id: organization.id
+      },
+      {
+        id: 2,
+        name: "SUPPRESSION",
+        description: "Reporting voter suppression",
+        organization_id: organization.id
+      },
+      {
+        id: 3,
+        name: "VOLUNTEER",
+        description: "Commits to volunteer",
+        organization_id: organization.id
+      },
+      {
+        id: 4,
+        name: "MEGADONOR",
+        description: "Sending a wire transfer",
+        organization_id: organization.id
+      }
+    ];
+
+    await r.knex("tag").insert(tags);
+
+    dbExpectedTags = tags.map(({ id, name, organization_id }) => ({
+      id: id.toString(),
+      organizationId: organization_id,
+      name
+    }));
+
+    gqlExpectedTags = tags.map(({ id, name, organization_id }) => ({
+      id: id.toString(),
+      organizationId: organization_id,
+      name
+    }));
+  });
+
+  beforeEach(async () => {
+    wrappedMutations = makeRunnableMutations(
+      assignmentTexterOps.mutations,
+      texterUser
+    );
+  });
+
+  it("saves the tags and calls the action handlers", async () => {
+    jest.spyOn(ComplexTestActionHandler, "onTagUpdate");
+
+    const result = await wrappedMutations.updateContactTags(
+      dbExpectedTags,
+      contacts[0].id
+    );
+
+    expect(result.data.updateContactTags).toEqual(contacts[0].id.toString());
+
+    const tagged = await r.knex("tag_campaign_contact");
+
+    expect(tagged).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tag_id: tags[0].id,
+          value: null,
+          campaign_contact_id: contacts[0].id
+        }),
+        expect.objectContaining({
+          tag_id: tags[1].id,
+          value: null,
+          campaign_contact_id: contacts[0].id
+        }),
+        expect.objectContaining({
+          tag_id: tags[2].id,
+          value: null,
+          campaign_contact_id: contacts[0].id
+        }),
+        expect.objectContaining({
+          tag_id: tags[3].id,
+          value: null,
+          campaign_contact_id: contacts[0].id
+        })
+      ])
+    );
+
+    expect(ComplexTestActionHandler.onTagUpdate).toHaveBeenCalledTimes(1);
+    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0]).toHaveLength(5);
+    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][0]).toMatchObject(
+      gqlExpectedTags
+    );
+    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][1]).toMatchObject(
+      texterUser
+    );
+    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][2]).toMatchObject(
+      contacts[0]
+    );
+    expect(
+      ComplexTestActionHandler.onTagUpdate.mock.calls[0][3]
+    ).toMatchObject({ id: Number(campaign.id) });
+    expect(
+      ComplexTestActionHandler.onTagUpdate.mock.calls[0][4]
+    ).toMatchObject({ id: Number(organization.id), uuid: organization.uuid });
+  });
+
+  describe("when cacheableData.tagCampaignContact.save throws an exception", () => {
+    it("eats the exception and logs it", async () => {
+      jest.spyOn(console, "error");
+
+      const result = await wrappedMutations.updateContactTags(
+        dbExpectedTags,
+        999999 // this will cause cacheableData.campaignContact.load to throw an exception
+      );
+
+      expect(result.errors[0].message).toEqual(
+        expect.stringMatching(/^Cannot convert `undefined`.*/)
+      );
+
+      expect(console.error).toHaveBeenCalledTimes(1); // eslint-disable-line no-console
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toEqual(
+        expect.stringMatching(
+          /^Error saving tagCampaignContact for campaignContactID 999999.*/
+        )
+      );
+    });
+  });
+
+  describe("when onTagUpdate throws an exception", () => {
+    it("eats the exception and logs it", async () => {
+      jest
+        .spyOn(ComplexTestActionHandler, "onTagUpdate")
+        .mockRejectedValue(new Error("mercury is retrograde"));
+
+      jest.spyOn(console, "error");
+
+      const result = await wrappedMutations.updateContactTags(
+        dbExpectedTags,
+        contacts[0].id
+      );
+
+      expect(result.data.updateContactTags).toEqual(contacts[0].id.toString());
+      expect(console.error).toHaveBeenCalledTimes(1); // eslint-disable-line no-console
+      // eslint-disable-next-line no-console
+      expect(console.error.mock.calls[0][0]).toEqual(
+        expect.stringMatching(/.*mercury is retrograde.*/)
+      );
+    });
+  });
+});

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -23,6 +23,8 @@ export function serverAdministratorInstructions() {
   };
 }
 
+export async function onTagUpdate(tags, contact, campaign, organization) {}
+
 export function clientChoiceDataCacheKey(organization, user) {
   return `${organization.id}`;
 }

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -142,6 +142,18 @@ export async function getAvailableActionHandlers(organization, user) {
   return actionHandlers.filter(x => x);
 }
 
+export async function getActionHandlersAvailableForTagUpdate(
+  organization,
+  user
+) {
+  const actionHandlers = await Promise.all(
+    Object.keys(CONFIGURED_ACTION_HANDLERS).map(name =>
+      getActionHandler(name, organization, user)
+    )
+  );
+  return actionHandlers.filter(x => x && !!x.onTagUpdate);
+}
+
 export async function getActionChoiceData(actionHandler, organization, user) {
   const cacheKeyFunc =
     actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -65,7 +65,7 @@ export async function processAction(
       body
     });
 
-    await httpRequest(url, {
+    return httpRequest(url, {
       method: "POST",
       retries: 0,
       timeout: 5000,

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -68,7 +68,7 @@ export async function processAction(
     return httpRequest(url, {
       method: "POST",
       retries: 0,
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization),
         "Content-Type": "application/json"
@@ -88,7 +88,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/contactTypes`,
     {
       method: "GET",
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -105,7 +105,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/inputTypes`,
     {
       method: "GET",
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -181,7 +181,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/surveyQuestions?statuses=Active${cycleFilter}`,
     {
       method: "GET",
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -198,7 +198,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/activistCodes?statuses=Active`,
     {
       method: "GET",
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -215,7 +215,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/canvassResponses/resultCodes`,
     {
       method: "GET",
-      timeout: 5000,
+      timeout: 32000,
       headers: {
         Authorization: Van.getAuth(organization)
       }

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -88,6 +88,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/contactTypes`,
     {
       method: "GET",
+      timeout: 5000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -104,6 +105,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/inputTypes`,
     {
       method: "GET",
+      timeout: 5000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -179,6 +181,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/surveyQuestions?statuses=Active${cycleFilter}`,
     {
       method: "GET",
+      timeout: 5000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -195,6 +198,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/activistCodes?statuses=Active`,
     {
       method: "GET",
+      timeout: 5000,
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -211,6 +215,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/canvassResponses/resultCodes`,
     {
       method: "GET",
+      timeout: 5000,
       headers: {
         Authorization: Van.getAuth(organization)
       }

--- a/src/integrations/message-handlers/index.js
+++ b/src/integrations/message-handlers/index.js
@@ -1,21 +1,55 @@
 import { getConfig } from "../../server/api/lib/config";
+import campaignCache from "../../server/models/cacheable_queries/campaign";
 
-export function getMessageHandlers(organization) {
+export const getMessageHandlers = organization => {
   const handlerKey = "MESSAGE_HANDLERS";
   const configuredHandlers = getConfig(handlerKey, organization);
   const enabledHandlers =
     (configuredHandlers && configuredHandlers.split(",")) || [];
 
-  const handlers = {};
+  const handlers = [];
   enabledHandlers.forEach(name => {
     try {
+      // eslint-disable-next-line global-require
       const c = require(`./${name}/index.js`);
-      handlers[name] = c;
+      handlers.push(c);
     } catch (err) {
-      log.error(
+      // eslint-disable-next-line no-console
+      console.error(
         `${handlerKey} failed to load message handler ${name} -- ${err}`
       );
     }
   });
   return handlers;
-}
+};
+
+const getAvailableHandlers = async (
+  { organization: organizationInput, campaignId },
+  requiredMethods
+) => {
+  let organization = organizationInput;
+  if (!organization) {
+    organization = await campaignCache.loadCampaignOrganization({
+      campaignId
+    });
+  }
+
+  const isHandlerAvailable = async handler =>
+    !!handler.available &&
+    requiredMethods.every(requiredMethod => !!handler[requiredMethod]) &&
+    (await handler.available(organization)) &&
+    handler;
+
+  const handlers = getMessageHandlers(organization);
+  const promises = handlers.map(handler => isHandlerAvailable(handler));
+  const resolved = await Promise.all(promises);
+  return resolved.filter(handler => !!handler);
+};
+
+export const getAvailablePostMessageSaveHandlers = async parameters => {
+  return getAvailableHandlers(parameters, ["postMessageSave"]);
+};
+
+export const getAvailablePreMessageSaveHandlers = async parameters => {
+  return getAvailableHandlers(parameters, ["preMessageSave"]);
+};

--- a/src/integrations/message-handlers/profanity-tagger/index.js
+++ b/src/integrations/message-handlers/profanity-tagger/index.js
@@ -31,8 +31,7 @@ export const serverAdministratorInstructions = () => {
   };
 };
 
-// note this is NOT async
-export const available = organization => {
+export const available = async organization => {
   return (
     getConfig("EXPERIMENTAL_TAGS", organization) &&
     (getConfig("PROFANITY_CONTACT_TAG_ID", organization) ||

--- a/src/server/api/lib/utils.js
+++ b/src/server/api/lib/utils.js
@@ -30,3 +30,5 @@ export const capitalizeWord = word => {
   }
   return "";
 };
+
+export const runningInLambda = () => !!process.env.AWS_LAMBDA_FUNCTION_NAME;

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -45,10 +45,10 @@ export const updateContactTags = async (
         organization,
         user
       )
-        .then(handler => {
+        .then(async handler => {
           if (handler) {
             // no, no AWAIT. FUTURE: convert to dispatch
-            handler
+            await handler
               .onTagUpdate(
                 tags,
                 campaignContactId,

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -1,4 +1,3 @@
-import { log } from "../../../lib";
 import { assignmentRequiredOrAdminRole } from "../errors";
 import { cacheableData } from "../../models";
 import { runningInLambda } from "../lib/utils";
@@ -9,72 +8,55 @@ export const updateContactTags = async (
   { tags, campaignContactId },
   { user }
 ) => {
-  const contact = await cacheableData.campaignContact.load(campaignContactId);
-  const campaign = await cacheableData.campaign.load(contact.campaign_id);
-  await assignmentRequiredOrAdminRole(
-    user,
-    campaign.organization_id,
-    contact.assignment_id,
-    contact
-  );
+  let contact;
+  try {
+    contact = await cacheableData.campaignContact.load(campaignContactId);
+    const campaign = await cacheableData.campaign.load(contact.campaign_id);
+    await assignmentRequiredOrAdminRole(
+      user,
+      campaign.organization_id,
+      contact.assignment_id,
+      contact
+    );
 
-  await cacheableData.tagCampaignContact
-    .save(campaignContactId, tags)
-    .catch(err => {
-      log.error(
-        `Error saving updated QuestionResponse for campaignContactID ${campaignContactId} questionResponses ${JSON.stringify(
-          questionResponses
-        )} error ${err}`
-      );
+    await cacheableData.tagCampaignContact.save(campaignContactId, tags);
+
+    const organization = await cacheableData.organization.load(
+      campaign.organization_id
+    );
+
+    // The rest is for ACTION_HANDLERS
+    const promises = [];
+    const getHandlersPromise = ActionHandlers.getActionHandlersAvailableForTagUpdate(
+      organization,
+      user
+    ).then(supportedActionHandlers => {
+      supportedActionHandlers.forEach(handler => {
+        const tagUpdatePromise = handler
+          .onTagUpdate(tags, user, contact, campaign, organization)
+          .catch(err => {
+            // eslint-disable-next-line no-console
+            console.error(
+              `Error executing handler.onTagUpdate for ${handler.name}, campaignContactId ${campaignContactId} error ${err}`
+            );
+          });
+        promises.push(tagUpdatePromise);
+      });
     });
 
-  const organization = await cacheableData.organization.load(
-    campaign.organization_id
-  );
-  // The rest is for ACTION_HANDLERS
-  const actionHandlers = ActionHandlers.getActionHandlers(organization);
-  const supportedActionHandlers = Object.keys(actionHandlers).filter(
-    handler => actionHandlers[handler].onTagUpdate
-  );
-
-  if (supportedActionHandlers.length) {
-    const promises = [];
-    for (let i = 0, l = supportedActionHandlers.length; i < l; i++) {
-      const actionHandlerPromise = ActionHandlers.getActionHandler(
-        supportedActionHandlers[i],
-        organization,
-        user
-      )
-        .then(async handler => {
-          if (handler) {
-            // no, no AWAIT. FUTURE: convert to dispatch
-            await handler
-              .onTagUpdate(
-                tags,
-                campaignContactId,
-                contact,
-                campaign,
-                organization
-              )
-              .catch(err => {
-                log.error(
-                  `Error executing handler for ${supportedActionHandlers[i]}, campaignContactId ${campaignContactId} error ${err}`
-                );
-              });
-          }
-        })
-        .catch(err => {
-          log.error(
-            `Error loading handler for InteractionStep ${interactionStepId} InteractionStepAction ${interactionStepAction} error ${err}`
-          );
-        });
-      promises.push(actionHandlerPromise);
-    }
+    promises.push(getHandlersPromise);
 
     if (runningInLambda()) {
       await Promise.all(promises);
     }
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Error saving tagCampaignContact for campaignContactID ${campaignContactId} tags ${tags}  error ${err}`
+    );
+    throw err;
   }
+
   return contact.id;
 };
 

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -78,7 +78,7 @@ export const updateQuestionResponses = async (
           if (!handler) {
             return questionResponse;
           }
-          await handler
+          const processActionPromise = handler
             .processAction(
               questionResponse,
               questionResponseInteractionStep,
@@ -92,6 +92,7 @@ export const updateQuestionResponses = async (
                 `Error executing handler for InteractionStep ${interactionStepId} InteractionStepAction ${interactionStepAction} error ${err}`
               );
             });
+          promises.push(processActionPromise);
           return questionResponse;
         })
         .catch(err => {

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -74,11 +74,11 @@ export const updateQuestionResponses = async (
         organization,
         user
       )
-        .then(handler => {
+        .then(async handler => {
           if (!handler) {
             return questionResponse;
           }
-          handler
+          await handler
             .processAction(
               questionResponse,
               questionResponseInteractionStep,

--- a/src/server/lib/http-request.js
+++ b/src/server/lib/http-request.js
@@ -20,11 +20,12 @@ const requestWithRetry = async (
   {
     validStatuses,
     statusValidationFunction,
-    retries = retries || 0,
+    retries: retriesInput,
     timeout = 2000,
     ...props
   } = {}
 ) => {
+  const retries = retriesInput || 0;
   const requestId = uuid();
 
   const retryDelay = () => {
@@ -46,7 +47,14 @@ const requestWithRetry = async (
   };
 
   const logRequest = () => {
-    return JSON.stringify({ url, props });
+    const logProps = {
+      ...props
+    };
+    if (props && props.headers && props.headers.Authorization) {
+      logProps.headers.Authorization = "redacted";
+    }
+
+    return JSON.stringify({ url, logProps });
   };
 
   const RetryReturnError = {


### PR DESCRIPTION
## Description

This PR is a minor refactoring of the message handling code. I'm creating this PR so it's clear that I did here, although the NGPVAN message handler will be based on this branch, and these changes will be included therein.

* made `available` async for the ngpvan case (future PR)
* moved filtering of message handlers to `message-handlers/index` for
  separation of conerns
* fixed profanity-tagger test

Going forward we may want to add caching around the `available` method of the message handlers the way we do for action handlers and contact loaders.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
