### PR TITLE
Configurable background processing backends with bull and lambda implementations

### DIFF
--- a/__test__/integrations/action-handlers/index.test.js
+++ b/__test__/integrations/action-handlers/index.test.js
@@ -531,18 +531,6 @@ describe("action-handlers/index", () => {
     });
   });
 
-  describe("#getActionHandlersAvailableForTagUpdate", () => {
-    it("returns all the handlers available for tag update", async () => {
-      const returned = await ActionHandlers.getActionHandlersAvailableForTagUpdate(
-        organization,
-        user
-      );
-
-      expect(returned).toHaveLength(1);
-      expect(returned).toEqual(expect.arrayContaining([ComplexTestAction]));
-    });
-  });
-
   describe("#getActionChoiceData", () => {
     let expectedReturn;
 

--- a/__test__/server/api/updateContactTags.test.js
+++ b/__test__/server/api/updateContactTags.test.js
@@ -96,9 +96,7 @@ describe("mutations.updateContactTags", () => {
     );
   });
 
-  it("saves the tags and calls the action handlers", async () => {
-    jest.spyOn(ComplexTestActionHandler, "onTagUpdate");
-
+  it("saves the tags", async () => {
     const result = await wrappedMutations.updateContactTags(
       dbExpectedTags,
       contacts[0].id
@@ -132,25 +130,11 @@ describe("mutations.updateContactTags", () => {
         })
       ])
     );
-
-    expect(ComplexTestActionHandler.onTagUpdate).toHaveBeenCalledTimes(1);
-    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0]).toHaveLength(5);
-    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][0]).toMatchObject(
-      gqlExpectedTags
-    );
-    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][1]).toMatchObject(
-      texterUser
-    );
-    expect(ComplexTestActionHandler.onTagUpdate.mock.calls[0][2]).toMatchObject(
-      contacts[0]
-    );
-    expect(
-      ComplexTestActionHandler.onTagUpdate.mock.calls[0][3]
-    ).toMatchObject({ id: Number(campaign.id) });
-    expect(
-      ComplexTestActionHandler.onTagUpdate.mock.calls[0][4]
-    ).toMatchObject({ id: Number(organization.id), uuid: organization.uuid });
   });
+
+  // TODO: implement these tests when we add a tag handler
+  it.skip("calls tag handlers", () => {});
+  it.skip("doesn't fail when dispatching to tag handlers throws an exception", () => {});
 
   describe("when cacheableData.tagCampaignContact.save throws an exception", () => {
     it("eats the exception and logs it", async () => {
@@ -171,28 +155,6 @@ describe("mutations.updateContactTags", () => {
         expect.stringMatching(
           /^Error saving tagCampaignContact for campaignContactID 999999.*/
         )
-      );
-    });
-  });
-
-  describe("when onTagUpdate throws an exception", () => {
-    it("eats the exception and logs it", async () => {
-      jest
-        .spyOn(ComplexTestActionHandler, "onTagUpdate")
-        .mockRejectedValue(new Error("mercury is retrograde"));
-
-      jest.spyOn(console, "error");
-
-      const result = await wrappedMutations.updateContactTags(
-        dbExpectedTags,
-        contacts[0].id
-      );
-
-      expect(result.data.updateContactTags).toEqual(contacts[0].id.toString());
-      expect(console.error).toHaveBeenCalledTimes(1); // eslint-disable-line no-console
-      // eslint-disable-next-line no-console
-      expect(console.error.mock.calls[0][0]).toEqual(
-        expect.stringMatching(/.*mercury is retrograde.*/)
       );
     });
   });

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -23,8 +23,6 @@ export function serverAdministratorInstructions() {
   };
 }
 
-export async function onTagUpdate(tags, contact, campaign, organization) {}
-
 export function clientChoiceDataCacheKey(organization, user) {
   return `${organization.id}`;
 }

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -153,18 +153,6 @@ export async function getAvailableActionHandlers(organization, user) {
   return actionHandlers.filter(x => x);
 }
 
-export async function getActionHandlersAvailableForTagUpdate(
-  organization,
-  user
-) {
-  const actionHandlers = await Promise.all(
-    Object.keys(CONFIGURED_ACTION_HANDLERS).map(name =>
-      getActionHandler(name, organization, user)
-    )
-  );
-  return actionHandlers.filter(x => x && !!x.onTagUpdate);
-}
-
 export async function getActionChoiceData(actionHandler, organization, user) {
   const cacheKeyFunc =
     actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);

--- a/src/integrations/action-handlers/test-action.js
+++ b/src/integrations/action-handlers/test-action.js
@@ -58,3 +58,15 @@ export async function processAction(
     .where("campaign_contact.id", campaignContactId)
     .update("custom_fields", JSON.stringify(customFields));
 }
+
+// Uncomment to test tag action handlers
+// TODO: move this to tag handlers
+// export async function onTagUpdate(
+//   tags,
+//   contact,
+//   campaign,
+//   organization,
+//   texter
+// ) {
+//   console.log("TEST TAG HANDLER", {tags, contact, campaign, organization, texter});
+// }

--- a/src/integrations/action-handlers/zapier-action.js
+++ b/src/integrations/action-handlers/zapier-action.js
@@ -27,14 +27,20 @@ export function clientChoiceDataCacheKey(organization) {
   return `${organization.id}`;
 }
 
-export async function onTagUpdate(tags, user, contact, campaign, organization) {
+export async function onTagUpdate(
+  tags,
+  contact,
+  campaign,
+  organization,
+  texter
+) {
   const baseUrl = getConfig("BASE_URL", organization);
   const conversationLink = `${baseUrl}/app/${organization.id}/todos/review/${contact.id}`;
 
   const payload = {
     texter: {
-      name: `${user.first_name} ${user.last_name}`,
-      email: user.email
+      name: `${texter.first_name} ${texter.last_name}`,
+      email: texter.email
     },
     campaign: {
       id: campaign.id,

--- a/src/integrations/job-runners/README.md
+++ b/src/integrations/job-runners/README.md
@@ -14,12 +14,16 @@ introducing conflicts with MoveOn/main.
 "Tasks" are lightweight fire-and-forget operations, while "Jobs" are
 long-running operations that are tracked in the JobRequest table.
 
+Task payloads should always be JSON-serializable and should be relatively small because
+they are passed to the job runner directly without being written to the database.
+If the maximum payload for a background operation exceeds 100Kb,
+consider using a Job rather than a Task.
+
 While most queueing systems should be able to handle both types of background
 processing, we are keeping them separate for now to allow for different execution
 strategies. For example, it might be reasonable to always run tasks in-process
 outside of AWS Lambda while still pushing Jobs to a separate worker process.
 
-Note: This api may change in the future.
 
 ## Configuration
 

--- a/src/integrations/job-runners/README.md
+++ b/src/integrations/job-runners/README.md
@@ -1,0 +1,52 @@
+# Job Runners
+
+## Intro
+
+Spoke has several functions that need to be run in the background after
+an API request has returned. Strategies for executing this background
+work depend on the deployment environment. This job runner API allows
+organizations to customize background jobs to their deployment without
+introducing conflicts with MoveOn/main.
+
+
+## Tasks vs Jobs
+
+"Tasks" are lightweight fire-and-forget operations, while "Jobs" are
+long-running operations that are tracked in the JobRequest table.
+
+While most queueing systems should be able to handle both types of background
+processing, we are keeping them separate for now to allow for different execution
+strategies. For example, it might be reasonable to always run tasks in-process
+outside of AWS Lambda while still pushing Jobs to a separate worker process.
+
+Note: This api may change in the future.
+
+## Configuration
+
+A Spoke instance must have exactly one job runner configured via the `JOB_RUNNER`
+env var. For backwards compatibility, JOB_RUNNER will default to 'legacy', which
+uses the `JOBS_SAME_PROCESS` and `JOBS_SYNC` env vars.
+
+Individual job runners may require additional configuration, for example
+an SQS queue URL or Lambda function ARN.
+
+## Implementing a Job Runner
+
+Job Runner modules must export the following functions:
+  * `fullyConfigured() -> boolean`
+  * `dispatchJob(jobData) -> JobRequest`
+  * `dispatchTask(taskName, payload) -> void`
+
+Use fullyConfigured to fail-fast if your job running strategy isn't properly configured.
+`dispatchTask` and `disptachJob` both enqueue units of work, but `dispatchJob` has to also
+save and return a JobRequest object.
+
+## Adding new Jobs and Tasks
+
+Tasks are defined in `src/workers/tasks.js` and Jobs are defined
+in `src/workers/job-processes.js`. To add a new task/job add its
+ name to the Tasks/Jobs enum, and the function to run in the
+ taskMap/jobsMap object.
+
+_Note: when writing new jobs/tasks keep in mind that they
+may execute in a separate process and design accordingly._

--- a/src/integrations/job-runners/README.md
+++ b/src/integrations/job-runners/README.md
@@ -50,3 +50,21 @@ in `src/workers/job-processes.js`. To add a new task/job add its
 
 _Note: when writing new jobs/tasks keep in mind that they
 may execute in a separate process and design accordingly._
+
+## Notes
+
+#### Retries
+
+As currently implemented, neither the 'legacy' nor the 'lambda-async' job runners
+support retries, but this could be a good feature to add to the API. Individual jobs
+would have to be tagged as retry-able/idempotent.
+
+#### Recommendations for running on AWS Lambda
+
+AWS Lambda "freezes" the application container as soon as it returns a response
+to API Gateway. Any background tasks are effectively paused until the container is
+reused to respond to another request, which is not guaranteed. The effect is more
+noticeable when traffic is low because containers are reused less.
+Because of this, it is not recommended to run jobs or tasks in-process without awaiting them.
+Either use the 'lambda-async' runner or pass TASKS_SYNC/JOBS_SYNC env vars when using
+the legacy runner.

--- a/src/integrations/job-runners/experimental-bull/README.md
+++ b/src/integrations/job-runners/experimental-bull/README.md
@@ -1,0 +1,16 @@
+# EXPERIMENTAL: bull job runner
+
+[Bull](https://github.com/OptimalBits/bull) is a mature, feature-rich job
+queueing library for nodejs.
+
+This job runner is experimental and should not be used in production yet
+
+## Running locally
+
+From the Spoke root directory:
+
+1. Install bull: `yarn add bull`
+2. Run redis locally
+3. Add `JOB_RUNNER=experimental-bull` and `REDIS_URL` to your .env
+4. Run the worker process: `dev-tools/babel-run-with-env.js src/integrations/job-runners/experimental-bull/processor.js`
+5. Run the application: `yarn run dev`

--- a/src/integrations/job-runners/experimental-bull/index.js
+++ b/src/integrations/job-runners/experimental-bull/index.js
@@ -1,0 +1,28 @@
+import { saveJob } from "../helpers";
+import { taskQueue, jobQueue } from "./queues";
+
+export const fullyConfigured = () => !!process.env.REDIS_URL;
+
+export const dispatchJob = async (
+  { queue_name, job_type, organization_id, campaign_id, payload },
+  opts = {}
+) => {
+  const job = await saveJob(
+    {
+      locks_queue: false,
+      assigned: true,
+      organization_id,
+      campaign_id,
+      queue_name,
+      payload,
+      job_type
+    },
+    opts.trx
+  );
+  await jobQueue.add({ jobId: job.id });
+  return job;
+};
+
+export const dispatchTask = async (taskName, payload) => {
+  await taskQueue.add({ taskName, payload });
+};

--- a/src/integrations/job-runners/experimental-bull/processor.js
+++ b/src/integrations/job-runners/experimental-bull/processor.js
@@ -1,0 +1,25 @@
+import { invokeJobFunction } from "../../../workers/job-processes";
+import { invokeTaskFunction } from "../../../workers/tasks";
+import { r } from "../../../server/models";
+
+import { jobQueue, taskQueue } from "./queues";
+
+taskQueue.process(async bullJob => {
+  console.debug("Processing bull job:", { ...bullJob, queue: null });
+  const { taskName, payload } = bullJob.data;
+  await invokeTaskFunction(taskName, payload);
+});
+
+jobQueue.process(async bullJob => {
+  console.debug("Processing bull job:", { ...bullJob, queue: null });
+  const { jobId } = bullJob.data;
+  const job = await r
+    .knex("job_request")
+    .select("*")
+    .where("id", jobId)
+    .first();
+  if (!job) {
+    throw new Error(`Job ${jobId} not found`);
+  }
+  await invokeJobFunction(job);
+});

--- a/src/integrations/job-runners/experimental-bull/queues.js
+++ b/src/integrations/job-runners/experimental-bull/queues.js
@@ -1,0 +1,7 @@
+import Queue from "bull";
+
+// Simple job and task queues. Note that bull gives us the option to
+// create separate queues for each job and task type, which would allow
+// finer control over concurrent processing, locking, and retries.
+export const jobQueue = new Queue("jobs", process.env.REDIS_URL);
+export const taskQueue = new Queue("tasks", process.env.REDIS_URL);

--- a/src/integrations/job-runners/helpers.js
+++ b/src/integrations/job-runners/helpers.js
@@ -10,10 +10,10 @@ export const saveJob = async (jobData, trx) => {
     unsavedJob = { ...jobData, payload: JSON.stringify(jobData.payload) };
   }
 
-  const res = await builder("job_request")
-    .insert(unsavedJob)
-    // TODO: on sqlite issue second query to get back data
-    .returning("*");
+  const [id] = await builder("job_request").insert(unsavedJob, "id");
 
-  return res[0];
+  return builder("job_request")
+    .select("*")
+    .where("id", id)
+    .first();
 };

--- a/src/integrations/job-runners/helpers.js
+++ b/src/integrations/job-runners/helpers.js
@@ -1,0 +1,19 @@
+import { r } from "../../server/models";
+
+export const saveJob = async (jobData, trx) => {
+  const builder = trx || r.knex;
+
+  let unsavedJob;
+  if (typeof jobData.payload === "string") {
+    unsavedJob = jobData;
+  } else {
+    unsavedJob = { ...jobData, payload: JSON.stringify(jobData.payload) };
+  }
+
+  const res = await builder("job_request")
+    .insert(unsavedJob)
+    // TODO: on sqlite issue second query to get back data
+    .returning("*");
+
+  return res[0];
+};

--- a/src/integrations/job-runners/helpers.js
+++ b/src/integrations/job-runners/helpers.js
@@ -7,7 +7,7 @@ export const saveJob = async (jobData, trx) => {
   if (typeof jobData.payload === "string") {
     unsavedJob = jobData;
   } else {
-    unsavedJob = { ...jobData, payload: JSON.stringify(jobData.payload) };
+    unsavedJob = { ...jobData, payload: JSON.stringify(jobData.payload || {}) };
   }
 
   const [id] = await builder("job_request").insert(unsavedJob, "id");

--- a/src/integrations/job-runners/index.js
+++ b/src/integrations/job-runners/index.js
@@ -1,22 +1,3 @@
-// WORK IN PROGRESS: plugin-style job runners
-// Motivation: strategies for running background jobs depend a lot on
-// the deployment environment. Providing a job-runner API allows
-// organizations using Spoke to customize background jobs to their
-// deployment environment without introducing conflicts with MoveOn/main
-
-// API:
-// *  fullyConfigured() -> Boolean
-// *  dispatchJob(jobData) -> job object
-// *  task(taskData) -> void
-//
-// TODOs:
-// * Figure out what to do about locks_queue. Not all runners can support it but it
-//   also doesn't seem necessary.
-// * Introduce better statuses and handling of job failure
-// * Rather than querying job_request directly in our resolvers,
-//   we should call the job runner: getJob, listOrganizationJobs, listCampaignJobs
-//   This allows job runners to implement their own storage, potentially outside of
-//   the database.
 function getJobRunner() {
   const name = process.env.JOB_RUNNER || "legacy";
   let runner;

--- a/src/integrations/job-runners/index.js
+++ b/src/integrations/job-runners/index.js
@@ -6,7 +6,8 @@
 
 // API:
 // *  fullyConfigured() -> Boolean
-// *  dispatch(jobData) -> job object
+// *  dispatchJob(jobData) -> job object
+// *  task(taskData) -> void
 //
 // TODOs:
 // * Figure out what to do about locks_queue. Not all runners can support it but it
@@ -18,17 +19,18 @@
 //   the database.
 function getJobRunner() {
   const name = process.env.JOB_RUNNER || "legacy";
+  let runner;
   try {
     // eslint-disable-next-line global-require
-    const runner = require(`./${name}`);
-    console.log(`Successfully loaded ${name} job runner`);
-    if (!runner.fullyConfigured()) {
-      throw new Error(`Job runner ${name} is not fully configured`);
-    }
-    return runner;
+    runner = require(`./${name}`);
   } catch (e) {
     throw new Error(`Job runner ${name} not found`);
   }
+  console.log(`Successfully loaded ${name} job runner`);
+  if (!runner.fullyConfigured()) {
+    throw new Error(`Job runner ${name} is not fully configured`);
+  }
+  return runner;
 }
 
 export const jobRunner = getJobRunner();

--- a/src/integrations/job-runners/index.js
+++ b/src/integrations/job-runners/index.js
@@ -1,0 +1,34 @@
+// WORK IN PROGRESS: plugin-style job runners
+// Motivation: strategies for running background jobs depend a lot on
+// the deployment environment. Providing a job-runner API allows
+// organizations using Spoke to customize background jobs to their
+// deployment environment without introducing conflicts with MoveOn/main
+
+// API:
+// *  fullyConfigured() -> Boolean
+// *  dispatch(jobData) -> job object
+//
+// TODOs:
+// * Figure out what to do about locks_queue. Not all runners can support it but it
+//   also doesn't seem necessary.
+// * Introduce better statuses and handling of job failure
+// * Rather than querying job_request directly in our resolvers,
+//   we should call the job runner: getJob, listOrganizationJobs, listCampaignJobs
+//   This allows job runners to implement their own storage, potentially outside of
+//   the database.
+function getJobRunner() {
+  const name = process.env.JOB_RUNNER || "legacy";
+  try {
+    // eslint-disable-next-line global-require
+    const runner = require(`./${name}`);
+    console.log(`Successfully loaded ${name} job runner`);
+    if (!runner.fullyConfigured()) {
+      throw new Error(`Job runner ${name} is not fully configured`);
+    }
+    return runner;
+  } catch (e) {
+    throw new Error(`Job runner ${name} not found`);
+  }
+}
+
+export const jobRunner = getJobRunner();

--- a/src/integrations/job-runners/lambda-async/handler.js
+++ b/src/integrations/job-runners/lambda-async/handler.js
@@ -1,0 +1,28 @@
+import { invokeJobFunction } from "../../../workers/job-processes";
+import { r } from "../../../server/models";
+
+exports.handler = async (event, context) => {
+  console.log("Received event ", event);
+  if (!event.jobId) {
+    console.error("Missing jobId in event", event);
+  }
+
+  try {
+    const job = await r
+      .knex("job_request")
+      .select("*")
+      .where("id", event.jobId)
+      .first();
+    if (!job) {
+      console.error(`Job ${event.jobId} not found`);
+      return;
+    }
+    console.log("Running job", job);
+    await invokeJobFunction(job);
+  } catch (e) {
+    // For now suppress Lambda retries by not raising the exception.
+    // In the future, we may want to mark jobs as retryable and let Lambda do
+    // its thing with exceptions.
+    console.error("Caught exception while processing job", e);
+  }
+};

--- a/src/integrations/job-runners/lambda-async/index.js
+++ b/src/integrations/job-runners/lambda-async/index.js
@@ -32,8 +32,18 @@ export const dispatch = async (
     .invoke({
       FunctionName: functionName,
       InvocationType: "Event",
-      Payload: JSON.stringify({ jobId: job.id })
+      Payload: JSON.stringify({ type: "JOB", jobId: job.id })
     })
     .promise();
   return job;
+};
+
+export const dispatchTask = async (taskName, payload) => {
+  await client
+    .invoke({
+      FunctionName: functionName,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ type: "TASK", taskName, payload })
+    })
+    .promise();
 };

--- a/src/integrations/job-runners/lambda-async/index.js
+++ b/src/integrations/job-runners/lambda-async/index.js
@@ -35,5 +35,5 @@ export const dispatch = async (
       Payload: JSON.stringify({ jobId: job.id })
     })
     .promise();
-  return job.id;
+  return job;
 };

--- a/src/integrations/job-runners/lambda-async/index.js
+++ b/src/integrations/job-runners/lambda-async/index.js
@@ -1,0 +1,39 @@
+import AWS from "aws-sdk";
+import { saveJob } from "../helpers";
+
+// TODO: push this functionality into lambda.js so users don't
+// have to deploy two lambdas
+const functionName = process.env.WORKER_LAMBDA_FUNCTION_NAME;
+
+const client = new AWS.Lambda();
+
+export const fullyConfigured = () => !!functionName;
+
+export const dispatch = async (
+  { queue_name, job_type, organization_id, campaign_id, payload },
+  opts = {}
+) => {
+  const job = await saveJob(
+    {
+      // locking the queue is not supported
+      // TODO: think about how that functionality should be handled
+      locks_queue: false,
+      assigned: true,
+      organization_id,
+      campaign_id,
+      queue_name,
+      payload,
+      job_type
+    },
+    opts.trx
+  );
+
+  await client
+    .invoke({
+      FunctionName: functionName,
+      InvocationType: "Event",
+      Payload: JSON.stringify({ jobId: job.id })
+    })
+    .promise();
+  return job.id;
+};

--- a/src/integrations/job-runners/lambda-async/index.js
+++ b/src/integrations/job-runners/lambda-async/index.js
@@ -9,7 +9,7 @@ const client = new AWS.Lambda();
 
 export const fullyConfigured = () => !!functionName;
 
-export const dispatch = async (
+export const dispatchJob = async (
   { queue_name, job_type, organization_id, campaign_id, payload },
   opts = {}
 ) => {

--- a/src/integrations/job-runners/legacy.js
+++ b/src/integrations/job-runners/legacy.js
@@ -1,0 +1,37 @@
+import { saveJob } from "./helpers";
+import { invokeJobFunction } from "../../workers/job-processes";
+
+const JOBS_SAME_PROCESS = !!(
+  process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
+);
+const JOBS_SYNC = !!(process.env.JOBS_SYNC || global.JOBS_SYNC);
+
+export const fullyConfigured = () => true;
+export const dispatch = async (
+  { queue_name, locks_queue, job_type, organization_id, campaign_id, payload },
+  opts = {}
+) => {
+  const job = await saveJob(
+    {
+      assigned: JOBS_SAME_PROCESS,
+      locks_queue,
+      job_type,
+      organization_id,
+      campaign_id,
+      queue_name,
+      payload
+    },
+    opts.trx
+  );
+
+  if (JOBS_SAME_PROCESS) {
+    if (JOBS_SYNC) {
+      await invokeJobFunction(job);
+    }
+    // Intentionally un-awaited promise
+    invokeJobFunction(job).catch(err =>
+      console.log("Exception in un-awaited job", err)
+    );
+  }
+  // default: just save the job
+};

--- a/src/integrations/job-runners/legacy.js
+++ b/src/integrations/job-runners/legacy.js
@@ -33,5 +33,6 @@ export const dispatch = async (
       console.log("Exception in un-awaited job", err)
     );
   }
+  return job;
   // default: just save the job
 };

--- a/src/server/api/lib/utils.js
+++ b/src/server/api/lib/utils.js
@@ -30,5 +30,3 @@ export const capitalizeWord = word => {
   }
   return "";
 };
-
-export const runningInLambda = () => !!process.env.AWS_LAMBDA_FUNCTION_NAME;

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -32,7 +32,7 @@ export const buyPhoneNumbers = async (
     }
     messagingServiceSid = msgSrv;
   }
-  return jobRunner.dispatch({
+  return await jobRunner.dispatch({
     queue_name: `${organizationId}:buy_phone_numbers`,
     organization_id: organizationId,
     job_type: "buy_phone_numbers",

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -32,7 +32,7 @@ export const buyPhoneNumbers = async (
     }
     messagingServiceSid = msgSrv;
   }
-  return await jobRunner.dispatch({
+  return await jobRunner.dispatchJob({
     queue_name: `${organizationId}:buy_phone_numbers`,
     organization_id: organizationId,
     job_type: "buy_phone_numbers",

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -3,6 +3,7 @@ import { accessRequired } from "../errors";
 import { getConfig } from "../lib/config";
 import { cacheableData } from "../../models";
 import { jobRunner } from "../../../integrations/job-runners";
+import { Jobs } from "../../../workers/job-processes";
 
 export const buyPhoneNumbers = async (
   _,
@@ -35,7 +36,7 @@ export const buyPhoneNumbers = async (
   return await jobRunner.dispatchJob({
     queue_name: `${organizationId}:buy_phone_numbers`,
     organization_id: organizationId,
-    job_type: "buy_phone_numbers",
+    job_type: Jobs.BUY_PHONE_NUMBERS,
     locks_queue: false,
     payload: JSON.stringify({
       areaCode,

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -140,14 +140,16 @@ export const sendMessage = async (
   }
   contact.message_status = saveResult.contactStatus;
 
-  await jobRunner.dispatchTask(Tasks.SEND_MESSAGE, {
-    message: saveResult.message,
-    contact,
-    // TODO: start a transaction inside the service send message function
-    trx: null,
-    organization,
-    campaign
-  });
+  if (!saveResult.blockSend) {
+    await jobRunner.dispatchTask(Tasks.SEND_MESSAGE, {
+      message: saveResult.message,
+      contact,
+      // TODO: start a transaction inside the service send message function
+      trx: null,
+      organization,
+      campaign
+    });
+  }
 
   if (initialMessageStatus === "needsMessage") {
     // don't both requerying the messages list on the response

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -143,7 +143,7 @@ export const sendMessage = async (
   await jobRunner.dispatchTask(Tasks.SEND_MESSAGE, {
     message: saveResult.message,
     contact,
-    // TODO: trx can't be supported with remote dispatch, see if it's necessary
+    // TODO: start a transaction inside the service send message function
     trx: null,
     organization,
     campaign

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -1,9 +1,10 @@
 import { GraphQLError } from "graphql/error";
 
 import { Message, cacheableData } from "../../models";
-import serviceMap from "../lib/services";
 
 import { getSendBeforeTimeUtc } from "../../../lib/timezones";
+import { jobRunner } from "../../../integrations/job-runners";
+import { Tasks } from "../../../workers/tasks";
 
 const JOBS_SAME_PROCESS = !!(
   process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
@@ -108,7 +109,7 @@ export const sendMessage = async (
     global.DEFAULT_SERVICE ||
     process.env.DEFAULT_SERVICE ||
     "";
-  const service = serviceMap[serviceName];
+
   const finalText = replaceCurlyApostrophes(text);
   const messageInstance = new Message({
     text: finalText,
@@ -139,19 +140,14 @@ export const sendMessage = async (
   }
   contact.message_status = saveResult.contactStatus;
 
-  // log.info(
-  //   `Sending (${serviceName}): ${messageInstance.user_number} -> ${messageInstance.contact_number}\nMessage: ${messageInstance.text}`
-  // );
-  //NO AWAIT: pro=return before api completes, con=context needs to stay alive
-  if (!saveResult.blockSend) {
-    service.sendMessage(
-      saveResult.message,
-      contact,
-      null,
-      organization,
-      campaign
-    );
-  }
+  await jobRunner.dispatchTask(Tasks.SEND_MESSAGE, {
+    message: saveResult.message,
+    contact,
+    // TODO: trx can't be supported with remote dispatch, see if it's necessary
+    trx: null,
+    organization,
+    campaign
+  });
 
   if (initialMessageStatus === "needsMessage") {
     // don't both requerying the messages list on the response

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -26,23 +26,23 @@ export const updateContactTags = async (
       campaign.organization_id
     );
 
-    const handlers = await ActionHandlers.getActionHandlersAvailableForTagUpdate(
-      organization,
-      user
+    const handlerNames = await ActionHandlers.rawAllTagUpdateActionHandlerNames();
+    await Promise.all(
+      handlerNames.map(name => {
+        return jobRunner.dispatchTask(Tasks.ACTION_HANDLER_TAG_UPDATE, {
+          name,
+          tags,
+          contact,
+          campaign,
+          organization,
+          texter: {
+            first_name: user.first_name,
+            last_name: user.last_name,
+            email: user.email
+          }
+        });
+      })
     );
-    if (handlers && handlers.length > 0) {
-      await jobRunner.dispatchTask(Tasks.ACTION_HANDLER_TAG_UPDATE, {
-        tags,
-        contact,
-        campaign,
-        organization,
-        texter: {
-          first_name: user.first_name,
-          last_name: user.last_name,
-          email: user.email
-        }
-      });
-    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.error(

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -31,13 +31,16 @@ export const updateContactTags = async (
       user
     );
     if (handlers && handlers.length > 0) {
-      // TODO: see if there is a better way to avoid unnecessary dispatches
       await jobRunner.dispatchTask(Tasks.ACTION_HANDLER_TAG_UPDATE, {
         tags,
-        user,
         contact,
         campaign,
-        organization
+        organization,
+        texter: {
+          first_name: user.first_name,
+          last_name: user.last_name,
+          email: user.email
+        }
       });
     }
   } catch (err) {

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -42,6 +42,8 @@ export const updateContactTags = async (
           }
         });
       })
+    ).catch(e =>
+      console.error("Dispatching to one or more tag handlers failed", e)
     );
   } catch (err) {
     // eslint-disable-next-line no-console

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -89,6 +89,16 @@ export const updateQuestionResponses = async (
       );
     });
 
-  await dispatchActionHandlers({ user, questionResponses, campaign, contact });
+  try {
+    await dispatchActionHandlers({
+      user,
+      questionResponses,
+      campaign,
+      contact
+    });
+  } catch (e) {
+    console.error("Dispatching to one or more action handlers failed", e);
+  }
+
   return contact.id;
 };

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -52,7 +52,7 @@ const dispatchActionHandlers = async ({
         }
 
         await jobRunner.dispatchTask(Tasks.ACTION_HANDLER_QUESTION_RESPONSE, {
-          interactionStepAction,
+          name: interactionStepAction,
           organization,
           user,
           questionResponse,

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -1,8 +1,69 @@
 import { log } from "../../../lib";
 import { assignmentRequiredOrAdminRole } from "../errors";
 import { cacheableData } from "../../models";
-import { runningInLambda } from "../lib/utils";
+import { jobRunner } from "../../../integrations/job-runners";
+import { Tasks } from "../../../workers/tasks";
+
 const ActionHandlers = require("../../../integrations/action-handlers");
+
+const dispatchActionHandlers = async ({
+  user,
+  contact,
+  campaign,
+  questionResponses
+}) => {
+  const actionHandlersConfigured =
+    Object.keys(ActionHandlers.rawAllActionHandlers()).length > 0;
+
+  if (actionHandlersConfigured) {
+    const interactionSteps =
+      campaign.interactionSteps ||
+      (await cacheableData.campaign.dbInteractionSteps(campaign.id));
+
+    const stepsWithActions = interactionSteps.filter(
+      interactionStep => interactionStep.answer_actions
+    );
+
+    if (!stepsWithActions.length) {
+      return contact.id;
+    }
+
+    const organization = await cacheableData.organization.load(
+      campaign.organization_id
+    );
+
+    await Promise.all(
+      questionResponses.map(async questionResponse => {
+        const { interactionStepId, value } = questionResponse;
+
+        const questionResponseInteractionStep = interactionSteps.find(
+          is =>
+            is.answer_actions &&
+            is.answer_option === value &&
+            is.parent_interaction_id === Number(interactionStepId)
+        );
+
+        const interactionStepAction =
+          questionResponseInteractionStep &&
+          questionResponseInteractionStep.answer_actions;
+
+        if (!interactionStepAction) {
+          return;
+        }
+
+        await jobRunner.dispatchTask(Tasks.ACTION_HANDLER_QUESTION_RESPONSE, {
+          interactionStepAction,
+          organization,
+          user,
+          questionResponse,
+          questionResponseInteractionStep,
+          campaign,
+          contact
+        });
+      })
+    );
+  }
+};
 
 export const updateQuestionResponses = async (
   _,
@@ -28,87 +89,6 @@ export const updateQuestionResponses = async (
       );
     });
 
-  // The rest is for ACTION_HANDLERS
-  const actionHandlersConfigured =
-    Object.keys(ActionHandlers.rawAllActionHandlers()).length > 0;
-
-  if (actionHandlersConfigured) {
-    const interactionSteps =
-      campaign.interactionSteps ||
-      (await cacheableData.campaign.dbInteractionSteps(campaign.id));
-
-    const stepsWithActions = interactionSteps.filter(
-      interactionStep => interactionStep.answer_actions
-    );
-
-    if (!stepsWithActions.length) {
-      return contact.id;
-    }
-
-    const organization = await cacheableData.organization.load(
-      campaign.organization_id
-    );
-
-    const promises = [];
-    questionResponses.map(async questionResponse => {
-      const { interactionStepId, value } = questionResponse;
-
-      const questionResponseInteractionStep = interactionSteps.find(
-        is =>
-          is.answer_actions &&
-          is.answer_option === value &&
-          is.parent_interaction_id === Number(interactionStepId)
-      );
-
-      const interactionStepAction =
-        questionResponseInteractionStep &&
-        questionResponseInteractionStep.answer_actions;
-
-      if (!interactionStepAction) {
-        return questionResponse;
-      }
-
-      // run interaction step handler
-      const actionHandlerPromise = ActionHandlers.getActionHandler(
-        interactionStepAction,
-        organization,
-        user
-      )
-        .then(async handler => {
-          if (!handler) {
-            return questionResponse;
-          }
-          const processActionPromise = handler
-            .processAction(
-              questionResponse,
-              questionResponseInteractionStep,
-              campaignContactId,
-              contact,
-              campaign,
-              organization
-            )
-            .catch(err => {
-              log.error(
-                `Error executing handler for InteractionStep ${interactionStepId} InteractionStepAction ${interactionStepAction} error ${err}`
-              );
-            });
-          promises.push(processActionPromise);
-          return questionResponse;
-        })
-        .catch(err => {
-          log.error(
-            `Error loading handler for InteractionStep ${interactionStepId} InteractionStepAction ${interactionStepAction} error ${err}`
-          );
-        });
-      promises.push(actionHandlerPromise);
-      return questionResponse;
-    });
-
-    if (runningInLambda()) {
-      await Promise.all(promises);
-    }
-  }
+  await dispatchActionHandlers({ user, questionResponses, campaign, contact });
   return contact.id;
 };
-
-export default updateQuestionResponses;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -7,20 +7,13 @@ import { gzip, makeTree, getHighestRole } from "../../lib";
 import { capitalizeWord } from "./lib/utils";
 import twilio from "./lib/twilio";
 
-import {
-  assignTexters,
-  dispatchContactIngestLoad,
-  exportCampaign,
-  importScript,
-  loadCampaignCache
-} from "../../workers/jobs";
+import { loadCampaignCache } from "../../workers/jobs";
 import { getIngestMethod } from "../../integrations/contact-loaders";
 import {
   Campaign,
   CannedResponse,
   InteractionStep,
   Invite,
-  JobRequest,
   Message,
   Organization,
   Tag,
@@ -73,12 +66,9 @@ import {
 } from "./mutations";
 
 const ActionHandlers = require("../../integrations/action-handlers");
+import { jobRunner } from "../../integrations/job-runners";
 
 const uuidv4 = require("uuid").v4;
-const JOBS_SAME_PROCESS = !!(
-  process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
-);
-const JOBS_SYNC = !!(process.env.JOBS_SYNC || global.JOBS_SYNC);
 
 // This function determines whether a field was requested
 // in a graphql query. Each graphql resolver receives a fourth parameter,
@@ -252,11 +242,10 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
       user
     );
     if (ingestMethod) {
-      let job = await JobRequest.save({
+      await jobRunner.dispatch({
         queue_name: `${id}:edit_campaign`,
         job_type: `ingest.${campaign.ingestMethod}`,
         locks_queue: true,
-        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
         campaign_id: id,
         payload: campaign.contactData
       });
@@ -268,12 +257,6 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
           ingest_method: campaign.ingestMethod,
           ingest_success: null
         });
-
-      if (JOBS_SAME_PROCESS) {
-        dispatchContactIngestLoad(job, organization, {
-          /*FUTURE: context obj*/
-        });
-      }
     } else {
       console.error("ingestMethod unavailable", campaign.ingestMethod);
     }
@@ -281,10 +264,9 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
 
   if (campaign.hasOwnProperty("texters")) {
     changed = true;
-    let job = await JobRequest.save({
+    await jobRunner.dispatch({
       queue_name: `${id}:edit_campaign`,
       locks_queue: true,
-      assigned: JOBS_SAME_PROCESS, // can get called immediately, below
       job_type: "assign_texters",
       campaign_id: id,
       payload: JSON.stringify({
@@ -292,14 +274,6 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
         texters: campaign.texters
       })
     });
-
-    if (JOBS_SAME_PROCESS) {
-      if (JOBS_SYNC) {
-        await assignTexters(job);
-      } else {
-        assignTexters(job);
-      }
-    }
   }
 
   if (campaign.hasOwnProperty("interactionSteps")) {
@@ -494,21 +468,16 @@ const rootMutations = {
       const campaign = await loaders.campaign.load(id);
       const organizationId = campaign.organization_id;
       await accessRequired(user, organizationId, "ADMIN");
-      const newJob = await JobRequest.save({
+      return await jobRunner.dispatch({
         queue_name: `${id}:export`,
         job_type: "export",
         locks_queue: false,
-        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
         campaign_id: id,
         payload: JSON.stringify({
           id,
           requester: user.id
         })
       });
-      if (JOBS_SAME_PROCESS) {
-        exportCampaign(newJob);
-      }
-      return newJob;
     },
     editOrganizationRoles: async (
       _,
@@ -1249,23 +1218,16 @@ const rootMutations = {
           url
         })
       );
-      const job = await JobRequest.save({
+      const job = await jobRunner.dispatch({
         queue_name: `${campaignId}:import_script`,
         job_type: "import_script",
         locks_queue: true,
-        assigned: JOBS_SAME_PROCESS, // can get called immediately, below
         campaign_id: campaignId,
         // NOTE: stringifying because compressedString is a binary buffer
         payload: compressedString.toString("base64")
       });
 
-      const jobId = job.id;
-
-      if (JOBS_SAME_PROCESS) {
-        importScript(job);
-      }
-
-      return jobId;
+      return job.id;
     },
     createTag: async (_, { organizationId, tagData }, { user }) => {
       await accessRequired(user, organizationId, "SUPERVOLUNTEER");

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -7,6 +7,7 @@ import { gzip, makeTree, getHighestRole } from "../../lib";
 import { capitalizeWord } from "./lib/utils";
 import twilio from "./lib/twilio";
 
+// TODO: make this a task
 import { loadCampaignCache } from "../../workers/jobs";
 import { getIngestMethod } from "../../integrations/contact-loaders";
 import {

--- a/src/workers/job-handler.js
+++ b/src/workers/job-handler.js
@@ -1,3 +1,0 @@
-import { processJobs } from "./job-processes";
-
-processJobs();

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -11,7 +11,8 @@ import {
   fixOrgless,
   clearOldJobs,
   importScript,
-  buyPhoneNumbers
+  buyPhoneNumbers,
+  startCampaignAsync
 } from "./jobs";
 import { setupUserNotificationObservers } from "../server/notifications";
 
@@ -32,7 +33,18 @@ const jobMap = {
   export: exportCampaign,
   assign_texters: assignTexters,
   import_script: importScript,
-  buy_phone_numbers: buyPhoneNumbers
+  buy_phone_numbers: buyPhoneNumbers,
+  start_campaign: startCampaignAsync
+};
+
+export const invokeJobFunction = async job => {
+  if (job.job_type in jobMap) {
+    await jobMap[job.job_type](job);
+  } else if (job.job_type.startsWith("ingest.")) {
+    await dispatchContactIngestLoad(job);
+  } else {
+    throw new Error(`Job of type ${job.job_type} not found`);
+  }
 };
 
 export async function processJobs() {

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -1,3 +1,7 @@
+// Jobs are potentially long-running background processing operations
+// that are tracked in the database via the JobRequest table.
+// See src/integrations/job-runners/README.md for more details
+
 import { r } from "../server/models";
 import { sleep, getNextJob } from "./lib";
 import { log } from "../lib";
@@ -11,31 +15,36 @@ import {
   fixOrgless,
   clearOldJobs,
   importScript,
-  buyPhoneNumbers,
-  startCampaignAsync
+  buyPhoneNumbers
 } from "./jobs";
 import { setupUserNotificationObservers } from "../server/notifications";
 
 export { seedZipCodes } from "../server/seeds/seed-zip-codes";
 
-/* Two process models are supported in this file.
+/* For the 'legacy' job runner when JOBS_SAME_PROCESS is false:
    The main in both cases is to process jobs and send/receive messages
    on separate loop(s) from the web server.
    * job processing (e.g. contact loading) shouldn't delay text message processing
 
    The two process models:
    * Run the 'scripts' in dev-tools/Procfile.dev
- */
+*/
 
 const JOBS_SAME_PROCESS = !!process.env.JOBS_SAME_PROCESS;
 
-const jobMap = {
-  export: exportCampaign,
-  assign_texters: assignTexters,
-  import_script: importScript,
-  buy_phone_numbers: buyPhoneNumbers,
-  start_campaign: startCampaignAsync
-};
+export const Jobs = Object.freeze({
+  EXPORT: "export",
+  ASSIGN_TEXTERS: "assign_texters",
+  IMPORT_SCRIPT: "import_script",
+  BUY_PHONE_NUMBERS: "buy_phone_numbers"
+});
+
+const jobMap = Object.freeze({
+  [Jobs.EXPORT]: exportCampaign,
+  [Jobs.ASSIGN_TEXTERS]: assignTexters,
+  [Jobs.IMPORT_SCRIPT]: importScript,
+  [Jobs.BUY_PHONE_NUMBERS]: buyPhoneNumbers
+});
 
 export const invokeJobFunction = async job => {
   if (job.job_type in jobMap) {

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -57,8 +57,6 @@ const tagUpdateActionHandler = async ({
   await handler.onTagUpdate(tags, contact, campaign, organization, texter);
 };
 
-// const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};
-
 const taskMap = Object.freeze({
   [Tasks.SEND_MESSAGE]: sendMessage,
   [Tasks.ACTION_HANDLER_QUESTION_RESPONSE]: questionResponseActionHandler,

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -50,11 +50,11 @@ const tagUpdateActionHandler = async ({
   tags,
   contact,
   campaign,
-  organization
+  organization,
+  texter
 }) => {
-  const handlers = await ActionHandlers.rawActionHandler(name);
-  await handler.onTagUpdate(tags, user, contact, campaign, organization);
-  await Promise.all(handlers.map(async handler => {}));
+  const handler = await ActionHandlers.rawActionHandler(name);
+  await handler.onTagUpdate(tags, contact, campaign, organization, texter);
 };
 
 // const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -1,0 +1,46 @@
+import serviceMap from "../server/api/lib/services";
+
+// Tasks are lightweight, fire-and-forget functions run in the background.
+// Unlike Jobs, tasks are not tracked in the database.
+// See src/integrations/job-runners/README.md for more details
+
+export const Tasks = Object.freeze({
+  SEND_MESSAGE: "SEND_MESSAGE",
+  ACTION_HANDLER: "ACTION_HANDLER",
+  MESSAGE_HANDLER_POST_SAVE: "MESSAGE_HANDLER_POST_SAVE"
+  // TODO:
+  // NOTIFICATION: "NOTIFICATION"
+});
+
+const sendMessage = async ({
+  message,
+  contact,
+  trx,
+  organization,
+  campaign
+}) => {
+  const service = serviceMap[message.service];
+  if (!service) {
+    throw new Error(`Failed to find service for message ${message}`);
+  }
+
+  await service.sendMessage(message, contact, trx, organization, campaign);
+};
+
+const invokeActionHandler = async ({ name, actionHandlerData }) => {};
+
+const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};
+
+const taskMap = Object.freeze({
+  [Tasks.SEND_MESSAGE]: sendMessage,
+  [Tasks.ACTION_HANDLER]: invokeActionHandler,
+  [Tasks.MESSAGE_HANDLER_POST_SAVE]: invokeMessageHandlerPostSave
+});
+
+export const invokeTaskFunction = async (taskName, payload) => {
+  if (taskName in taskMap) {
+    await taskMap[taskName](payload);
+  } else {
+    throw new Error(`Task of type ${taskName} not found`);
+  }
+};

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -7,10 +7,7 @@ import * as ActionHandlers from "../integrations/action-handlers";
 export const Tasks = Object.freeze({
   SEND_MESSAGE: "send_message",
   ACTION_HANDLER_QUESTION_RESPONSE: "action_handler:question_response",
-  ACTION_HANDLER_TAG_UPDATE: "action_handler:tag_update",
-  MESSAGE_HANDLER_POST_SAVE: "message_handler:post_save"
-  // TODO:
-  // NOTIFICATION: "NOTIFICATION"
+  ACTION_HANDLER_TAG_UPDATE: "action_handler:tag_update"
 });
 
 const sendMessage = async ({
@@ -29,19 +26,14 @@ const sendMessage = async ({
 };
 
 const questionResponseActionHandler = async ({
-  interactionStepAction,
+  name,
   organization,
-  user,
   questionResponse,
   questionResponseInteractionStep,
   campaign,
   contact
 }) => {
-  const handler = await ActionHandlers.getActionHandler(
-    interactionStepAction,
-    organization,
-    user
-  );
+  const handler = await ActionHandlers.rawActionHandler(name);
   // TODO: clean up processAction interface
   await handler.processAction(
     questionResponse,
@@ -54,21 +46,15 @@ const questionResponseActionHandler = async ({
 };
 
 const tagUpdateActionHandler = async ({
+  name,
   tags,
-  user,
   contact,
   campaign,
   organization
 }) => {
-  const handlers = await ActionHandlers.getActionHandlersAvailableForTagUpdate(
-    organization,
-    user
-  );
-  await Promise.all(
-    handlers.map(async handler => {
-      await handler.onTagUpdate(tags, user, contact, campaign, organization);
-    })
-  );
+  const handlers = await ActionHandlers.rawActionHandler(name);
+  await handler.onTagUpdate(tags, user, contact, campaign, organization);
+  await Promise.all(handlers.map(async handler => {}));
 };
 
 // const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};
@@ -77,7 +63,6 @@ const taskMap = Object.freeze({
   [Tasks.SEND_MESSAGE]: sendMessage,
   [Tasks.ACTION_HANDLER_QUESTION_RESPONSE]: questionResponseActionHandler,
   [Tasks.ACTION_HANDLER_TAG_UPDATE]: tagUpdateActionHandler
-  // [Tasks.MESSAGE_HANDLER_POST_SAVE]: invokeMessageHandlerPostSave
 });
 
 export const invokeTaskFunction = async (taskName, payload) => {

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -1,13 +1,14 @@
-import serviceMap from "../server/api/lib/services";
-
 // Tasks are lightweight, fire-and-forget functions run in the background.
 // Unlike Jobs, tasks are not tracked in the database.
 // See src/integrations/job-runners/README.md for more details
+import serviceMap from "../server/api/lib/services";
+import * as ActionHandlers from "../integrations/action-handlers";
 
 export const Tasks = Object.freeze({
-  SEND_MESSAGE: "SEND_MESSAGE",
-  ACTION_HANDLER: "ACTION_HANDLER",
-  MESSAGE_HANDLER_POST_SAVE: "MESSAGE_HANDLER_POST_SAVE"
+  SEND_MESSAGE: "send_message",
+  ACTION_HANDLER_QUESTION_RESPONSE: "action_handler:question_response",
+  ACTION_HANDLER_TAG_UPDATE: "action_handler:tag_update",
+  MESSAGE_HANDLER_POST_SAVE: "message_handler:post_save"
   // TODO:
   // NOTIFICATION: "NOTIFICATION"
 });
@@ -27,14 +28,56 @@ const sendMessage = async ({
   await service.sendMessage(message, contact, trx, organization, campaign);
 };
 
-const invokeActionHandler = async ({ name, actionHandlerData }) => {};
+const questionResponseActionHandler = async ({
+  interactionStepAction,
+  organization,
+  user,
+  questionResponse,
+  questionResponseInteractionStep,
+  campaign,
+  contact
+}) => {
+  const handler = await ActionHandlers.getActionHandler(
+    interactionStepAction,
+    organization,
+    user
+  );
+  // TODO: clean up processAction interface
+  await handler.processAction(
+    questionResponse,
+    questionResponseInteractionStep,
+    contact.id,
+    contact,
+    campaign,
+    organization
+  );
+};
 
-const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};
+const tagUpdateActionHandler = async ({
+  tags,
+  user,
+  contact,
+  campaign,
+  organization
+}) => {
+  const handlers = await ActionHandlers.getActionHandlersAvailableForTagUpdate(
+    organization,
+    user
+  );
+  await Promise.all(
+    handlers.map(async handler => {
+      await handler.onTagUpdate(tags, user, contact, campaign, organization);
+    })
+  );
+};
+
+// const invokeMessageHandlerPostSave = async ({ name, postSaveData }) => {};
 
 const taskMap = Object.freeze({
   [Tasks.SEND_MESSAGE]: sendMessage,
-  [Tasks.ACTION_HANDLER]: invokeActionHandler,
-  [Tasks.MESSAGE_HANDLER_POST_SAVE]: invokeMessageHandlerPostSave
+  [Tasks.ACTION_HANDLER_QUESTION_RESPONSE]: questionResponseActionHandler,
+  [Tasks.ACTION_HANDLER_TAG_UPDATE]: tagUpdateActionHandler
+  // [Tasks.MESSAGE_HANDLER_POST_SAVE]: invokeMessageHandlerPostSave
 });
 
 export const invokeTaskFunction = async (taskName, payload) => {


### PR DESCRIPTION
Motivation: the optimal strategy for executing background work is specific to how Spoke is deployed and how much it needs to scale. By making job running an integration point, it will be easier for organizations to customize their Spoke deployment while keeping up to date with MoveOn/main.

`job-runners` expose a simple api for executing "Jobs", i.e. heavy-weight jobs tracked in the DB, and "Tasks", light-weight fire-and-forget functions. I tried to add tasks for all the places where we intentionally don't await promises, since that does not work well on Lambda.

In addition to migrating the existing job execution strategies in a backwards-compatible way, I added job runners implementations using Lambda async invocation and `bull`, a Redis-backed job queuing library. `lambda-async` has been used in production while `bull` is really more of an example at this point.

Possible follow ups to this PR:
1. Make sending notifications a task
2. Delegate job tracking to the job runner since some backends can do it without the JobRequest table
3. Expose an api for optional features like retries, locking, and rate limiting per job/task type
4. Improve the `bull` job runner and make it the default for non-lambda deployments
5. Add an SQS-backed job runner for Lambda with support for retries and rate limiting
6. Split tag handling out of action handlers into its own integration