### PR TITLE
More message handlers around profanity

### DIFF
--- a/__test__/integrations/message-handlers/profanity-tagger.test.js
+++ b/__test__/integrations/message-handlers/profanity-tagger.test.js
@@ -1,7 +1,6 @@
 import { r, cacheableData } from "../../../src/server/models";
 import serviceMap from "../../../src/server/api/lib/services";
 import {
-  postMessageSave,
   available,
   DEFAULT_PROFANITY_REGEX_BASE64
 } from "../../../src/integrations/message-handlers/profanity-tagger";
@@ -61,7 +60,8 @@ describe("Message Hanlder: profanity-tagger", () => {
         '{"EXPERIMENTAL_TAGS": "1", "PROFANITY_CONTACT_TAG_ID": "1", "PROFANITY_TEXTER_TAG_ID": "2", "PROFANITY_TEXTER_SUSPEND_COUNT": "1"}'
       );
     await cacheableData.organization.clear(c.organizationId);
-    const org = await cacheableData.organization.load(c.organizationId);
+
+    // SEND
     await sendMessage(c.testContacts[1].id, c.testTexterUser, {
       userId: c.testTexterUser.id,
       contactNumber: c.testContacts[1].cell,

--- a/src/integrations/message-handlers/auto-optout/index.js
+++ b/src/integrations/message-handlers/auto-optout/index.js
@@ -1,5 +1,5 @@
 import { getConfig } from "../../../server/api/lib/config";
-import { r, cacheableData } from "../../../server/models";
+import { cacheableData, Message } from "../../../server/models";
 import serviceMap from "../../../server/api/lib/services";
 
 export const serverAdministratorInstructions = () => {

--- a/src/integrations/message-handlers/auto-optout/index.js
+++ b/src/integrations/message-handlers/auto-optout/index.js
@@ -1,0 +1,98 @@
+import { getConfig } from "../../../server/api/lib/config";
+import { r, cacheableData } from "../../../server/models";
+import serviceMap from "../../../server/api/lib/services";
+
+export const serverAdministratorInstructions = () => {
+  return {
+    description: `
+      Based on certain message replies you can auto-optout people.
+    `,
+    setupInstructions: `Set environment/organization variables
+       AUTO_OPTOUT_REGEX_LIST_BASE64
+       This should be encoded to BASE64 after creating a JSON list object in the form:
+       [{"regex": "....", "reason": "hostile", "autoreply": true}]
+       Be VERY careful about the regex -- if it is accidentally general,
+       you might end up opting way more people out than you intended.
+       Consider testing your AUTO_OPTOUT_REGEX_BASE64 with the PROFANITY TAGGER first
+       and confirming that the list is what you expect.
+    `,
+    environmentVariables: ["AUTO_OPTOUT_REGEX_LIST_BASE64", "OPT_OUT_MESSAGE"]
+  };
+};
+
+// note this is NOT async
+export const available = organization => {
+  return getConfig("AUTO_OPTOUT_REGEX_BASE64", organization);
+};
+
+// export const preMessageSave = async () => {};
+
+export const postMessageSave = async ({ message, campaign, organization }) => {
+  if (message.is_from_contact) {
+    const config = Buffer.from(
+      getConfig("AUTO_OPTOUT_REGEX_LIST_BASE64", organization),
+      "base64"
+    ).toString();
+
+    const regexList = JSON.parse(config || []);
+    const matches = regexList.filter(matcher => {
+      const re = new RegExp(matcher.regex, "i");
+      return String(message.text).match(re);
+    });
+
+    if (matches.length) {
+      const reason = matches[0].reason || "auto_optout";
+      const shouldAutoReply = matches[0].autoreply;
+      // OPTOUT
+      const contact = await cacheableData.campaignContact.load(
+        message.campaign_contact_id
+      );
+      await cacheableData.optOut.save({
+        cell: message.contact_number,
+        campaignContactId: message.campaign_contact_id,
+        assignmentId: contact.assignment_id,
+        reason,
+        campaign
+      });
+
+      if (shouldAutoReply && message.service) {
+        const service = serviceMap[message.service];
+        const autoReplyMessage =
+          typeof shouldAutoReply === "string"
+            ? shouldAutoReply
+            : getConfig("opt_out_message", organization) ||
+              getConfig("OPT_OUT_MESSAGE", organization) ||
+              "I'm opting you out of texts immediately. Have a great day.";
+        const messageInstance = new Message({
+          text: autoReplyMessage,
+          contact_number: message.contact_number,
+          user_number: "",
+          user_id: null,
+          campaign_contact_id: message.campaign_contact_id,
+          messageservice_sid: null,
+          send_status: "SENDING",
+          service: message.service,
+          is_from_contact: false,
+          queued_at: new Date(),
+          send_before: new Date()
+        });
+        const saveResult = await cacheableData.message.save({
+          messageInstance,
+          contact,
+          campaign,
+          organization
+        });
+        if (saveResult.message) {
+          // FUTURE use dispatchTask when
+          await service.sendMessage(
+            saveResult.message,
+            contact,
+            null,
+            organization,
+            campaign
+          );
+        }
+      }
+    }
+  }
+};

--- a/src/integrations/message-handlers/index.js
+++ b/src/integrations/message-handlers/index.js
@@ -12,7 +12,7 @@ export function getMessageHandlers(organization) {
       const c = require(`./${name}/index.js`);
       handlers[name] = c;
     } catch (err) {
-      log.error(
+      console.error(
         `${handlerKey} failed to load message handler ${name} -- ${err}`
       );
     }

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -19,6 +19,7 @@ import _ from "lodash";
 // -1 - -MAX_SEND_ATTEMPTS (5): failed send messages
 // -100-....: custom local errors
 // -101: incoming message with a MediaUrl
+// -166: blocked send for profanity message_handler match
 
 const MAX_SEND_ATTEMPTS = 5;
 const MESSAGE_VALIDITY_PADDING_SECONDS = 30;

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -143,13 +143,15 @@ export const sendMessage = async (
   //   `Sending (${serviceName}): ${messageInstance.user_number} -> ${messageInstance.contact_number}\nMessage: ${messageInstance.text}`
   // );
   //NO AWAIT: pro=return before api completes, con=context needs to stay alive
-  service.sendMessage(
-    saveResult.message,
-    contact,
-    null,
-    organization,
-    campaign
-  );
+  if (!saveResult.blockSend) {
+    service.sendMessage(
+      saveResult.message,
+      contact,
+      null,
+      organization,
+      campaign
+    );
+  }
 
   if (initialMessageStatus === "needsMessage") {
     // don't both requerying the messages list on the response

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -280,6 +280,7 @@ const messageCache = {
         )
         .map(h => handlers[h]);
       for (let i = 0, l = availableHandlers.length; i < l; i++) {
+        // NOTE: these handlers can alter messageToSave properties
         const result = await availableHandlers[i].preMessageSave({
           messageToSave,
           activeCellFound,
@@ -330,6 +331,11 @@ const messageCache = {
       await campaignCache.incrCount(campaignId, "needsResponseCount", 1);
     }
 
+    const retVal = {
+      message: messageToSave,
+      contactStatus: newStatus
+    };
+
     if (Object.keys(handlers).length && organization) {
       const availableHandlers = Object.keys(handlers)
         .filter(
@@ -348,16 +354,18 @@ const messageCache = {
           campaign,
           organization
         });
-        if (result && "newStatus" in result) {
-          newStatus = result.newStatus;
+        if (result) {
+          if ("newStatus" in result) {
+            retVal.contactStatus = result.newStatus;
+          }
+          if ("blockSend" in result) {
+            retVal.blockSend = result.blockSend;
+          }
         }
       }
     }
 
-    return {
-      message: messageToSave,
-      contactStatus: newStatus
-    };
+    return retVal;
   }
 };
 


### PR DESCRIPTION
## Description

This adds a new message handler `auto-optout` which will auto-optout messages that come in with certain text. It also adds an option to the profanity-tagger message handler to block messages that match texter profanity, so contacts do not receive it.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
