### PR TITLE
Roll back react-formal upgrade because it breaks 'select' fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "react-async-script": "^0.6.0",
     "react-chartjs": "^0.7.3",
     "react-dom": "^15.6.1",
-    "react-formal": "^0.25.4",
+    "react-formal": "^0.20.0",
     "react-router": "^3.2.0",
     "react-tap-event-plugin": "^2.0.0",
     "recompose": "^0.30.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4049,7 +4049,7 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-classnames@^2.2.3, classnames@^2.2.5:
+classnames@^2.1.5, classnames@^2.2.3, classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
   integrity sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==
@@ -7560,6 +7560,11 @@ hsla-regex@^1.0.0:
   resolved "https://registry.yarnpkg.com/hsla-regex/-/hsla-regex-1.0.0.tgz#c1ce7a3168c8c6614033a4b5f7877f3b225f9c38"
   integrity sha1-wc56MWjIxmFAM6S194d/OyJfnDg=
 
+html-attributes@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/html-attributes/-/html-attributes-1.1.0.tgz#82027a4fac7a6070ea6c18cc3886aea18d6dea09"
+  integrity sha1-ggJ6T6x6YHDqbBjMOIauoY1t6gk=
+
 html-comment-regex@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/html-comment-regex/-/html-comment-regex-1.1.2.tgz#97d4688aeb5c81886a364faa0cad1dda14d433a7"
@@ -8071,7 +8076,7 @@ interpret@^2.0.0:
   resolved "https://registry.yarnpkg.com/interpret/-/interpret-2.2.0.tgz#1a78a0b5965c40a5416d007ad6f50ad27c417df9"
   integrity sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==
 
-invariant@^2.1.0, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
+invariant@^2.1.0, invariant@^2.1.2, invariant@^2.2.1, invariant@^2.2.2, invariant@^2.2.4:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/invariant/-/invariant-2.2.4.tgz#610f3c92c9359ce1db616e538008d23ff35158e6"
   integrity sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==
@@ -9855,10 +9860,15 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.16.3, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.11:
+lodash@4.17.15, "lodash@>=3.5 <5", lodash@^4.0.0, lodash@^4.0.1, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.3.0, lodash@~4.17.11:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
+
+lodash@^3.10.1:
+  version "3.10.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
+  integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
 log-symbols@3.0.0, log-symbols@^3.0.0:
   version "3.0.0"
@@ -11653,6 +11663,13 @@ pgpass@1.*:
   dependencies:
     split "^1.0.0"
 
+pick-attributes@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pick-attributes/-/pick-attributes-1.0.2.tgz#cbff108eccdee4c693319dd4fb087a7db4eba58e"
+  integrity sha1-y/8Qjsze5MaTMZ3U+wh6fbTrpY4=
+  dependencies:
+    html-attributes "^1.1.0"
+
 picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
@@ -12552,7 +12569,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.0, prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.5.9, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.5.10, prop-types@^15.5.4, prop-types@^15.5.6, prop-types@^15.5.7, prop-types@^15.5.8, prop-types@^15.6.0, prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -12952,23 +12969,24 @@ react-event-listener@^0.6.2:
     prop-types "^15.6.0"
     warning "^4.0.1"
 
-react-formal@^0.25.4:
-  version "0.25.4"
-  resolved "https://registry.yarnpkg.com/react-formal/-/react-formal-0.25.4.tgz#e829822128d1ef51e3f261ffc56f1e4dacec4563"
-  integrity sha1-6CmCISjR71Hj8mH/xW8eTazsRWM=
+react-formal@^0.20.0:
+  version "0.20.6"
+  resolved "https://registry.yarnpkg.com/react-formal/-/react-formal-0.20.6.tgz#086b636c28bf761403c04ccd659db3bde139eb57"
+  integrity sha1-CGtjbCi/dhQDwEzNZZ2zveE561c=
   dependencies:
     chain-function "^1.0.0"
     classnames "^2.2.5"
     invariant "^2.2.1"
-    lodash "^4.16.3"
-    prop-types "^15.5.0"
+    lodash "^3.10.1"
+    pick-attributes "^1.0.2"
     property-expr "^1.3.1"
-    react-input-message "^0.15.1"
+    react-input-message "^0.14.1"
     react-prop-types "^0.3.2"
     react-pure-render "^1.0.2"
     spy-on-component "^1.0.2"
-    topeka "^1.0.0"
+    topeka "^0.4.1"
     uncontrollable "^4.0.3"
+    universal-promise "^1.1.0"
     warning "^2.0.0"
     yup "^0.21.1"
 
@@ -12985,14 +13003,14 @@ react-hot-loader@^1.3.0:
     react-hot-api "^0.4.5"
     source-map "^0.4.4"
 
-react-input-message@^0.15.1:
-  version "0.15.1"
-  resolved "https://registry.yarnpkg.com/react-input-message/-/react-input-message-0.15.1.tgz#3ba8d15f4c1e71e15d86b5755f6177120cbba9a0"
-  integrity sha1-O6jRX0weceFdhrV1X2F3Egy7qaA=
+react-input-message@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/react-input-message/-/react-input-message-0.14.2.tgz#134f8d99d84261234d78929ad855f71eed39687b"
+  integrity sha1-E0+NmdhCYSNNeJKa2FX3Hu05aHs=
   dependencies:
     classnames "^2.2.3"
-    prop-types "^15.5.9"
-    topeka "^1.0.0"
+    topeka "^0.4.0"
+    universal-promise "^1.1.0"
 
 react-is@^16.10.2, react-is@^16.13.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
   version "16.13.1"
@@ -15122,15 +15140,16 @@ toidentifier@1.0.0:
   resolved "https://registry.yarnpkg.com/toidentifier/-/toidentifier-1.0.0.tgz#7e1be3470f1e77948bc43d94a3c8f4d7752ba553"
   integrity sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==
 
-topeka@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/topeka/-/topeka-1.0.1.tgz#96415b9126e43ecbdc4ea4666a5b485683634372"
-  integrity sha512-6SNDI4998y7MpEr4SxakKXvXPDxB0u+B29P61T69B8YVU15Hb2Pj8onB7C63SM2zwwmSsebhCTxeREG1b5bFJw==
+topeka@^0.4.0, topeka@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/topeka/-/topeka-0.4.1.tgz#faa979de592710fc270a02139173125f4f9dced6"
+  integrity sha1-+ql53lknEPwnCgITkXMSX0+dztY=
   dependencies:
-    classnames "^2.2.5"
-    invariant "^2.2.2"
+    chain-function "^1.0.0"
+    classnames "^2.1.5"
+    invariant "^2.1.2"
     property-expr "^1.3.1"
-    uncontrollable "^4.1.0"
+    uncontrollable "^3.1.3"
 
 topo@2.x.x:
   version "2.0.2"
@@ -15353,7 +15372,14 @@ unc-path-regex@^0.1.2:
   resolved "https://registry.yarnpkg.com/unc-path-regex/-/unc-path-regex-0.1.2.tgz#e73dd3d7b0d7c5ed86fbac6b0ae7d8c6a69d50fa"
   integrity sha1-5z3T17DXxe2G+6xrCufYxqadUPo=
 
-uncontrollable@^4.0.3, uncontrollable@^4.1.0:
+uncontrollable@^3.1.3:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-3.3.1.tgz#e23b402e7a4c69b1853fb4b43ce34b6480c65b6f"
+  integrity sha1-4jtALnpMabGFP7S0PONLZIDGW28=
+  dependencies:
+    invariant "^2.1.0"
+
+uncontrollable@^4.0.3:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/uncontrollable/-/uncontrollable-4.1.0.tgz#e0358291252e1865222d90939b19f2f49f81c1a9"
   integrity sha1-4DWCkSUuGGUiLZCTmxny9J+Bwak=
@@ -15436,7 +15462,7 @@ unique-string@^2.0.0:
   dependencies:
     crypto-random-string "^2.0.0"
 
-universal-promise@^1.0.1:
+universal-promise@^1.0.1, universal-promise@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/universal-promise/-/universal-promise-1.1.0.tgz#563f9123372940839598c9d48be5ec33fa69cff1"
   integrity sha1-Vj+RIzcpQIOVmMnUi+XsM/ppz/E=


### PR DESCRIPTION
This broke 'select' fields like the action handler drop down. Let's just roll it back for now and upgrade to the current release separately. 