### PR TITLE
Add sorting by timezone to campaign list

### DIFF
--- a/__test__/containers/CampaignList.test.js
+++ b/__test__/containers/CampaignList.test.js
@@ -5,6 +5,7 @@ import React from "react";
 import { mount } from "enzyme";
 import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
 import { AdminCampaignList } from "../../src/containers/AdminCampaignList";
+import { TIMEZONE_SORT } from "../../src/components/AdminCampaignList/SortBy";
 import { StyleSheetTestUtils } from "aphrodite";
 
 describe("CampaignList", () => {
@@ -111,6 +112,64 @@ describe("CampaignList", () => {
           <span> &mdash; Created by Lorem Ipsum</span>
         )
       ).toBeTruthy();
+    });
+  });
+
+  describe("Campaign list sorting", () => {
+    const campaignWithCreator = {
+      id: 1,
+      creator: {
+        displayName: "Lorem Ipsum"
+      },
+      completionStats: {}
+    };
+
+    const data = {
+      organization: {
+        id: 1,
+        cacheable: 2,
+        campaigns: {
+          campaigns: [campaignWithCreator],
+          pageInfo: {
+            limit: 1000,
+            offset: 0,
+            total: 1
+          }
+        }
+      }
+    };
+
+    test("Timezone column is displayed when timezone is current sort", () => {
+      const wrapper = mount(
+        <MuiThemeProvider>
+          <AdminCampaignList
+            data={data}
+            mutations={mutations}
+            params={params}
+          />
+        </MuiThemeProvider>
+      );
+      wrapper.childAt(0).setState({
+        sortBy: TIMEZONE_SORT.value
+      });
+      expect(
+        wrapper.containsMatchingElement(<span>Timezone</span>)
+      ).toBeTruthy();
+    });
+
+    test("Timezone column is hidden when it isn't the current sort", () => {
+      const wrapper = mount(
+        <MuiThemeProvider>
+          <AdminCampaignList
+            data={data}
+            mutations={mutations}
+            params={params}
+          />
+        </MuiThemeProvider>
+      );
+      expect(
+        wrapper.containsMatchingElement(<span>Timezone</span>)
+      ).toBeFalsy();
     });
   });
 });

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -191,6 +191,7 @@ const rootSchema = gql`
     ID_ASC
     ID_DESC
     TITLE
+    TIMEZONE
   }
 
   type RootQuery {

--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -11,6 +11,7 @@ import theme from "../../styles/theme";
 import Empty from "../Empty";
 import DataTables from "material-ui-datatables";
 import { CircularProgress } from "material-ui";
+import { SORTS, TIMEZONE_SORT } from "./SortBy";
 
 const inlineStyles = {
   past: {
@@ -62,7 +63,8 @@ export class CampaignTable extends React.Component {
     onPreviousPageClick: PropTypes.func,
     onRowSizeChange: PropTypes.func,
     campaignsToArchive: PropTypes.array,
-    campaignsWithChangingStatus: PropTypes.array
+    campaignsWithChangingStatus: PropTypes.array,
+    currentSortBy: PropTypes.oneOf(SORTS.map(s => s.value))
   };
 
   state = {
@@ -129,8 +131,21 @@ export class CampaignTable extends React.Component {
       });
     }
 
+    const timezoneColumn = [];
+    // only show the timezone column when we're currently sorting by timezone
+    if (this.props.currentSortBy === TIMEZONE_SORT.value) {
+      timezoneColumn.push({
+        key: "timezone",
+        label: "Timezone",
+        sortable: false,
+        style: {
+          width: "5em"
+        }
+      });
+    }
+
     return [
-      // id, title, user, contactcount, unassigned, unmessaged, due date, archive
+      // id, timezone (if current sort), title, user, contactcount, unassigned, unmessaged, due date, archive
       {
         key: "id",
         label: "id",
@@ -139,6 +154,7 @@ export class CampaignTable extends React.Component {
           width: "5em"
         }
       },
+      ...timezoneColumn,
       {
         key: "title",
         label: "Campaign",
@@ -278,7 +294,6 @@ export class CampaignTable extends React.Component {
     const { campaigns, pageInfo } = this.props.data.organization.campaigns;
     const { limit, offset, total } = pageInfo;
     const displayPage = Math.floor(offset / limit) + 1;
-    console.log("CampaignTable", campaigns);
     return campaigns.length === 0 ? (
       <Empty title="No campaigns" icon={<SpeakerNotesIcon />} />
     ) : (

--- a/src/components/AdminCampaignList/SortBy.jsx
+++ b/src/components/AdminCampaignList/SortBy.jsx
@@ -46,17 +46,23 @@ export const ID_DESC_SORT = {
   value: "ID_DESC"
 };
 
-const TITLE_SORT = {
+export const TITLE_SORT = {
   display: "Title",
   value: "TITLE"
 };
 
-const SORTS = [
+export const TIMEZONE_SORT = {
+  display: "Timezone",
+  value: "TIMEZONE"
+};
+
+export const SORTS = [
   DUE_DATE_DESC_SORT,
   DUE_DATE_ASC_SORT,
   ID_DESC_SORT,
   ID_ASC_SORT,
-  TITLE_SORT
+  TITLE_SORT,
+  TIMEZONE_SORT
 ];
 
 export const DEFAULT_SORT_BY_VALUE = ID_ASC_SORT.value;

--- a/src/containers/AdminCampaignList.jsx
+++ b/src/containers/AdminCampaignList.jsx
@@ -339,6 +339,7 @@ export class AdminCampaignList extends React.Component {
             data={this.props.data}
             campaignsToArchive={this.state.campaignsToArchive}
             campaignsWithChangingStatus={this.state.campaignsWithChangingStatus}
+            currentSortBy={this.state.sortBy}
             onNextPageClick={this.handleNextPageClick}
             onPreviousPageClick={this.handlePreviousPageClick}
             onRowSizeChange={this.handleRowSizeChanged}
@@ -365,6 +366,7 @@ const campaignInfoFragment = `
   hasUnassignedContacts
   hasUnsentInitialMessages
   description
+  timezone
   dueBy
   creator {
     displayName

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -99,6 +99,9 @@ const buildOrderByClause = (query, sortBy) => {
     case "TITLE":
       fragmentArray = [title];
       break;
+    case "TIMEZONE":
+      fragmentArray = ['"campaign"."timezone"'];
+      break;
     case "ID_DESC":
       fragmentArray = [desc(id)];
       break;


### PR DESCRIPTION
# Fixes #1007 

## Description

You can now sort by timezone on the campaign list. I discussed this with Sky during the hacknight and we decided sorting by the timezone name was good enough (that's the only timezone info currently available in the client). The timezone column is only displayed when it is the active sort option to try and save some space on small screens.

<details>
  <summary>Screenshots</summary>

View with default sort (same as before)
<img width="1430" alt="image" src="https://user-images.githubusercontent.com/560881/86697075-0a9d1b00-bfdc-11ea-8e1c-4468c847ec6d.png">

Sorting by timezone with column visible
<img width="1433" alt="image" src="https://user-images.githubusercontent.com/560881/86697230-315b5180-bfdc-11ea-86ad-1a32abba3bba.png">

</details>

## Questions I have:
- Did I put these tests in the right place? Do you typically write tests for UI changes of this size? I also haven't used Enzyme before so I'm not sure about good patterns.
- I did try to test the Campaign view with in-browser mobile emulation but it seems like it isn't mobile-friendly, is that right?

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation **(don't think any are required here)**
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
