### PR TITLE
add onFocus to open canned response dialog and add empty string to state

### DIFF
--- a/src/components/forms/GSScriptField.jsx
+++ b/src/components/forms/GSScriptField.jsx
@@ -19,7 +19,7 @@ export default class GSScriptField extends GSFormField {
     super(props);
     this.state = {
       open: false,
-      script: props.value
+      script: props.value || ""
     };
   }
 
@@ -51,7 +51,6 @@ export default class GSScriptField extends GSFormField {
     const { open } = this.state;
     const { customFields, sampleContact } = this.props;
     const scriptFields = allScriptFields(customFields);
-
     return (
       <Dialog
         style={styles.dialog}
@@ -90,6 +89,9 @@ export default class GSScriptField extends GSFormField {
         <TextField
           multiLine
           onTouchTap={event => {
+            this.handleOpenDialog(event);
+          }}
+          onFocus={event => {
             this.handleOpenDialog(event);
           }}
           floatingLabelText={this.floatingLabelText()}


### PR DESCRIPTION
## Description
add onFocus to open canned response dialog and add empty string to state

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change, and any blockers that make your change a WIP_

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
