### PR TITLE
NGP VAN permissive cellphone selection

### DIFF
--- a/__test__/integrations/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/integrations/contact-loaders/ngpvan/ngpvan.test.js
@@ -239,7 +239,6 @@ describe("ngpvan", () => {
       csvReply = `CanvassFileRequestID,VanID,Address,FirstName,LastName,StreetAddress,City,State,ZipOrPostal,County,Employer,Occupation,Email,HomePhone,IsHomePhoneACellExchange,CellPhone,WorkPhone,IsWorkPhoneACellExchange,Phone,OptInPhone,OptInStatus,OptInPhoneType,CongressionalDistrict,StateHouse,StateSenate,Party,PollingLocation,PollingAddress,PollingCity
 1286,6144436,"1749 Kori Ter, Ranbelsi, SC 02569",Jean,Leclerc,1749 Kori Ter,Ranbelsi,SC,,Suffolk,,,,,,,,,,,,,001,004,002,R,,,
 1286,6144439,"169 Unnag St, Fekokmuw, NM 15043",Sophia,Robinson,169 Unnag St,Fekokmuw,NM,,Suffolk,,,,,,,,,,,,,001,004,002,R,,,
-1286,6348005,"415 Domru Park, Igguhe, AK 41215",Samuel,Jimenez,415 Domru Park,Igguhe,AK,,Suffolk,,,,(216) 274-1428,0,,,,(973) 687-4476,,,,001,004,002,O,,,
 1286,6409040,"50 Vichad Path, Bapherte, DC 07893",Bobby,Barber,50 Vichad Path,Bapherte,DC,,Suffolk,,,,,,,,,,,,,001,004,002,D,,,
 1286,6455083,"627 Wizow Way, Lofaje, DE 89435",Larry,Foster,627 Wizow Way,Lofaje,DE,,Suffolk,,,,,,3214028326,,,(384) 984-5966,,,,001,004,002,D,,,
 1286,6475967,"902 Jotho Park, Ilibaed, MN 91571",Cordelia,Gagliardi,902 Jotho Park,Ilibaed,MN,,Suffolk,,,,(887) 867-3213,0,(242) 554-4053,,,(473) 324-5133,,,,001,004,002,D,,,
@@ -247,12 +246,9 @@ describe("ngpvan", () => {
 1286,6687736,"1660 Tiwa Pike, Owucudji, MD 78594",Phoebe,König,1660 Tiwa Pike,Owucudji,MD,,Suffolk,,,,,,(765) 927-7705,,,(232) 872-2395,,,,001,004,002,D,,,
 1286,6687737,"1820 Kasi Plz, Uhokuicu, NJ 70521",Andrew,Coli,1820 Kasi Plz,Uhokuicu,NJ,,Suffolk,,,,,,(830) 978-5900,,,(256) 289-2236,,,,001,004,002,R,,,
 1286,6740265,"1864 Pohe Path, Lahutci, IA 21134",Francis,Anderson,1864 Pohe Path,Lahutci,IA,,Suffolk,,,,(229) 403-7155,0,,,,(839) 862-7352,,,,001,004,002,R,,,
-1286,6740266,"28 Lian Cir, Ruutunu, NM 59815",Sallie,Naylor,28 Lian Cir,Ruutunu,NM,,Suffolk,,,,(216) 509-8792,0,,,,(972) 896-8504,,,,001,004,002,R,,,
 1286,6848857,"296 Bilez Sq, Efabodgun, NC 26984",Florence,Adkins,296 Bilez Sq,Efabodgun,NC,,Suffolk,,,,,,,,,,,,,001,004,002,D,,,
 1286,6870533,"701 Zetli Plz, Nuwdope, CA 62375",Leona,Orsini,701 Zetli Plz,Nuwdope,CA,,Suffolk,,,,(968) 346-8020,0,,,,(874) 366-8307,,,,001,004,002,R,,,
-1286,8277239,"299 Evto Cir, Nembecivo, MN 03381",Howard,Ashton,299 Evto Cir,Nembecivo,MN,,Suffolk,,,,(472) 767-4456,0,,,,(401) 854-6069,,,,001,004,002,D,,,
 1286,15597061,"1591 Zuote Rdg, Pudugpu, MA 56190",Francis,Reyes,1591 Zuote Rdg,Pudugpu,MA,,Suffolk,,,,,,,,,,,,,001,004,002,R,,,
-1286,17293476,"65 Niboko Pkwy, Tawurel, LA 39583",Jerry,Tucci,65 Niboko Pkwy,Tawurel,LA,,Suffolk,,,,(973) 507-1207,0,,,,(760) 455-8006,,,,001,004,002,D,,,
 1286,19680982,"588 Pinovu Path, Notjuap, WV 59864",Isaac,Stefani,588 Pinovu Path,Notjuap,WV,,Suffolk,,,,,,,,,,,,,001,004,002,D,,,
 1286,20700354,"241 Ozno Sq, Pomizivi, TN 13358",Marion,Cook,241 Ozno Sq,Pomizivi,TN,,Suffolk,,,,,,(831) 401-6718,,,(670) 427-8081,,,,001,004,002,R,,,
 1286,21681436,"902 Hamze Pl, Biuhke, SC 35341",Bill,Fiore,902 Hamze Pl,Biuhke,SC,,Suffolk,,,,,,(802) 897-2566,,,(332) 794-5172,,,,001,004,002,R,,,
@@ -347,7 +343,7 @@ describe("ngpvan", () => {
       const getCsvNock = makeSuccessfulGetCsvNock();
 
       await processContactLoad(job, maxContacts, organization);
-      expect(ngpvan.makeRowTransformer.mock.calls).toEqual([[true]]);
+      expect(ngpvan.makeRowTransformer.mock.calls).toEqual([[false]]);
 
       expect(csvParser.parseCSVAsync).toHaveBeenCalledTimes(1);
 

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -1,7 +1,6 @@
 import { getConfig } from "../../server/api/lib/config";
 import { r } from "../../server/models";
 import { log } from "../../lib";
-import _ from "lodash";
 
 export const availabilityCacheKey = (name, organization, userId) =>
   `${getConfig("CACHE_PREFIX", organization) || ""}action-avail-${name}-${
@@ -12,8 +11,6 @@ export const choiceDataCacheKey = (name, organization, suffix) =>
   `${getConfig("CACHE_PREFIX", organization) ||
     ""}action-choices-${name}-${suffix}`;
 
-// TODO: organization is never actually passed to this method so action handlers
-//   are not actually configurable at the organization level
 export function getActionHandlers(organization) {
   const enabledActionHandlers = (
     getConfig("ACTION_HANDLERS", organization) ||
@@ -35,10 +32,6 @@ export function getActionHandlers(organization) {
 }
 
 const CONFIGURED_ACTION_HANDLERS = getActionHandlers();
-const CONFIGURED_TAG_HANDLERS = _.pickBy(
-  CONFIGURED_ACTION_HANDLERS,
-  handler => !!handler.onTagUpdate
-);
 
 export async function getSetCacheableResult(cacheKey, fallbackFunc) {
   if (r.redis && cacheKey) {
@@ -106,8 +99,8 @@ export async function getActionHandlerAvailability(
   try {
     return (
       await getSetCacheableResult(
-        availabilityCacheKey(name, organization, user.id),
-        () => fallbackFunction(actionHandler, organization, user)
+        availabilityCacheKey(name, organization, user || { id: "" }),
+        () => fallbackFunction(actionHandler, organization, user || {})
       )
     ).result;
   } catch (caughtError) {
@@ -118,17 +111,13 @@ export async function getActionHandlerAvailability(
 }
 
 export function rawActionHandler(name) {
+  // RARE: You should almost always use getActionHandler() below,
+  // unless workflow has already tested availability for the org-user
   return CONFIGURED_ACTION_HANDLERS[name];
 }
 
 export function rawAllActionHandlers() {
   return CONFIGURED_ACTION_HANDLERS;
-}
-
-// TODO: clean up tag update API. Because tag update handlers are _always_ run if configured
-//   it would be better to separate tag handler integrations from question response handlers
-export function rawAllTagUpdateActionHandlerNames() {
-  return Object.keys(CONFIGURED_TAG_HANDLERS);
 }
 
 export async function getActionHandler(name, organization, user) {
@@ -153,6 +142,18 @@ export async function getAvailableActionHandlers(organization, user) {
   return actionHandlers.filter(x => x);
 }
 
+export async function getActionHandlersAvailableForTagUpdate(
+  organization,
+  user
+) {
+  const actionHandlers = await Promise.all(
+    Object.keys(CONFIGURED_ACTION_HANDLERS).map(name =>
+      getActionHandler(name, organization, user)
+    )
+  );
+  return actionHandlers.filter(x => x && !!x.onTagUpdate);
+}
+
 export async function getActionChoiceData(actionHandler, organization, user) {
   const cacheKeyFunc =
     actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);
@@ -164,7 +165,7 @@ export async function getActionChoiceData(actionHandler, organization, user) {
     cacheKey = exports.choiceDataCacheKey(
       actionHandler.name,
       organization,
-      cacheKeyFunc(organization, user)
+      cacheKeyFunc(organization, user || {})
     );
   } catch (caughtException) {
     log.error(
@@ -176,7 +177,7 @@ export async function getActionChoiceData(actionHandler, organization, user) {
   try {
     returned =
       (await exports.getSetCacheableResult(cacheKey, async () =>
-        clientChoiceDataFunc(organization, user)
+        clientChoiceDataFunc(organization, user || {})
       )) || {};
   } catch (caughtException) {
     log.error(

--- a/src/integrations/action-handlers/index.js
+++ b/src/integrations/action-handlers/index.js
@@ -1,6 +1,7 @@
 import { getConfig } from "../../server/api/lib/config";
 import { r } from "../../server/models";
 import { log } from "../../lib";
+import _ from "lodash";
 
 export const availabilityCacheKey = (name, organization, userId) =>
   `${getConfig("CACHE_PREFIX", organization) || ""}action-avail-${name}-${
@@ -11,6 +12,8 @@ export const choiceDataCacheKey = (name, organization, suffix) =>
   `${getConfig("CACHE_PREFIX", organization) ||
     ""}action-choices-${name}-${suffix}`;
 
+// TODO: organization is never actually passed to this method so action handlers
+//   are not actually configurable at the organization level
 export function getActionHandlers(organization) {
   const enabledActionHandlers = (
     getConfig("ACTION_HANDLERS", organization) ||
@@ -32,6 +35,10 @@ export function getActionHandlers(organization) {
 }
 
 const CONFIGURED_ACTION_HANDLERS = getActionHandlers();
+const CONFIGURED_TAG_HANDLERS = _.pickBy(
+  CONFIGURED_ACTION_HANDLERS,
+  handler => !!handler.onTagUpdate
+);
 
 export async function getSetCacheableResult(cacheKey, fallbackFunc) {
   if (r.redis && cacheKey) {
@@ -99,8 +106,8 @@ export async function getActionHandlerAvailability(
   try {
     return (
       await getSetCacheableResult(
-        availabilityCacheKey(name, organization, user || { id: "" }),
-        () => fallbackFunction(actionHandler, organization, user || {})
+        availabilityCacheKey(name, organization, user.id),
+        () => fallbackFunction(actionHandler, organization, user)
       )
     ).result;
   } catch (caughtError) {
@@ -111,13 +118,17 @@ export async function getActionHandlerAvailability(
 }
 
 export function rawActionHandler(name) {
-  // RARE: You should almost always use getActionHandler() below,
-  // unless workflow has already tested availability for the org-user
   return CONFIGURED_ACTION_HANDLERS[name];
 }
 
 export function rawAllActionHandlers() {
   return CONFIGURED_ACTION_HANDLERS;
+}
+
+// TODO: clean up tag update API. Because tag update handlers are _always_ run if configured
+//   it would be better to separate tag handler integrations from question response handlers
+export function rawAllTagUpdateActionHandlerNames() {
+  return Object.keys(CONFIGURED_TAG_HANDLERS);
 }
 
 export async function getActionHandler(name, organization, user) {
@@ -142,18 +153,6 @@ export async function getAvailableActionHandlers(organization, user) {
   return actionHandlers.filter(x => x);
 }
 
-export async function getActionHandlersAvailableForTagUpdate(
-  organization,
-  user
-) {
-  const actionHandlers = await Promise.all(
-    Object.keys(CONFIGURED_ACTION_HANDLERS).map(name =>
-      getActionHandler(name, organization, user)
-    )
-  );
-  return actionHandlers.filter(x => x && !!x.onTagUpdate);
-}
-
 export async function getActionChoiceData(actionHandler, organization, user) {
   const cacheKeyFunc =
     actionHandler.clientChoiceDataCacheKey || (org => `${org.id}`);
@@ -165,7 +164,7 @@ export async function getActionChoiceData(actionHandler, organization, user) {
     cacheKey = exports.choiceDataCacheKey(
       actionHandler.name,
       organization,
-      cacheKeyFunc(organization, user || {})
+      cacheKeyFunc(organization, user)
     );
   } catch (caughtException) {
     log.error(
@@ -177,7 +176,7 @@ export async function getActionChoiceData(actionHandler, organization, user) {
   try {
     returned =
       (await exports.getSetCacheableResult(cacheKey, async () =>
-        clientChoiceDataFunc(organization, user || {})
+        clientChoiceDataFunc(organization, user)
       )) || {};
   } catch (caughtException) {
     log.error(

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -1,6 +1,5 @@
 import { getConfig } from "../../server/api/lib/config";
 import Van from "../contact-loaders/ngpvan/util";
-import { log } from "../../lib";
 
 import httpRequest from "../../server/lib/http-request.js";
 
@@ -38,6 +37,48 @@ export function clientChoiceDataCacheKey(organization) {
   return `${organization.id}`;
 }
 
+export const postCanvassResponse = async (contact, organization, body) => {
+  let vanId;
+  try {
+    vanId = JSON.parse(contact.custom_fields || "{}").VanID;
+  } catch (caughtException) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Error parsing custom_fields for contact ${contact.id} ${caughtException}`
+    );
+    return {};
+  }
+
+  if (!vanId) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `Cannot sync results to van for campaign_contact ${contact.id}. No VanID in custom fields`
+    );
+    return {};
+  }
+
+  const url = Van.makeUrl(`v4/people/${vanId}/canvassResponses`, organization);
+
+  // eslint-disable-next-line no-console
+  console.info("Sending contact update to VAN", {
+    vanId,
+    body
+  });
+
+  return httpRequest(url, {
+    method: "POST",
+    retries: 0,
+    timeout: 32000,
+    headers: {
+      Authorization: Van.getAuth(organization),
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(body),
+    validStatuses: [204],
+    compress: false
+  });
+};
+
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
 export async function processAction(
@@ -55,30 +96,10 @@ export async function processAction(
 
     const body = JSON.parse(answerActionsData.value);
 
-    const url = Van.makeUrl(
-      `v4/people/${contact.external_id}/canvassResponses`,
-      organization
-    );
-
-    log.info("Sending contact update to VAN", {
-      vanId: contact.external_id,
-      body
-    });
-
-    return httpRequest(url, {
-      method: "POST",
-      retries: 0,
-      timeout: 32000,
-      headers: {
-        Authorization: Van.getAuth(organization),
-        "Content-Type": "application/json"
-      },
-      body: JSON.stringify(body),
-      validStatuses: [204],
-      compress: false
-    });
+    return postCanvassResponse(contact, organization, body);
   } catch (caughtError) {
-    log.error("Encountered exception in ngpvan.processAction", caughtError);
+    // eslint-disable-next-line no-console
+    console.error("Encountered exception in ngpvan.processAction", caughtError);
     throw caughtError;
   }
 }
@@ -97,7 +118,8 @@ async function getContactTypeIdAndInputTypeId(organization) {
     .then(async response => await response.json())
     .catch(error => {
       const message = `Error retrieving contact types from VAN ${error}`;
-      log.error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
       throw new Error(message);
     });
 
@@ -114,7 +136,8 @@ async function getContactTypeIdAndInputTypeId(organization) {
     .then(async response => await response.json())
     .catch(error => {
       const message = `Error retrieving input types from VAN ${error}`;
-      log.error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
       throw new Error(message);
     });
 
@@ -134,7 +157,8 @@ async function getContactTypeIdAndInputTypeId(organization) {
       ct => ct.name === contactType
     ));
     if (!contactTypeId) {
-      log.error(`Contact type ${contactType} not returned by VAN`);
+      // eslint-disable-next-line no-console
+      console.error(`Contact type ${contactType} not returned by VAN`);
     }
 
     const inputType =
@@ -144,7 +168,8 @@ async function getContactTypeIdAndInputTypeId(organization) {
       inTy => inTy.name === inputType
     ));
     if (!inputTypeId) {
-      log.error(`Input type ${inputType} not returned by VAN`);
+      // eslint-disable-next-line no-console
+      console.error(`Input type ${inputType} not returned by VAN`);
     }
 
     if (!inputTypeId || !contactTypeId) {
@@ -153,7 +178,8 @@ async function getContactTypeIdAndInputTypeId(organization) {
       );
     }
   } catch (error) {
-    log.error(
+    // eslint-disable-next-line no-console
+    console.error(
       `Error loading canvass/contactTypes or canvass/inputTypes from VAN  ${error}`
     );
   }
@@ -190,7 +216,8 @@ export async function getClientChoiceData(organization) {
     .then(async response => await response.json())
     .catch(error => {
       const message = `Error retrieving survey questions from VAN ${error}`;
-      log.error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
       throw new Error(message);
     });
 
@@ -207,7 +234,8 @@ export async function getClientChoiceData(organization) {
     .then(async response => await response.json())
     .catch(error => {
       const message = `Error retrieving activist codes from VAN ${error}`;
-      log.error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
       throw new Error(message);
     });
 
@@ -224,7 +252,8 @@ export async function getClientChoiceData(organization) {
     .then(async response => await response.json())
     .catch(error => {
       const message = `Error retrieving canvass result codes from VAN ${error}`;
-      log.error(message);
+      // eslint-disable-next-line no-console
+      console.error(message);
       throw new Error(message);
     });
 
@@ -243,7 +272,8 @@ export async function getClientChoiceData(organization) {
       canvassResultCodesPromise
     ]);
   } catch (caughtError) {
-    log.error(
+    // eslint-disable-next-line no-console
+    console.error(
       `Error loading surveyQuestions, activistCodes or canvass/resultCodes from VAN  ${caughtError}`
     );
     return {
@@ -327,7 +357,8 @@ export async function available(organization) {
     !!getConfig("NGP_VAN_APP_NAME", organization);
 
   if (!result) {
-    log.info(
+    // eslint-disable-next-line no-console
+    console.info(
       "ngpvan-action unavailable. Missing one or more required environment variables"
     );
   }
@@ -337,13 +368,15 @@ export async function available(organization) {
       const { data } = await exports.getClientChoiceData(organization);
       const parsedData = (data && JSON.parse(data)) || {};
       if (parsedData.error) {
-        log.info(
+        // eslint-disable-next-line no-console
+        console.info(
           `ngpvan-action unavailable. getClientChoiceData returned error ${parsedData.error}`
         );
         result = false;
       }
     } catch (caughtError) {
-      log.info(
+      // eslint-disable-next-line no-console
+      console.info(
         `ngpvan-action unavailable. getClientChoiceData threw an exception ${caughtError}`
       );
       result = false;

--- a/src/integrations/contact-loaders/ngpvan/index.js
+++ b/src/integrations/contact-loaders/ngpvan/index.js
@@ -29,7 +29,8 @@ export function serverAdministratorInstructions() {
       "NGP_VAN_CACHE_TTL",
       "NGP_VAN_EXPORT_JOB_TYPE_ID",
       "NGP_VAN_MAXIMUM_LIST_SIZE",
-      "NGP_VAN_WEBHOOK_BASE_URL"
+      "NGP_VAN_WEBHOOK_BASE_URL",
+      "NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION"
     ]
   };
 }
@@ -187,11 +188,13 @@ const getPhoneNumberIfLikelyCell = (phoneType, row) => {
   return undefined;
 };
 
-export const getCellFromRow = row => {
+export const getCellFromRow = (row, cautious = true) => {
   const phoneTypes = [
     { typeName: "Cell", assumeCellIfPresent: true },
-    { typeName: "Home", assumeCellIfPresent: false },
-    { typeName: "Work", assumeCellIfPresent: false }
+    { typeName: "OptIn", assumeCellIfPresent: !cautious || false },
+    { typeName: "", assumeCellIfPresent: !cautious || false },
+    { typeName: "Home", assumeCellIfPresent: !cautious || false },
+    { typeName: "Work", assumeCellIfPresent: !cautious || false }
   ];
   let cell = undefined;
   phoneTypes.some(phoneType => {
@@ -205,14 +208,17 @@ export const getCellFromRow = row => {
   return cell;
 };
 
-export const rowTransformer = (originalFields, originalRow) => {
+export const makeRowTransformer = (cautious = true) => (
+  originalFields,
+  originalRow
+) => {
   const addedFields = ["external_id"];
 
   const row = {
     ...originalRow
   };
 
-  row.cell = exports.getCellFromRow(originalRow);
+  row.cell = exports.getCellFromRow(originalRow, cautious);
   if (row.cell) {
     addedFields.push("cell");
   }
@@ -329,9 +335,16 @@ export async function processContactLoad(job, maxContacts, organization) {
 
   try {
     const vanContacts = await vanResponse.text();
+    const cautiousCellPhoneSelection = getConfig(
+      "NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION",
+      organization
+    );
 
     const { validationStats, contacts } = await parseCSVAsync(vanContacts, {
-      rowTransformer,
+      rowTransformer: exports.makeRowTransformer(
+        !cautiousCellPhoneSelection ||
+          (cautiousCellPhoneSelection && cautiousCellPhoneSelection === "true")
+      ),
       headerTransformer
     });
 

--- a/src/integrations/contact-loaders/ngpvan/index.js
+++ b/src/integrations/contact-loaders/ngpvan/index.js
@@ -335,16 +335,12 @@ export async function processContactLoad(job, maxContacts, organization) {
 
   try {
     const vanContacts = await vanResponse.text();
-    const cautiousCellPhoneSelection = getConfig(
-      "NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION",
-      organization
-    );
+    const cautiousCellPhoneSelection =
+      getConfig("NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION", organization) ===
+      "true";
 
     const { validationStats, contacts } = await parseCSVAsync(vanContacts, {
-      rowTransformer: exports.makeRowTransformer(
-        !cautiousCellPhoneSelection ||
-          (cautiousCellPhoneSelection && cautiousCellPhoneSelection === "true")
-      ),
+      rowTransformer: exports.makeRowTransformer(cautiousCellPhoneSelection),
       headerTransformer
     });
 

--- a/src/integrations/message-handlers/ngpvan/index.js
+++ b/src/integrations/message-handlers/ngpvan/index.js
@@ -1,0 +1,64 @@
+import { getConfig } from "../../../server/api/lib/config";
+import { runningInLambda } from "../../../server/api/lib/utils";
+
+import {
+  getActionHandler,
+  getActionChoiceData
+} from "../../../integrations/action-handlers";
+
+export const DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT = "Texted";
+
+export const serverAdministratorInstructions = () => {
+  return {
+    description: `
+      Update the contact in VAN with a status of Texted
+      when the initial message is sent to the contact
+      for a campaign.
+    `,
+    setupInstructions: `
+      This message handler is dependent on the ngpvan-action Action Handler.
+      Follow its setup instructions.
+    `,
+    environmentVariables: []
+  };
+};
+
+export const available = async organization => {
+  const handler = await getActionHandler("ngpvan-action", organization);
+  return !!handler;
+};
+
+// export const preMessageSave = async () => {};
+
+export const postMessageSave = async ({ contact, organization }) => {
+  if (contact.message_status !== "needsMessage") {
+    return {};
+  }
+
+  const handler = await getActionHandler("ngpvan-action", organization);
+  const clientChoiceData = await getActionChoiceData(handler, organization);
+  const initialTextResult =
+    getConfig("NGP_VAN_INITIAL_TEXT_CANVASS_RESULT", organization) ||
+    DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT;
+
+  const texted = clientChoiceData.find(ccd => ccd.name === initialTextResult);
+  const body = JSON.parse(texted.details);
+
+  const promise = handler
+    .postCanvassResponse(contact, organization, body)
+    .then(() => {})
+    .catch(caughtError => {
+      // eslint-disable-next-line no-console
+      console.error(
+        "Encountered exception in ngpvan.postMessageSave",
+        caughtError
+      );
+      return {};
+    });
+
+  if (runningInLambda()) {
+    return promise;
+  }
+
+  return {};
+};


### PR DESCRIPTION
## Description

This was an ask from NYCET (@Frydafly).  Rather than relying on VAN's rating of likely cell phones, by default Spoke will pick the first phone number it finds in the following order:

 * CellPhone
 * OptInPhone
 * Phone
 * Home
 * Work

Also added a configuration option to use the original, more cautious strategy, which selects a number VAN considers likely to be a cell phone. Set `NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION` to true to use the more cautious strategy.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
