### PR TITLE
bugfix: update campaign assignedCount on dynamic assignment

### DIFF
--- a/src/server/api/mutations/findNewCampaignContact.js
+++ b/src/server/api/mutations/findNewCampaignContact.js
@@ -78,6 +78,11 @@ export const findNewCampaignContact = async (
     .catch(log.error);
 
   if (updatedCount > 0) {
+    await cacheableData.campaign.incrCount(
+      campaign.id,
+      "assignedCount",
+      updatedCount
+    );
     return {
       found: true
     };


### PR DESCRIPTION
# Fixes Unassigned count does not update when using Dynamic assignment campaigns

## Description

the cache needs to be updated for findNewCampaignContact

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
