### PR TITLE
Include action handlers with Google Docs script import

### DIFF
--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -46,11 +46,6 @@ const getParagraphIndent = getOr(
   0,
   "paragraph.paragraphStyle.indentFirstLine.magnitude"
 );
-const namedStyleIndent = compose(
-  getOr(0, "paragraphStyle.indentFirstLine.magnitude"),
-  getNamedStyle,
-  getParagraphStyle
-);
 const getParagraphBold = compose(
   getOr(false, "textRun.textStyle.bold"),
   find(getTextRun),
@@ -63,7 +58,7 @@ const namedStyleBold = compose(
 );
 const getParagraph = element => ({
   style: getParagraphStyle(element),
-  indent: getParagraphIndent(element) + namedStyleIndent(element),
+  indent: getParagraphIndent(element),
   isParagraphBold: namedStyleBold(element) || getParagraphBold(element),
   text: getParagraphText(element)
 });

--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -29,6 +29,7 @@ const getDocument = async documentId => {
   return result;
 };
 
+let actionHandlers = {};
 let namedStyles = [];
 const getNamedStyle = style => namedStyles.find(x => x.namedStyleType === style);
 const getParagraphStyle = getOr("", "paragraph.paragraphStyle.namedStyleType");
@@ -56,10 +57,21 @@ const namedStyleBold = compose(
   getNamedStyle,
   getParagraphStyle
 );
+const getParagraphItalic = compose(
+  getOr(false, "textRun.textStyle.italic"),
+  find(getTextRun),
+  getOr([], "paragraph.elements")
+);
+const namedStyleItalic = compose(
+  getOr(false, "textStyle.italic"),
+  getNamedStyle,
+  getParagraphStyle
+);
 const getParagraph = element => ({
   style: getParagraphStyle(element),
   indent: getParagraphIndent(element),
   isParagraphBold: namedStyleBold(element) || getParagraphBold(element),
+  isParagraphItalic: namedStyleItalic(element) || getParagraphItalic(element),
   text: getParagraphText(element)
 });
 const hasParagraph = has("paragraph");
@@ -120,6 +132,8 @@ const getInteractions = sections =>
   getSectionParagraphs(sections, "Interactions");
 const getCannedResponses = sections =>
   getSectionParagraphs(sections, "Canned Responses");
+const getActionHandlers = sections =>
+  getSectionParagraphs(sections, "Action Handlers");
 
 const isNextChunkAQuestion = (interactionParagraphs, currentIndent) =>
   interactionParagraphs.length > 1 &&
@@ -199,7 +213,17 @@ const makeInteractionHierarchy = (
       !interactionParagraphs[0].isParagraphBold
     ) {
       const interactionParagraph = interactionParagraphs.shift();
-      interactionsHierarchyNode.script.push(interactionParagraph.text);
+      if (interactionParagraph.isParagraphItalic) {
+        // Italic = action handler.
+        const handlerLabel = interactionParagraph.text.trim().toLowerCase();
+        const handler = actionHandlers[handlerLabel];
+        if (!handler) continue;
+        interactionsHierarchyNode.action = handler.name;
+        interactionsHierarchyNode.action_data = handler.data;
+      } else {
+        // Regular text, add to script.
+        interactionsHierarchyNode.script.push(interactionParagraph.text);
+      }
     }
 
     if (!interactionsHierarchyNode.script[0]) {
@@ -251,8 +275,8 @@ const saveInteractionsHierarchyNode = async (
       question: interactionsHierarchyNode.question || "",
       script: interactionsHierarchyNode.script.join("\n") || "",
       answer_option: interactionsHierarchyNode.answer || "",
-      answer_actions: "",
-      answer_actions_data: "",
+      answer_actions: interactionsHierarchyNode.action || "",
+      answer_actions_data: interactionsHierarchyNode.action_data || "",
       campaign_id: campaignId,
       is_deleted: false
     })
@@ -360,6 +384,39 @@ const replaceCannedResponsesInDatabase = async (
   });
 };
 
+const makeActionHandlersList = actionHandlerParagraphs => {
+  const actionHandlers = {};
+  while (actionHandlerParagraphs[0]) {
+    const handler = {};
+
+    const paragraph = actionHandlerParagraphs.shift();
+    if (!paragraph.isParagraphItalic) {
+      throw new Error(
+        `Action handler format error -- can't find a italic paragraph. Look for [${paragraph.text}]`
+      );
+    }
+    handler.label = paragraph.text;
+
+    while (
+      actionHandlerParagraphs[0] &&
+      !actionHandlerParagraphs[0].isParagraphItalic
+    ) {
+      handler.name = actionHandlerParagraphs.shift().text;
+      handler.data = actionHandlerParagraphs.shift().text;
+    }
+
+    if (!handler.name || !handler.data) {
+      throw new Error(
+        `Action handler format error -- handler missing name or data. Look for [${handler.label}]`
+      );
+    }
+
+    actionHandlers[handler.label.trim().toLowerCase()] = handler;
+  }
+
+  return actionHandlers;
+};
+
 const importScriptFromDocument = async (campaignId, scriptUrl) => {
   const match = scriptUrl.match(/document\/d\/(.*)\//);
   if (!match || !match[1]) {
@@ -378,6 +435,11 @@ const importScriptFromDocument = async (campaignId, scriptUrl) => {
   const document = result.data.body.content;
   namedStyles = result.data.namedStyles.styles;
   const sections = getSections(document);
+
+  const actionHandlerParagraphs = getActionHandlers(sections) || [];
+  actionHandlers = makeActionHandlersList(
+    _.clone(actionHandlerParagraphs)
+  );
 
   const interactionParagraphs = getInteractions(sections);
   const interactionsHierarchy = makeInteractionHierarchy(


### PR DESCRIPTION
## Description

This lets you add an Action Handlers section to your google doc script template, and reference those handlers in the Interaction Steps that get imported. To distinguish the action handlers from script text, action handlers are in _italics_.

![2020-07-14 at 11 33 AM](https://user-images.githubusercontent.com/18371709/87445649-4b8dc480-c5c6-11ea-91a2-eb8378ea9fba.png)

![2020-07-14 at 11 34 AM](https://user-images.githubusercontent.com/18371709/87445671-521c3c00-c5c6-11ea-915a-ff915388f825.png)

It also includes an improvement to the document parsing which takes into account named styles (e.g. Heading 3) to determine if a paragraph is bold/italic. Previously you could have a heading paragraph that looks bold in the doc, but wasn't seen that way by the importer.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
