### PR TITLE
VAN input type is optional

### DIFF
--- a/__test__/integrations/action-handlers/ngpvan-action.test.js
+++ b/__test__/integrations/action-handlers/ngpvan-action.test.js
@@ -552,6 +552,228 @@ describe("ngpvn-action", () => {
       allNocksDone();
     });
 
+    describe("when there's an input/contact type configured", () => {
+      beforeEach(async () => {
+        process.env.NGP_VAN_INPUT_TYPE = "Back End";
+        process.env.NGP_VAN_CONTACT_TYPE = "Robocall";
+      });
+
+      it("returns what we expect", async () => {
+        makeAllNocks({ getSurveyResultsStatusCode: 200 });
+
+        const clientChoiceData = await NgpVanAction.getClientChoiceData();
+        const receivedItems = JSON.parse(clientChoiceData.data).items;
+
+        const expectedItems = [
+          {
+            name: "2020VotePPE - Yes - Early",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 378552,
+                  surveyResponseId: 1555791
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VotePPE - Yes - Eday",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 378552,
+                  surveyResponseId: 1555792
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VotePPE - Yes - Absentee",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 378552,
+                  surveyResponseId: 1555793
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VotePPE - Maybe",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 378552,
+                  surveyResponseId: 1555794
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VotePPE - No",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 378552,
+                  surveyResponseId: 1555795
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VoteTime - Morning",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 381390,
+                  surveyResponseId: 1566012
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VoteTime - Afternoon",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 381390,
+                  surveyResponseId: 1566013
+                }
+              ]
+            })
+          },
+          {
+            name: "2020VoteTime - Evening",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "SurveyResponse",
+                  surveyQuestionId: 381390,
+                  surveyResponseId: 1566014
+                }
+              ]
+            })
+          },
+          {
+            name: "EdayIssue-PollWorker",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "ActivistCode",
+                  action: "Apply",
+                  activistCodeId: 4482459
+                }
+              ]
+            })
+          },
+          {
+            name: "Opt-In: Cell Phone",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              responses: [
+                {
+                  type: "ActivistCode",
+                  action: "Apply",
+                  activistCodeId: 4153148
+                }
+              ]
+            })
+          },
+          {
+            name: "Busy",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 18
+            })
+          },
+          {
+            name: "Call Back",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 17
+            })
+          },
+          {
+            name: "Canvassed",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 14
+            })
+          },
+          {
+            name: "Come Back",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 13
+            })
+          },
+          {
+            name: "Deceased",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 4
+            })
+          },
+          {
+            name: "Disconnected",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 25
+            })
+          },
+          {
+            name: "Do Not Call",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 22
+            })
+          },
+          {
+            name: "Do Not Email",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 131
+            })
+          },
+          {
+            name: "Do Not Text",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 130
+            })
+          },
+          {
+            name: "Do Not Walk",
+            details: JSON.stringify({
+              canvassContext: { contactTypeId: 4, inputTypeId: 5 },
+              resultCodeId: 23
+            })
+          }
+        ];
+
+        expect(receivedItems).toEqual(expectedItems);
+        expect(clientChoiceData.expiresSeconds).toEqual(600);
+
+        allNocksDone();
+      });
+    });
+
     describe("when there's an election cycle filter", () => {
       beforeEach(async () => {
         process.env.NGP_VAN_ELECTION_CYCLE_FILTER = "2020";
@@ -605,6 +827,25 @@ describe("ngpvn-action", () => {
     describe("when canvass/contactTypes doesn't have the item we want", () => {
       it("throws an exception", async () => {
         makeAllNocks({ getCanvassResponsesContactTypesResult: [] });
+
+        const clientChoiceData = await NgpVanAction.getClientChoiceData();
+        const receivedError = JSON.parse(clientChoiceData.data).error;
+
+        expect(receivedError).toEqual(
+          "Failed to load canvass/contactTypes or canvass/inputTypes from VAN"
+        );
+
+        nock.abortPendingRequests();
+      });
+    });
+
+    describe("when canvass/inputTypes doesn't have the item we want", () => {
+      beforeEach(async () => {
+        process.env.NGP_VAN_INPUT_TYPE = "Telepathy";
+      });
+
+      it("throws an exception", async () => {
+        makeAllNocks({ getCanvassResponsesInputTypesResult: [] });
 
         const clientChoiceData = await NgpVanAction.getClientChoiceData();
         const receivedError = JSON.parse(clientChoiceData.data).error;

--- a/__test__/integrations/action-handlers/ngpvan-action.test.js
+++ b/__test__/integrations/action-handlers/ngpvan-action.test.js
@@ -345,7 +345,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VotePPE - Yes - Early",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -358,7 +358,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VotePPE - Yes - Eday",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -371,7 +371,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VotePPE - Yes - Absentee",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -384,7 +384,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VotePPE - Maybe",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -397,7 +397,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VotePPE - No",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -410,7 +410,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VoteTime - Morning",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -423,7 +423,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VoteTime - Afternoon",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -436,7 +436,7 @@ describe("ngpvn-action", () => {
         {
           name: "2020VoteTime - Evening",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "SurveyResponse",
@@ -449,7 +449,7 @@ describe("ngpvn-action", () => {
         {
           name: "EdayIssue-PollWorker",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "ActivistCode",
@@ -462,7 +462,7 @@ describe("ngpvn-action", () => {
         {
           name: "Opt-In: Cell Phone",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             responses: [
               {
                 type: "ActivistCode",
@@ -475,56 +475,56 @@ describe("ngpvn-action", () => {
         {
           name: "Busy",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 18
           })
         },
         {
           name: "Call Back",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 17
           })
         },
         {
           name: "Canvassed",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 14
           })
         },
         {
           name: "Come Back",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 13
           })
         },
         {
           name: "Deceased",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 4
           })
         },
         {
           name: "Disconnected",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 25
           })
         },
         {
           name: "Do Not Call",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 22
           })
         },
         {
           name: "Do Not Email",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
 
             resultCodeId: 131
           })
@@ -532,7 +532,7 @@ describe("ngpvn-action", () => {
         {
           name: "Do Not Text",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
 
             resultCodeId: 130
           })
@@ -540,7 +540,7 @@ describe("ngpvn-action", () => {
         {
           name: "Do Not Walk",
           details: JSON.stringify({
-            canvassContext: { contactTypeId: 37, inputTypeId: 11 },
+            canvassContext: { contactTypeId: 37 },
             resultCodeId: 23
           })
         }
@@ -605,21 +605,6 @@ describe("ngpvn-action", () => {
     describe("when canvass/contactTypes doesn't have the item we want", () => {
       it("throws an exception", async () => {
         makeAllNocks({ getCanvassResponsesContactTypesResult: [] });
-
-        const clientChoiceData = await NgpVanAction.getClientChoiceData();
-        const receivedError = JSON.parse(clientChoiceData.data).error;
-
-        expect(receivedError).toEqual(
-          "Failed to load canvass/contactTypes or canvass/inputTypes from VAN"
-        );
-
-        nock.abortPendingRequests();
-      });
-    });
-
-    describe("when canvass/inputTypes doesn't have the item we want", () => {
-      it("throws an exception", async () => {
-        makeAllNocks({ getCanvassResponsesInputTypesResult: [] });
 
         const clientChoiceData = await NgpVanAction.getClientChoiceData();
         const receivedError = JSON.parse(clientChoiceData.data).error;

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -161,20 +161,21 @@ async function getContactTypeIdAndInputTypeId(organization) {
       console.error(`Contact type ${contactType} not returned by VAN`);
     }
 
-    const inputType = getConfig("NGP_VAN_INPUT_TYPE", organization);
-    if (inputType) {
-      ({ inputTypeId } = inputTypesResponse.find(
-        inTy => inTy.name === inputType
-      ));
-      if (!inputTypeId) {
+    const inputTypeName = getConfig("NGP_VAN_INPUT_TYPE", organization);
+    if (inputTypeName) {
+      const inputType = inputTypesResponse.find(
+        inTy => inTy.name === inputTypeName
+      ) || {};
+      inputTypeId = inputType.inputTypeId || -1;
+      if (inputTypeId === -1) {
         // eslint-disable-next-line no-console
         console.error(`Input type ${inputType} not returned by VAN`);
       }
     }
 
-    if (!contactTypeId) {
+    if (inputTypeId === -1 || !contactTypeId) {
       throw new Error(
-        "VAN did not return the configured contact type. Check the log"
+        "VAN did not return the configured input type or contact type. Check the log"
       );
     }
   } catch (error) {
@@ -192,7 +193,7 @@ export async function getClientChoiceData(organization) {
     organization
   );
 
-  if (!contactTypeId) {
+  if (inputTypeId === -1 || !contactTypeId) {
     return {
       data: `${JSON.stringify({
         error:


### PR DESCRIPTION
## Description

When creating canvass responses through the VAN API, `inputTypeId` is [optional](https://developers.ngpvan.com/van-api#people-post-people--vanid--canvassresponses), and defaults to 11 ("API"). The Spoke action handler was specifying this default value explicitly — which would be fine — except that for some reason VAN's API is not returning that default inputType is not always included as one of the available options when you [get them](https://developers.ngpvan.com/van-api#canvass-responses-get-canvassresponses-inputtypes) from VAN.

That was causing errors because it made the Action Handler think it was using an illegal value. The simplest solution is to omit `inputTypeId` entirely if it's not specified in the configuration.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
