### PR TITLE
Enable action handlers to know if a response was added, updated, or deleted

### DIFF
--- a/__test__/integrations/action-handlers/ngpvan-action.test.js
+++ b/__test__/integrations/action-handlers/ngpvan-action.test.js
@@ -715,7 +715,7 @@ describe("ngpvn-action", () => {
     let organization;
     let interactionStepValue;
 
-    let unusedQuestionResponse;
+    let questionResponse;
     let unusedCampaignContactId;
     let unusedCampaign;
 
@@ -725,9 +725,14 @@ describe("ngpvn-action", () => {
     beforeEach(async () => {
       interactionStepValue = '{"hex":"#B22222","rgb":{"r":178,"g":34,"b":34}}';
       interactionStep = {
+        id: "77",
         answer_actions_data: JSON.stringify({
           value: JSON.stringify(interactionStepValue)
         })
+      };
+
+      questionResponse = {
+        interactionStepId: "77"
       };
 
       contact = {
@@ -757,12 +762,15 @@ describe("ngpvn-action", () => {
       postPeopleCanvassResponsesNock = makePostPeopleCanvassResponsesNock();
 
       await NgpVanAction.processAction(
-        unusedQuestionResponse,
+        questionResponse,
         interactionStep,
         unusedCampaignContactId,
         contact,
         unusedCampaign,
-        organization
+        organization,
+        {
+          unchanged: {}
+        }
       );
 
       postPeopleCanvassResponsesNock.done();
@@ -777,12 +785,15 @@ describe("ngpvn-action", () => {
         let error;
         try {
           await NgpVanAction.processAction(
-            unusedQuestionResponse,
+            questionResponse,
             interactionStep,
             unusedCampaignContactId,
             contact,
             unusedCampaign,
-            organization
+            organization,
+            {
+              unchanged: {}
+            }
           );
         } catch (caughtException) {
           error = caughtException;
@@ -826,12 +837,15 @@ describe("ngpvn-action", () => {
         let error;
         try {
           await NgpVanAction.processAction(
-            unusedQuestionResponse,
+            questionResponse,
             interactionStep,
             unusedCampaignContactId,
             contact,
             unusedCampaign,
-            organization
+            organization,
+            {
+              unchanged: {}
+            }
           );
         } catch (caughtException) {
           error = caughtException;
@@ -839,6 +853,27 @@ describe("ngpvn-action", () => {
 
         expect(error.message).toEqual(
           expect.stringMatching(/^unexpected token*/i)
+        );
+
+        expect(postPeopleCanvassResponsesNock.isDone()).toEqual(false);
+        nock.cleanAll();
+      });
+    });
+
+    describe("when the question response has not been added or updated", () => {
+      it("returns without doing anything", async () => {
+        postPeopleCanvassResponsesNock = makePostPeopleCanvassResponsesNock();
+
+        await NgpVanAction.processAction(
+          questionResponse,
+          interactionStep,
+          unusedCampaignContactId,
+          contact,
+          unusedCampaign,
+          organization,
+          {
+            unchanged: { 77: {} }
+          }
         );
 
         expect(postPeopleCanvassResponsesNock.isDone()).toEqual(false);

--- a/__test__/integrations/action-handlers/ngpvan-action.test.js
+++ b/__test__/integrations/action-handlers/ngpvan-action.test.js
@@ -761,17 +761,13 @@ describe("ngpvn-action", () => {
     it("calls the people endpoint", async () => {
       postPeopleCanvassResponsesNock = makePostPeopleCanvassResponsesNock();
 
-      await NgpVanAction.processAction(
+      await NgpVanAction.processAction({
         questionResponse,
         interactionStep,
-        unusedCampaignContactId,
         contact,
-        unusedCampaign,
         organization,
-        {
-          unchanged: {}
-        }
-      );
+        previousValue: null
+      });
 
       postPeopleCanvassResponsesNock.done();
     });
@@ -784,17 +780,13 @@ describe("ngpvn-action", () => {
 
         let error;
         try {
-          await NgpVanAction.processAction(
+          await NgpVanAction.processAction({
             questionResponse,
             interactionStep,
-            unusedCampaignContactId,
             contact,
-            unusedCampaign,
             organization,
-            {
-              unchanged: {}
-            }
-          );
+            previousValue: null
+          });
         } catch (caughtException) {
           error = caughtException;
         }
@@ -836,44 +828,21 @@ describe("ngpvn-action", () => {
 
         let error;
         try {
-          await NgpVanAction.processAction(
+          await NgpVanAction.processAction({
             questionResponse,
             interactionStep,
             unusedCampaignContactId,
             contact,
             unusedCampaign,
             organization,
-            {
-              unchanged: {}
-            }
-          );
+            previousValue: null
+          });
         } catch (caughtException) {
           error = caughtException;
         }
 
         expect(error.message).toEqual(
           expect.stringMatching(/^unexpected token*/i)
-        );
-
-        expect(postPeopleCanvassResponsesNock.isDone()).toEqual(false);
-        nock.cleanAll();
-      });
-    });
-
-    describe("when the question response has not been added or updated", () => {
-      it("returns without doing anything", async () => {
-        postPeopleCanvassResponsesNock = makePostPeopleCanvassResponsesNock();
-
-        await NgpVanAction.processAction(
-          questionResponse,
-          interactionStep,
-          unusedCampaignContactId,
-          contact,
-          unusedCampaign,
-          organization,
-          {
-            unchanged: { 77: {} }
-          }
         );
 
         expect(postPeopleCanvassResponsesNock.isDone()).toEqual(false);

--- a/__test__/server/api/campaign/updateQuestionResponses.test.js
+++ b/__test__/server/api/campaign/updateQuestionResponses.test.js
@@ -241,7 +241,7 @@ describe("mutations.updateQuestionResponses", () => {
           value: colorInteractionSteps[0].answerOption
         },
         {
-          campaignContactId: contacts[0].id.toString(),
+          campaignContactId: contacts[0].id,
           interactionStepId: redInteractionStep.id,
           value: shadesOfRedInteractionSteps[0].answerOption
         }
@@ -589,7 +589,7 @@ describe("mutations.updateQuestionResponses", () => {
             value: colorInteractionSteps[0].answerOption
           },
           {
-            campaignContactId: contacts[0].id.toString(),
+            campaignContactId: contacts[0].id,
             interactionStepId: redInteractionStep.id,
             value: shadesOfRedInteractionSteps[0].answerOption
           }
@@ -660,7 +660,7 @@ describe("mutations.updateQuestionResponses", () => {
             value: colorInteractionSteps[0].answerOption
           },
           {
-            campaignContactId: contacts[0].id.toString(),
+            campaignContactId: contacts[0].id,
             interactionStepId: redInteractionStep.id,
             value: shadesOfRedInteractionSteps[0].answerOption
           }
@@ -723,7 +723,7 @@ describe("mutations.updateQuestionResponses", () => {
         );
       });
 
-      describe("when one of the question responses has already be saved with the same value", () => {
+      describe("when one of the question responses has already been saved with the same value", () => {
         beforeEach(async () => {
           questionResponses = [
             {
@@ -732,7 +732,7 @@ describe("mutations.updateQuestionResponses", () => {
               value: colorInteractionSteps[0].answerOption
             },
             {
-              campaignContactId: contacts[0].id.toString(),
+              campaignContactId: contacts[0].id,
               interactionStepId: redInteractionStep.id,
               value: shadesOfRedInteractionSteps[0].answerOption
             }
@@ -756,18 +756,28 @@ describe("mutations.updateQuestionResponses", () => {
           expect(ComplexTestActionHandler.processAction).toHaveBeenCalledTimes(
             1
           );
-          expect(ComplexTestActionHandler.processAction.mock.calls).toEqual(
-            expect.arrayContaining([
-              [
-                expect.objectContaining(questionResponses[0]),
-                expect.objectWithId(colorInteractionSteps[0]),
-                Number(contacts[0].id),
-                expect.objectWithId(contacts[0]),
-                expect.objectWithId(campaign),
-                expect.objectWithId(organization)
-              ]
-            ])
-          );
+
+          expect(ComplexTestActionHandler.processAction.mock.calls).toEqual([
+            [
+              expect.objectContaining(questionResponses[0]),
+              expect.objectWithId(colorInteractionSteps[0]),
+              Number(contacts[0].id),
+              expect.objectWithId(contacts[0]),
+              expect.objectWithId(campaign),
+              expect.objectWithId(organization),
+              {
+                new: {
+                  "1": {
+                    campaignContactId: 1,
+                    interactionStepId: "1",
+                    value: "Red"
+                  }
+                },
+                updated: {},
+                unchanged: {}
+              }
+            ]
+          ]);
 
           ComplexTestActionHandler.processAction.mockReset();
 
@@ -779,18 +789,57 @@ describe("mutations.updateQuestionResponses", () => {
 
           await sleep(100);
 
-          expect(ComplexTestActionHandler.processAction).toHaveBeenCalledTimes(
-            1
-          );
           expect(ComplexTestActionHandler.processAction.mock.calls).toEqual(
             expect.arrayContaining([
+              [
+                expect.objectContaining(questionResponses[0]),
+                expect.objectWithId(colorInteractionSteps[0]),
+                Number(contacts[0].id),
+                expect.objectWithId(contacts[0]),
+                expect.objectWithId(campaign),
+                expect.objectWithId(organization),
+                {
+                  new: {
+                    "2": {
+                      campaignContactId: 1,
+                      interactionStepId: "2",
+                      value: "Crimson"
+                    }
+                  },
+                  updated: {},
+                  unchanged: {
+                    "1": {
+                      campaignContactId: 1,
+                      interactionStepId: "1",
+                      value: "Red"
+                    }
+                  }
+                }
+              ],
               [
                 expect.objectContaining(questionResponses[1]),
                 expect.objectWithId(shadesOfRedInteractionSteps[0]),
                 Number(contacts[0].id),
                 expect.objectWithId(contacts[0]),
                 expect.objectWithId(campaign),
-                expect.objectWithId(organization)
+                expect.objectWithId(organization),
+                {
+                  new: {
+                    "2": {
+                      campaignContactId: 1,
+                      interactionStepId: "2",
+                      value: "Crimson"
+                    }
+                  },
+                  updated: {},
+                  unchanged: {
+                    "1": {
+                      campaignContactId: 1,
+                      interactionStepId: "1",
+                      value: "Red"
+                    }
+                  }
+                }
               ]
             ])
           );

--- a/__test__/server/models/question-response.test.js
+++ b/__test__/server/models/question-response.test.js
@@ -103,7 +103,7 @@ describe("questionResponse cacheableData methods", async () => {
       },
       deleted: [
         {
-          interactionStepId: "1",
+          interactionStepId: 1,
           value: "hmm1"
         }
       ]

--- a/__test__/server/models/question-response.test.js
+++ b/__test__/server/models/question-response.test.js
@@ -26,9 +26,21 @@ describe("questionResponse cacheableData methods", async () => {
       choices: 2
     });
     const interactionSteps = await r.knex("interaction_step").select();
-    await cacheableData.questionResponse.save(cid, [
+
+    let saveResult = await cacheableData.questionResponse.save(cid, [
       { interactionStepId: "1", value: "hmm1" }
     ]);
+    expect(saveResult).toEqual({
+      new: {
+        "1": {
+          interactionStepId: "1",
+          value: "hmm1"
+        }
+      },
+      updated: {},
+      unchanged: {}
+    });
+
     let questionResponses = await r.knex("question_response").select();
     expect(questionResponses.length).toBe(1);
     expect(questionResponses[0].value).toBe("hmm1");
@@ -40,11 +52,28 @@ describe("questionResponse cacheableData methods", async () => {
     expect(questionResponses[0].value).toBe("hmm1");
     expect(questionResponses[0].interaction_step_id).toBe(1);
     await sleep(20);
+
     // change value adding one
-    await cacheableData.questionResponse.save(cid, [
+    saveResult = await cacheableData.questionResponse.save(cid, [
       { interactionStepId: "1", value: "hmm1" },
       { interactionStepId: "2", value: "1hmm2" }
     ]);
+    expect(saveResult).toEqual({
+      new: {
+        "2": {
+          interactionStepId: "2",
+          value: "1hmm2"
+        }
+      },
+      updated: {},
+      unchanged: {
+        "1": {
+          interactionStepId: "1",
+          value: "hmm1"
+        }
+      }
+    });
+
     questionResponses = await r.knex("question_response").select();
     expect(questionResponses.length).toBe(2);
     expect(questionResponses[0].value).toBe("hmm1");

--- a/__test__/server/models/question-response.test.js
+++ b/__test__/server/models/question-response.test.js
@@ -31,10 +31,10 @@ describe("questionResponse cacheableData methods", async () => {
       { interactionStepId: "1", value: "hmm1" }
     ]);
     expect(saveResult).toEqual({
-      newOrUpdatedPreviousValue: {
+      newOrUpdated: {
         "1": null
       },
-      deletedPrevious: []
+      deleted: []
     });
 
     let questionResponses = await r.knex("question_response").select();
@@ -55,10 +55,10 @@ describe("questionResponse cacheableData methods", async () => {
       { interactionStepId: "2", value: "1hmm2" }
     ]);
     expect(saveResult).toEqual({
-      newOrUpdatedPreviousValue: {
+      newOrUpdated: {
         "2": null
       },
-      deletedPrevious: []
+      deleted: []
     });
 
     questionResponses = await r.knex("question_response").select();
@@ -77,10 +77,10 @@ describe("questionResponse cacheableData methods", async () => {
       { interactionStepId: "2", value: "updated-1hmm2" }
     ]);
     expect(saveResult).toEqual({
-      newOrUpdatedPreviousValue: {
+      newOrUpdated: {
         "2": "1hmm2"
       },
-      deletedPrevious: []
+      deleted: []
     });
 
     questionResponses = await r.knex("question_response").select();
@@ -98,10 +98,10 @@ describe("questionResponse cacheableData methods", async () => {
       { interactionStepId: "2", value: "1hmm2" }
     ]);
     expect(saveResult).toEqual({
-      newOrUpdatedPreviousValue: {
+      newOrUpdated: {
         "2": "updated-1hmm2"
       },
-      deletedPrevious: [
+      deleted: [
         {
           interactionStepId: "1",
           value: "hmm1"

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -786,7 +786,6 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   renderMessagingRowSendSkip(contact) {
-    console.log("this.props", this.props);
     return (
       <div className={css(flexStyles.sectionSend)}>
         <FlatButton

--- a/src/integrations/action-handlers/actionkit-rsvp.js
+++ b/src/integrations/action-handlers/actionkit-rsvp.js
@@ -67,11 +67,7 @@ export const akidGenerate = function(ak_secret, cleartext) {
   return `${cleartext}.${shortHash}`;
 };
 
-export async function processAction(
-  questionResponse,
-  interactionStep,
-  campaignContactId
-) {
+export async function processAction({ campaignContactId }) {
   const contactRes = await r
     .knex("campaign_contact")
     .where("campaign_contact.id", campaignContactId)

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -63,6 +63,17 @@ export async function processAction({
     .update("custom_fields", JSON.stringify(customFields));
 }
 
+// What happens when a texter remotes an answer that triggers the action
+export async function processDeletedQuestionResponse(options) {
+  console.log(
+    `complex-test-action handler called with parameters ${JSON.stringify(
+      options,
+      "",
+      2
+    )}`
+  );
+}
+
 export async function getClientChoiceData(organization, user) {
   const items = [
     {

--- a/src/integrations/action-handlers/complex-test-action.js
+++ b/src/integrations/action-handlers/complex-test-action.js
@@ -41,14 +41,11 @@ export async function available(organizationId) {
 
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
-export async function processAction(
-  questionResponse,
+export async function processAction({
   interactionStep,
   campaignContactId,
   contact
-  // campaign,     // unused parameter
-  // organization  // unused parameter
-) {
+}) {
   // This is a meta action that updates a variable in the contact record itself.
   // Generally, you want to send action data to the outside world, so you
   // might want the request library loaded above

--- a/src/integrations/action-handlers/mobilecommons-signup.js
+++ b/src/integrations/action-handlers/mobilecommons-signup.js
@@ -46,11 +46,7 @@ export async function available(organizationId) {
   };
 }
 
-export async function processAction(
-  questionResponse,
-  interactionStep,
-  campaignContactId
-) {
+export async function processAction({ campaignContactId }) {
   const contactRes = await r
     .knex("campaign_contact")
     .where("campaign_contact.id", campaignContactId)

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -82,13 +82,18 @@ export const postCanvassResponse = async (contact, organization, body) => {
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
 export async function processAction(
-  unusedQuestionResponse,
+  questionResponse,
   interactionStep,
   unusedCampaignContactId,
   contact,
   unusedCampaign,
-  organization
+  organization,
+  questionResponsesStatus
 ) {
+  if (questionResponsesStatus.unchanged[questionResponse.interactionStepId]) {
+    return;
+  }
+
   try {
     const answerActionsData = JSON.parse(
       (interactionStep || {}).answer_actions_data || "{}"

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -62,7 +62,7 @@ export const postCanvassResponse = async (contact, organization, body) => {
   // eslint-disable-next-line no-console
   console.info("Sending contact update to VAN", {
     vanId,
-    body
+    body: JSON.stringify(body)
   });
 
   return httpRequest(url, {

--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -81,19 +81,11 @@ export const postCanvassResponse = async (contact, organization, body) => {
 
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
-export async function processAction(
-  questionResponse,
+export async function processAction({
   interactionStep,
-  unusedCampaignContactId,
   contact,
-  unusedCampaign,
-  organization,
-  questionResponsesStatus
-) {
-  if (questionResponsesStatus.unchanged[questionResponse.interactionStepId]) {
-    return;
-  }
-
+  organization
+}) {
   try {
     const answerActionsData = JSON.parse(
       (interactionStep || {}).answer_actions_data || "{}"

--- a/src/integrations/action-handlers/revere-signup.js
+++ b/src/integrations/action-handlers/revere-signup.js
@@ -45,11 +45,7 @@ export async function available(organizationId) {
   };
 }
 
-export async function processAction(
-  questionResponse,
-  interactionStep,
-  campaignContactId
-) {
+export async function processAction({ campaignContactId }) {
   const contactRes = await r
     .knex("campaign_contact")
     .where("campaign_contact.id", campaignContactId)

--- a/src/integrations/action-handlers/test-action.js
+++ b/src/integrations/action-handlers/test-action.js
@@ -37,14 +37,12 @@ export async function available(organizationId) {
 
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
-export async function processAction(
-  questionResponse,
-  interactionStep,
+export async function processAction({
   campaignContactId,
   contact
   // campaign,    // unused parameter
   // organization // unused parameter
-) {
+}) {
   // This is a meta action that updates a variable in the contact record itself.
   // Generally, you want to send action data to the outside world, so you
   // might want the request library loaded above

--- a/src/integrations/action-handlers/zapier-action.js
+++ b/src/integrations/action-handlers/zapier-action.js
@@ -72,12 +72,6 @@ export async function onTagUpdate(
 // What happens when a texter saves the answer that triggers the action
 // This is presumably the meat of the action
 export async function processAction() {
-  // unusedQuestionResponse,
-  // interactionStep,
-  // unusedCampaignContactId,
-  // contact,
-  // unusedCampaign,
-  // organization
   try {
     throw new Error("zapier-action.processAction is not implemented");
   } catch (caughtError) {

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -48,9 +48,7 @@ const dispatchActionHandlers = async ({
         const { interactionStepId, value } = questionResponse;
 
         const updatedPreviousValue =
-          questionResponsesStatus.newOrUpdatedPreviousValue[
-            interactionStepId.toString()
-          ];
+          questionResponsesStatus.newOrUpdated[interactionStepId.toString()];
 
         if (updatedPreviousValue === undefined) {
           return Promise.resolve();
@@ -76,7 +74,7 @@ const dispatchActionHandlers = async ({
           previousValue: updatedPreviousValue
         });
       }),
-      ...questionResponsesStatus.deletedPrevious.map(async deletedQr => {
+      ...questionResponsesStatus.deleted.map(async deletedQr => {
         const { interactionStepId, value } = deletedQr;
         const interactionStep = findInteractionStep(value, interactionStepId);
 

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -10,7 +10,8 @@ const dispatchActionHandlers = async ({
   user,
   contact,
   campaign,
-  questionResponses
+  questionResponses,
+  questionResponsesStatus
 }) => {
   const actionHandlersConfigured =
     Object.keys(ActionHandlers.rawAllActionHandlers()).length > 0;
@@ -58,7 +59,8 @@ const dispatchActionHandlers = async ({
           questionResponse,
           questionResponseInteractionStep,
           campaign,
-          contact
+          contact,
+          questionResponsesStatus
         });
       })
     );
@@ -102,7 +104,7 @@ export const updateQuestionResponses = async (
     }
   });
 
-  await cacheableData.questionResponse
+  const questionResponsesStatus = await cacheableData.questionResponse
     .save(campaignContactId, questionResponses)
     .catch(err => {
       log.error(
@@ -115,9 +117,10 @@ export const updateQuestionResponses = async (
   try {
     await dispatchActionHandlers({
       user,
-      questionResponses: Object.values(questionResponsesHash),
+      questionResponses,
       campaign,
-      contact
+      contact,
+      questionResponsesStatus
     });
   } catch (e) {
     console.error("Dispatching to one or more action handlers failed", e);

--- a/src/server/api/mutations/updateQuestionResponses.js
+++ b/src/server/api/mutations/updateQuestionResponses.js
@@ -79,6 +79,29 @@ export const updateQuestionResponses = async (
     contact
   );
 
+  const questionResponsesHash = {};
+  questionResponses.forEach(questionResponse => {
+    questionResponsesHash[
+      questionResponse.interactionStepId
+    ] = questionResponse;
+  });
+
+  const oldQuestionResponses = await cacheableData.questionResponse.query(
+    campaignContactId
+  );
+  oldQuestionResponses.forEach(oldQuestionResponse => {
+    const newQuestionResponse =
+      questionResponsesHash[oldQuestionResponse.interaction_step_id];
+    if (
+      newQuestionResponse &&
+      newQuestionResponse.value === oldQuestionResponse.value
+    ) {
+      delete questionResponsesHash[
+        oldQuestionResponse.interaction_step_id.toString()
+      ];
+    }
+  });
+
   await cacheableData.questionResponse
     .save(campaignContactId, questionResponses)
     .catch(err => {
@@ -92,7 +115,7 @@ export const updateQuestionResponses = async (
   try {
     await dispatchActionHandlers({
       user,
-      questionResponses,
+      questionResponses: Object.values(questionResponsesHash),
       campaign,
       contact
     });

--- a/src/server/models/cacheable_queries/question-response.js
+++ b/src/server/models/cacheable_queries/question-response.js
@@ -76,7 +76,7 @@ const questionResponseCache = {
           const insertQuestionResponses = [];
           const updateStepIds = [];
           questionResponses.forEach(qr => {
-            newIds[qr.interactionStepId.toString()] = 1;
+            newIds[qr.interactionStepId] = 1;
             const existing = dbResponses.filter(
               db => db.interaction_step_id === Number(qr.interactionStepId)
             );
@@ -97,12 +97,12 @@ const questionResponseCache = {
             }
           });
           const toDelete = dbResponses.filter(
-            dbqr => !(dbqr.interaction_step_id.toString() in newIds)
+            dbqr => !(dbqr.interaction_step_id in newIds)
           );
           toDelete.forEach(dbqr => {
             toReturn.deleted.push({
               value: dbqr.value,
-              interactionStepId: dbqr.interaction_step_id.toString()
+              interactionStepId: dbqr.interaction_step_id
             });
           });
           const deletes = toDelete.map(db => db.interaction_step_id);

--- a/src/server/models/cacheable_queries/question-response.js
+++ b/src/server/models/cacheable_queries/question-response.js
@@ -98,12 +98,10 @@ const questionResponseCache = {
               insertQuestionResponses.push(newObj);
             }
           });
-          console.log("dbResponses", dbResponses, newIds);
           const toDelete = dbResponses.filter(
             dbqr => !(dbqr.interaction_step_id.toString() in newIds)
           );
           toDelete.forEach(dbqr => {
-            console.log("dbqr", dbqr);
             toReturn.deletedPrevious.push({
               value: dbqr.value,
               interactionStepId: dbqr.interaction_step_id.toString()

--- a/src/server/models/cacheable_queries/question-response.js
+++ b/src/server/models/cacheable_queries/question-response.js
@@ -51,8 +51,8 @@ const questionResponseCache = {
     // This is a bit elaborate because we want to preserve the created_at time
     // Otherwise, we could just delete all and recreate
     const toReturn = {
-      newOrUpdatedPreviousValue: {},
-      deletedPrevious: []
+      newOrUpdated: {},
+      deleted: []
     };
     if (!campaignContactId) {
       return toReturn; // guard for delete command
@@ -87,12 +87,10 @@ const questionResponseCache = {
             };
             if (!existing.length) {
               insertQuestionResponses.push(newObj);
-              toReturn.newOrUpdatedPreviousValue[
-                Number(qr.interactionStepId)
-              ] = null;
+              toReturn.newOrUpdated[Number(qr.interactionStepId)] = null;
             } else if (existing[0].value !== qr.value) {
               updateStepIds.push(qr.interactionStepId);
-              toReturn.newOrUpdatedPreviousValue[Number(qr.interactionStepId)] =
+              toReturn.newOrUpdated[Number(qr.interactionStepId)] =
                 existing[0].value;
               // will be both deleted and inserted
               insertQuestionResponses.push(newObj);
@@ -102,7 +100,7 @@ const questionResponseCache = {
             dbqr => !(dbqr.interaction_step_id.toString() in newIds)
           );
           toDelete.forEach(dbqr => {
-            toReturn.deletedPrevious.push({
+            toReturn.deleted.push({
               value: dbqr.value,
               interactionStepId: dbqr.interaction_step_id.toString()
             });

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -31,22 +31,39 @@ const questionResponseActionHandler = async ({
   name,
   organization,
   questionResponse,
-  questionResponseInteractionStep,
+  interactionStep,
   campaign,
   contact,
-  questionResponsesStatus
+  wasDeleted,
+  previousValue
 }) => {
   const handler = await ActionHandlers.rawActionHandler(name);
-  // TODO: clean up processAction interface
-  await handler.processAction(
-    questionResponse,
-    questionResponseInteractionStep,
-    contact.id,
-    contact,
-    campaign,
-    organization,
-    questionResponsesStatus
-  );
+
+  if (!wasDeleted) {
+    // TODO: clean up processAction interface
+    return handler.processAction({
+      questionResponse,
+      interactionStep,
+      campaignContactId: contact.id,
+      contact,
+      campaign,
+      organization,
+      previousValue
+    });
+  } else if (
+    handler.processDeletedQuestionResponse &&
+    typeof handler.processDeletedQuestionResponse === "function"
+  ) {
+    return handler.processDeletedQuestionResponse({
+      questionResponse,
+      interactionStep,
+      campaignContactId: contact.id,
+      contact,
+      campaign,
+      organization,
+      previousValue
+    });
+  }
 };
 
 const tagUpdateActionHandler = async ({
@@ -64,16 +81,17 @@ const tagUpdateActionHandler = async ({
 const startCampaignCache = async ({ campaign, organization }) => {
   // Refresh all the campaign data into cache
   // This should refresh/clear any corruption
-  console.log("loadCampaignCache async tasks...", campaign.id);
   const loadAssignments = cacheableData.campaignContact.updateCampaignAssignmentCache(
     campaign.id
   );
   const loadContacts = cacheableData.campaignContact
     .loadMany(campaign, organization, {})
     .then(() => {
+      // eslint-disable-next-line no-console
       console.log("FINISHED contact loadMany", campaign.id);
     })
     .catch(err => {
+      // eslint-disable-next-line no-console
       console.error("ERROR contact loadMany", campaign.id, err, campaign);
     });
   const loadOptOuts = cacheableData.optOut.loadMany(organization.id);

--- a/src/workers/tasks.js
+++ b/src/workers/tasks.js
@@ -33,7 +33,8 @@ const questionResponseActionHandler = async ({
   questionResponse,
   questionResponseInteractionStep,
   campaign,
-  contact
+  contact,
+  questionResponsesStatus
 }) => {
   const handler = await ActionHandlers.rawActionHandler(name);
   // TODO: clean up processAction interface
@@ -43,7 +44,8 @@ const questionResponseActionHandler = async ({
     contact.id,
     contact,
     campaign,
-    organization
+    organization,
+    questionResponsesStatus
   );
 };
 


### PR DESCRIPTION
## Solution

- Have `cacheable_queries.QuestionResponse.save` return information about which question responses were
  - added or updated
  - deleted
- If a response was deleted, call processDeletedQuestionResponse
- If a response was updated, pass previousValue to the action handler
  - an action handler could use this to remove the previous response from the external system
  - no action handlers currently use this value
  
## Description of problem

I noticed that we call the action handlers for all preceding question responses each time another question response is added. This results in action handlers, such as the NGP VAN action handler, syncing the same contact with the same information repeatedly.  

Initial message is sent question 1 is asked.

```
Initial message / question 1
```

Contact responds, texter registers the answer and sends question 2.

```
Initial message / question 1
|
|-- response to question 1 / question 2 (action handler fires for Q1)
```

Contact responds again, texter registers the answer.  This is the buggy behavior. When the second question is answered, the action handlers fire for both the first and second questions.

```
Initial message / question 1
|
|-- response to question 1 / question 2 (action handler fires for Q1)
|
|----response to question 2 (action handler fires for Q2)
```

Better behavior, which is enabled by this PR, is to have only the action handler for Q2 fire when registering the response for Q2.

```
Initial message / question 1
|
|-- response to question 1 / question 2 
|
|----response to question 2 (action handler fires for Q2)
```


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
