### PR TITLE
update campaign.needsResponseCount when optout without a response

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -287,6 +287,7 @@ const rootSchema = gql`
     createOptOut(
       optOut: OptOutInput!
       campaignContactId: String!
+      noReply: Boolean
     ): CampaignContact
     editCampaignContactMessageStatus(
       messageStatus: String!

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -286,7 +286,11 @@ export class AssignmentTexterContact extends React.Component {
       };
 
       await this.handleSubmitSurveys();
-      await this.props.mutations.createOptOut(optOut, contact.id);
+      await this.props.mutations.createOptOut(
+        optOut,
+        contact.id,
+        !optOutMessageText.length
+      );
       this.props.onFinishContact(contact.id);
     } catch (err) {
       console.log("handleOptOut Error", err);
@@ -442,13 +446,18 @@ AssignmentTexterContact.propTypes = {
 };
 
 const mutations = {
-  createOptOut: ownProps => (optOut, campaignContactId) => ({
+  createOptOut: ownProps => (optOut, campaignContactId, noReply) => ({
     mutation: gql`
       mutation createOptOut(
         $optOut: OptOutInput!
         $campaignContactId: String!
+        $noReply: Boolean!
       ) {
-        createOptOut(optOut: $optOut, campaignContactId: $campaignContactId) {
+        createOptOut(
+          optOut: $optOut
+          campaignContactId: $campaignContactId
+          noReply: $noReply
+        ) {
           id
           optOut {
             id
@@ -459,7 +468,8 @@ const mutations = {
     `,
     variables: {
       optOut,
-      campaignContactId
+      campaignContactId,
+      noReply
     }
   }),
   createCannedResponse: ownProps => cannedResponse => ({

--- a/src/integrations/message-handlers/auto-optout/index.js
+++ b/src/integrations/message-handlers/auto-optout/index.js
@@ -64,6 +64,7 @@ export const postMessageSave = async ({ message, organization }) => {
         campaignContactId: message.campaign_contact_id,
         assignmentId: contact.assignment_id,
         campaign: { organization_id: organization.id },
+        noReply: true,
         reason
       });
     }

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1077,7 +1077,7 @@ const rootMutations = {
     },
     createOptOut: async (
       _,
-      { optOut, campaignContactId },
+      { optOut, campaignContactId, noReply },
       { loaders, user }
     ) => {
       const contact = await cacheableData.campaignContact.load(
@@ -1108,7 +1108,8 @@ const rootMutations = {
         campaignContactId,
         reason,
         assignmentId,
-        campaign
+        campaign,
+        noReply
       });
       console.log(
         "createOptOut post save",

--- a/src/server/models/cacheable_queries/opt-out.js
+++ b/src/server/models/cacheable_queries/opt-out.js
@@ -1,4 +1,5 @@
 import { r, OptOut } from "../../models";
+import campaignCache from "./campaign";
 
 // STRUCTURE
 // SET by organization, so optout-<organization_id> has a <cell> key
@@ -105,7 +106,14 @@ const optOutCache = {
       .limit(1);
     return dbResult.length > 0;
   },
-  save: async ({ cell, campaignContactId, campaign, assignmentId, reason }) => {
+  save: async ({
+    cell,
+    campaignContactId,
+    campaign,
+    assignmentId,
+    reason,
+    noReply
+  }) => {
     const organizationId = campaign.organization_id;
     if (r.redis) {
       const hashKey = orgCacheKey(organizationId);
@@ -144,6 +152,9 @@ const optOutCache = {
       .update({
         is_opted_out: true
       });
+    if (noReply) {
+      await campaignCache.incrCount(campaign.id, "needsResponseCount", -1);
+    }
   },
   loadMany
 };


### PR DESCRIPTION
# Fixes needsResponseCount out of sync with optouts (auto and no message)

## Description

When there's an optout without a reply, the campaign.needsResponseCount doesn't update, but we need to decrement it.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
