### PR TITLE
Fix VAN action handler with warehouse loader

### DIFF
--- a/src/integrations/action-handlers/ngpvan-action.js
+++ b/src/integrations/action-handlers/ngpvan-action.js
@@ -40,7 +40,8 @@ export function clientChoiceDataCacheKey(organization) {
 export const postCanvassResponse = async (contact, organization, body) => {
   let vanId;
   try {
-    vanId = JSON.parse(contact.custom_fields || "{}").VanID;
+    const customFields = JSON.parse(contact.custom_fields || "{}");
+    vanId = customFields.VanID || customFields.vanid;
   } catch (caughtException) {
     // eslint-disable-next-line no-console
     console.error(


### PR DESCRIPTION

## Description

Fixes a minor bug. Redshift forces column names to be all lower case, so the VAN action handler wasn't working for contacts from the data warehouse contact loader, because it saw `vanid` instead of `VanID`.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
