### PR TITLE
Feature #1645: Canned response tag association

### DIFF
--- a/__test__/components/CampaignCannedResponseForm.test.js
+++ b/__test__/components/CampaignCannedResponseForm.test.js
@@ -14,13 +14,38 @@ describe("CampaignCannedResponseForm component", () => {
     defaultValue: {
       id: 1,
       title: "Response1",
-      text: "Response1 desc"
-    }
+      text: "Response1 desc",
+      tagIds: [1, 2]
+    },
+    tags: [
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]
   };
 
   const props2 = {
     formButtonText: "Add Response",
-    defaultValue: {}
+    defaultValue: {},
+    tags: [
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]
   };
 
   // when
@@ -43,6 +68,19 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Edit Response");
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 
   test("Renders form with correct fields and label for adding", () => {
@@ -64,5 +102,18 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Add Response");
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([]);
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 });

--- a/__test__/components/CampaignCannedResponseForm.test.js
+++ b/__test__/components/CampaignCannedResponseForm.test.js
@@ -68,21 +68,19 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Edit Response");
-    if (process.env.EXPERIMENTAL_TAGS) {
-      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
-      expect(wrapper.find("TagChips").prop("tags")).toEqual([
-        {
-          id: 1,
-          name: "Tag1",
-          description: "Tag1Desc"
-        },
-        {
-          id: 2,
-          name: "Tag2",
-          description: "Tag2Desc"
-        }
-      ]);
-    }
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 
   test("Renders form with correct fields and label for adding", () => {
@@ -104,20 +102,18 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Add Response");
-    if (process.env.EXPERIMENTAL_TAGS) {
-      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([]);
-      expect(wrapper.find("TagChips").prop("tags")).toEqual([
-        {
-          id: 1,
-          name: "Tag1",
-          description: "Tag1Desc"
-        },
-        {
-          id: 2,
-          name: "Tag2",
-          description: "Tag2Desc"
-        }
-      ]);
-    }
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([]);
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 });

--- a/__test__/components/CampaignCannedResponseForm.test.js
+++ b/__test__/components/CampaignCannedResponseForm.test.js
@@ -68,19 +68,21 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Edit Response");
-    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
-    expect(wrapper.find("TagChips").prop("tags")).toEqual([
-      {
-        id: 1,
-        name: "Tag1",
-        description: "Tag1Desc"
-      },
-      {
-        id: 2,
-        name: "Tag2",
-        description: "Tag2Desc"
-      }
-    ]);
+    if (process.env.EXPERIMENTAL_TAGS) {
+      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+      expect(wrapper.find("TagChips").prop("tags")).toEqual([
+        {
+          id: 1,
+          name: "Tag1",
+          description: "Tag1Desc"
+        },
+        {
+          id: 2,
+          name: "Tag2",
+          description: "Tag2Desc"
+        }
+      ]);
+    }
   });
 
   test("Renders form with correct fields and label for adding", () => {
@@ -102,18 +104,20 @@ describe("CampaignCannedResponseForm component", () => {
         .find("button")
         .text()
     ).toBe("Add Response");
-    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([]);
-    expect(wrapper.find("TagChips").prop("tags")).toEqual([
-      {
-        id: 1,
-        name: "Tag1",
-        description: "Tag1Desc"
-      },
-      {
-        id: 2,
-        name: "Tag2",
-        description: "Tag2Desc"
-      }
-    ]);
+    if (process.env.EXPERIMENTAL_TAGS) {
+      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([]);
+      expect(wrapper.find("TagChips").prop("tags")).toEqual([
+        {
+          id: 1,
+          name: "Tag1",
+          description: "Tag1Desc"
+        },
+        {
+          id: 2,
+          name: "Tag2",
+          description: "Tag2Desc"
+        }
+      ]);
+    }
   });
 });

--- a/__test__/components/CampaignCannedResponsesForm.test.js
+++ b/__test__/components/CampaignCannedResponsesForm.test.js
@@ -48,23 +48,23 @@ describe("CampaignCannedResponsesForm component", () => {
 
   test("Renders canned responses with correct text", () => {
     expect(wrapper.find("ListItem").text()).toContain("Response1");
-
     expect(wrapper.find("ListItem").text()).toContain("Response1 desc");
 
-    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
-
-    expect(wrapper.find("TagChips").prop("tags")).toEqual([
-      {
-        id: 1,
-        name: "Tag1",
-        description: "Tag1Desc"
-      },
-      {
-        id: 2,
-        name: "Tag2",
-        description: "Tag2Desc"
-      }
-    ]);
+    if (process.env.EXPERIMENTAL_TAGS) {
+      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+      expect(wrapper.find("TagChips").prop("tags")).toEqual([
+        {
+          id: 1,
+          name: "Tag1",
+          description: "Tag1Desc"
+        },
+        {
+          id: 2,
+          name: "Tag2",
+          description: "Tag2Desc"
+        }
+      ]);
+    }
   });
 
   test("Renders CampaignCannedResponseForm component for editing when edit icon clicked", () => {

--- a/__test__/components/CampaignCannedResponsesForm.test.js
+++ b/__test__/components/CampaignCannedResponsesForm.test.js
@@ -4,7 +4,7 @@
 import React from "react";
 import { mount } from "enzyme";
 import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
-import CampaignCannedResponsesForm from "../../src/components/CampaignCannedResponsesForm";
+import { CampaignCannedResponsesForm } from "../../src/components/CampaignCannedResponsesForm";
 import { StyleSheetTestUtils } from "aphrodite";
 
 describe("CampaignCannedResponsesForm component", () => {
@@ -14,26 +14,57 @@ describe("CampaignCannedResponsesForm component", () => {
       {
         id: 1,
         title: "Response1",
-        text: "Response1 desc"
+        text: "Response1 desc",
+        tagIds: [1, 2]
       }
     ]
+  };
+
+  const data = {
+    organization: {
+      tags: [
+        {
+          id: 1,
+          name: "Tag1",
+          description: "Tag1Desc"
+        },
+        {
+          id: 2,
+          name: "Tag2",
+          description: "Tag2Desc"
+        }
+      ]
+    }
   };
 
   StyleSheetTestUtils.suppressStyleInjection();
   const wrapper = mount(
     <MuiThemeProvider>
-      <CampaignCannedResponsesForm formValues={formValues} />
+      <CampaignCannedResponsesForm formValues={formValues} data={data} />
     </MuiThemeProvider>
   );
 
   // when
 
   test("Renders canned responses with correct text", () => {
-    expect(wrapper.find("ListItem").prop("primaryText")).toBe("Response1");
+    expect(wrapper.find("ListItem").text()).toContain("Response1");
 
-    expect(wrapper.find("ListItem").prop("secondaryText")).toBe(
-      "Response1 desc"
-    );
+    expect(wrapper.find("ListItem").text()).toContain("Response1 desc");
+
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 
   test("Renders CampaignCannedResponseForm component for editing when edit icon clicked", () => {
@@ -48,7 +79,8 @@ describe("CampaignCannedResponsesForm component", () => {
     expect(cannedResponseForm.prop("defaultValue")).toEqual({
       id: 1,
       title: "Response1",
-      text: "Response1 desc"
+      text: "Response1 desc",
+      tagIds: [1, 2]
     });
     expect(cannedResponseForm.prop("formButtonText")).toBe("Edit Response");
   });

--- a/__test__/components/CampaignCannedResponsesForm.test.js
+++ b/__test__/components/CampaignCannedResponsesForm.test.js
@@ -49,22 +49,19 @@ describe("CampaignCannedResponsesForm component", () => {
   test("Renders canned responses with correct text", () => {
     expect(wrapper.find("ListItem").text()).toContain("Response1");
     expect(wrapper.find("ListItem").text()).toContain("Response1 desc");
-
-    if (process.env.EXPERIMENTAL_TAGS) {
-      expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
-      expect(wrapper.find("TagChips").prop("tags")).toEqual([
-        {
-          id: 1,
-          name: "Tag1",
-          description: "Tag1Desc"
-        },
-        {
-          id: 2,
-          name: "Tag2",
-          description: "Tag2Desc"
-        }
-      ]);
-    }
+    expect(wrapper.find("TagChips").prop("tagIds")).toEqual([1, 2]);
+    expect(wrapper.find("TagChips").prop("tags")).toEqual([
+      {
+        id: 1,
+        name: "Tag1",
+        description: "Tag1Desc"
+      },
+      {
+        id: 2,
+        name: "Tag2",
+        description: "Tag2Desc"
+      }
+    ]);
   });
 
   test("Renders CampaignCannedResponseForm component for editing when edit icon clicked", () => {

--- a/__test__/components/TagChips.test.js
+++ b/__test__/components/TagChips.test.js
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+import React from "react";
+import { mount } from "enzyme";
+import MuiThemeProvider from "material-ui/styles/MuiThemeProvider";
+import TagChips from "../../src/components/TagChips";
+import { StyleSheetTestUtils } from "aphrodite";
+
+describe("TagChips component", () => {
+  // given
+
+  const tags = [
+    {
+      id: 1,
+      name: "Tag1"
+    },
+    {
+      id: 2,
+      name: "Tag2"
+    }
+  ];
+
+  const tagIds = [1, 2, 3];
+
+  StyleSheetTestUtils.suppressStyleInjection();
+  const wrapper = mount(
+    <MuiThemeProvider>
+      <TagChips tags={tags} tagIds={tagIds} />
+    </MuiThemeProvider>
+  );
+
+  // when
+
+  test("Renders TagChip components with correct text if a tagId is present", () => {
+    expect(
+      wrapper
+        .find("TagChip")
+        .at(0)
+        .prop("text")
+    ).toBe("Tag1");
+    expect(
+      wrapper
+        .find("TagChip")
+        .at(1)
+        .prop("text")
+    ).toBe("Tag2");
+    expect(
+      wrapper
+        .find("TagChip")
+        .at(2)
+        .exists()
+    ).toBeFalsy();
+  });
+});

--- a/__test__/server/api/campaign/campaign.test.js
+++ b/__test__/server/api/campaign/campaign.test.js
@@ -364,7 +364,6 @@ it("should save campaign canned responses across copies and match saved data", a
     { campaignId: testCampaign.id },
     testAdminUser
   );
-
   expect(campaignDataResults.data.campaign.cannedResponses.length).toEqual(6);
   for (let i = 0; i < 6; i++) {
     expect(campaignDataResults.data.campaign.cannedResponses[i].title).toEqual(

--- a/__test__/server/api/updateContactTags.test.js
+++ b/__test__/server/api/updateContactTags.test.js
@@ -146,7 +146,9 @@ describe("mutations.updateContactTags", () => {
       );
 
       expect(result.errors[0].message).toEqual(
-        expect.stringMatching(/^Cannot convert `undefined`.*/)
+        expect.stringMatching(
+          /^The loader.load\(\) function must be called with a value,but got: undefined.*/
+        )
       );
 
       expect(console.error).toHaveBeenCalledTimes(1); // eslint-disable-line no-console

--- a/__test__/server/db/utils.js
+++ b/__test__/server/db/utils.js
@@ -15,7 +15,9 @@ export const tables = [
   "canned_response",
   "opt_out",
   "question_response",
-  "campaign_contact"
+  "campaign_contact",
+  "tag",
+  "tag_canned_response"
 ];
 
 // Adapted from https://dba.stackexchange.com/a/37068

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -662,6 +662,9 @@ export const getConversations = async (
                   text
                   isFromContact
                 }
+                tags {
+                  id
+                }
                 optOut {
                   cell
                 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -27,7 +27,8 @@ module.exports = {
     TWILIO_MESSAGE_SERVICE_SID: "TEST_MESSAGE_SID",
     TEST_ENVIRONMENT: "1",
     TEST_ENVIRONMENT_FAKE: "0",
-    TEST_ENVIRONMENT_FAKE2: "false"
+    TEST_ENVIRONMENT_FAKE2: "false",
+    EXPERIMENTAL_TAGS: "1"
   },
   moduleFileExtensions: ["js", "jsx"],
   transform: {

--- a/migrations/20200701185642_addTagCannedResponseTable.js
+++ b/migrations/20200701185642_addTagCannedResponseTable.js
@@ -1,0 +1,23 @@
+exports.up = async knex => {
+  await knex.schema.createTable("tag_canned_response", table => {
+    table.increments();
+    table
+      .integer("canned_response_id")
+      .notNullable()
+      .references("id")
+      .inTable("canned_response")
+      .index();
+    table
+      .integer("tag_id")
+      .notNullable()
+      .references("id")
+      .inTable("tag");
+
+    table.timestamp("created_at").defaultTo(knex.fn.now());
+    table.unique(["canned_response_id", "tag_id"]);
+  });
+};
+
+exports.down = async knex => {
+  await knex.schema.dropTable("tag_canned_response");
+};

--- a/src/api/canned-response.js
+++ b/src/api/canned-response.js
@@ -13,6 +13,6 @@ export const schema = `
     title: String
     text: String
     isUserCreated: Boolean
-    tags: [Tag]
+    tagIds: [ID]
   }
 `;

--- a/src/api/canned-response.js
+++ b/src/api/canned-response.js
@@ -5,6 +5,7 @@ export const schema = `
     text: String
     campaignId: String
     userId: String
+    tagIds: [Int]
   }
 
   type CannedResponse {
@@ -12,5 +13,6 @@ export const schema = `
     title: String
     text: String
     isUserCreated: Boolean
+    tags: [Tag]
   }
 `;

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -288,6 +288,7 @@ const rootSchema = gql`
     sendMessage(
       message: MessageInput!
       campaignContactId: String!
+      cannedResponseId: String
     ): CampaignContact
     createOptOut(
       optOut: OptOutInput!

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -582,13 +582,16 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   renderMessagingRowMessage() {
+    const { cannedResponseScript } = this.state;
     return (
       <div className={css(flexStyles.sectionMessageField)}>
         <GSForm
           ref="form"
           schema={this.messageSchema}
           value={{ messageText: this.state.messageText }}
-          onSubmit={this.props.onMessageFormSubmit}
+          onSubmit={this.props.onMessageFormSubmit(
+            cannedResponseScript && cannedResponseScript.id
+          )}
           onChange={
             this.state.messageReadOnly
               ? null // message is uneditable for firstMessage

--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -71,35 +71,39 @@ export default class CannedResponseForm extends React.Component {
             multiLine
             fullWidth
           />
-          <AutoComplete
-            ref="autocompleteInput"
-            floatingLabelText="Tags"
-            filter={AutoComplete.fuzzyFilter}
-            dataSource={
-              tags && tags.filter(t => this.state.tagIds.indexOf(t.id) === -1)
-            }
-            maxSearchResults={8}
-            onNewRequest={({ id }) => {
-              this.refs.autocompleteInput.setState({ searchText: "" });
-              this.setState({ tagIds: [...this.state.tagIds, id] });
-            }}
-            dataSourceConfig={{
-              text: "name",
-              value: "id"
-            }}
-            fullWidth
-          />
-          <TagChips
-            tags={tags}
-            tagIds={this.state.tagIds}
-            onRequestDelete={listedTag => {
-              this.setState({
-                tagIds: this.state.tagIds.filter(
-                  tagId => tagId !== listedTag.id
-                )
-              });
-            }}
-          />
+          {window.EXPERIMENTAL_TAGS && (
+            <AutoComplete
+              ref="autocompleteInput"
+              floatingLabelText="Tags"
+              filter={AutoComplete.fuzzyFilter}
+              dataSource={
+                tags && tags.filter(t => this.state.tagIds.indexOf(t.id) === -1)
+              }
+              maxSearchResults={8}
+              onNewRequest={({ id }) => {
+                this.refs.autocompleteInput.setState({ searchText: "" });
+                this.setState({ tagIds: [...this.state.tagIds, id] });
+              }}
+              dataSourceConfig={{
+                text: "name",
+                value: "id"
+              }}
+              fullWidth
+            />
+          )}
+          {window.EXPERIMENTAL_TAGS && (
+            <TagChips
+              tags={tags}
+              tagIds={this.state.tagIds}
+              onRequestDelete={listedTag => {
+                this.setState({
+                  tagIds: this.state.tagIds.filter(
+                    tagId => tagId !== listedTag.id
+                  )
+                });
+              }}
+            />
+          )}
           <div className={css(styles.buttonRow)}>
             <FlatButton
               {...dataTest("addResponse")}

--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -37,8 +37,7 @@ export default class CannedResponseForm extends React.Component {
   render() {
     const modelSchema = yup.object({
       title: yup.string().required(),
-      text: yup.string().required(),
-      tags: yup.string()
+      text: yup.string().required()
     });
 
     const {
@@ -76,9 +75,9 @@ export default class CannedResponseForm extends React.Component {
             ref="autocompleteInput"
             floatingLabelText="Tags"
             filter={AutoComplete.fuzzyFilter}
-            dataSource={tags.filter(
-              t => this.state.tagIds.indexOf(t.id) === -1
-            )}
+            dataSource={
+              tags && tags.filter(t => this.state.tagIds.indexOf(t.id) === -1)
+            }
             maxSearchResults={8}
             onNewRequest={({ id }) => {
               this.refs.autocompleteInput.setState({ searchText: "" });

--- a/src/components/CampaignCannedResponseForm.jsx
+++ b/src/components/CampaignCannedResponseForm.jsx
@@ -5,33 +5,47 @@ import yup from "yup";
 import GSForm from "./forms/GSForm";
 import Form from "react-formal";
 import FlatButton from "material-ui/FlatButton";
+import AutoComplete from "material-ui/AutoComplete";
 import { dataTest } from "../lib/attributes";
 import theme from "../styles/theme";
+import TagChips from "./TagChips";
 
 const styles = StyleSheet.create({
   buttonRow: {
     marginTop: 5
+  },
+  tagChips: {
+    display: "flex",
+    flexWrap: "wrap"
   }
 });
 
 // THIS IS A COPY/PASTE FROM CANNED RESPONSE FORM BECAUSE I CANT MAKE FORM.CONTEXT WORK
-class CannedResponseForm extends React.Component {
-  handleSave = formValues => {
+export default class CannedResponseForm extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      ...this.props.defaultValue,
+      tagIds: this.props.defaultValue.tagIds || []
+    };
+  }
+  handleSave = () => {
     const { onSaveCannedResponse } = this.props;
-    onSaveCannedResponse(formValues);
+    onSaveCannedResponse(this.state);
   };
 
   render() {
     const modelSchema = yup.object({
       title: yup.string().required(),
-      text: yup.string().required()
+      text: yup.string().required(),
+      tags: yup.string()
     });
 
     const {
       customFields,
       handleCloseAddForm,
       formButtonText,
-      defaultValue
+      tags
     } = this.props;
     return (
       <div>
@@ -39,7 +53,8 @@ class CannedResponseForm extends React.Component {
           ref="form"
           schema={modelSchema}
           onSubmit={this.handleSave}
-          defaultValue={defaultValue}
+          defaultValue={this.state}
+          onChange={v => this.setState(v)}
         >
           <Form.Field
             {...dataTest("title")}
@@ -56,6 +71,35 @@ class CannedResponseForm extends React.Component {
             label="Script"
             multiLine
             fullWidth
+          />
+          <AutoComplete
+            ref="autocompleteInput"
+            floatingLabelText="Tags"
+            filter={AutoComplete.fuzzyFilter}
+            dataSource={tags.filter(
+              t => this.state.tagIds.indexOf(t.id) === -1
+            )}
+            maxSearchResults={8}
+            onNewRequest={({ id }) => {
+              this.refs.autocompleteInput.setState({ searchText: "" });
+              this.setState({ tagIds: [...this.state.tagIds, id] });
+            }}
+            dataSourceConfig={{
+              text: "name",
+              value: "id"
+            }}
+            fullWidth
+          />
+          <TagChips
+            tags={tags}
+            tagIds={this.state.tagIds}
+            onRequestDelete={listedTag => {
+              this.setState({
+                tagIds: this.state.tagIds.filter(
+                  tagId => tagId !== listedTag.id
+                )
+              });
+            }}
           />
           <div className={css(styles.buttonRow)}>
             <FlatButton
@@ -90,7 +134,6 @@ CannedResponseForm.propTypes = {
   handleCloseAddForm: type.func,
   customFields: type.array,
   formButtonText: type.string,
-  defaultValue: type.object
+  defaultValue: type.object,
+  tags: type.array
 };
-
-export default CannedResponseForm;

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -168,12 +168,14 @@ export class CampaignCannedResponsesForm extends React.Component {
       >
         <div className={css(styles.title)}>{response.title}</div>
         <div className={css(styles.text)}>{response.text}</div>
-        {response.tagIds && response.tagIds.length > 0 && (
-          <TagChips
-            tags={this.props.data.organization.tags}
-            tagIds={response.tagIds}
-          />
-        )}
+        {window.EXPERIMENTAL_TAGS &&
+          response.tagIds &&
+          response.tagIds.length > 0 && (
+            <TagChips
+              tags={this.props.data.organization.tags}
+              tagIds={response.tagIds}
+            />
+          )}
       </ListItem>
     ));
     return listItems;

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -14,6 +14,9 @@ import yup from "yup";
 import theme from "../styles/theme";
 import { StyleSheet, css } from "aphrodite";
 import { dataTest } from "../lib/attributes";
+import loadData from "../containers/hoc/load-data";
+import gql from "graphql-tag";
+import TagChips from "./TagChips";
 
 const styles = StyleSheet.create({
   formContainer: {
@@ -29,10 +32,20 @@ const styles = StyleSheet.create({
   form: {
     backgroundColor: theme.colors.white,
     padding: 10
+  },
+  title: {
+    marginBottom: 8
+  },
+  text: {
+    fontSize: 14,
+    color: theme.colors.gray,
+    marginBottom: 8,
+    overflow: "hidden",
+    height: 32
   }
 });
 
-export default class CampaignCannedResponsesForm extends React.Component {
+export class CampaignCannedResponsesForm extends React.Component {
   state = {
     showForm: false,
     formButtonText: "",
@@ -86,7 +99,9 @@ export default class CampaignCannedResponsesForm extends React.Component {
                 });
                 this.setState({ showForm: false });
               }}
+              organizationId={this.props.organizationId}
               customFields={this.props.customFields}
+              tags={this.props.data.organization.tags}
             />
           </div>
         </div>
@@ -115,8 +130,6 @@ export default class CampaignCannedResponsesForm extends React.Component {
         {...dataTest("cannedResponse")}
         value={response.text}
         key={response.id}
-        primaryText={response.title}
-        secondaryText={response.text}
         rightIconButton={
           <span>
             <IconButton
@@ -151,7 +164,16 @@ export default class CampaignCannedResponsesForm extends React.Component {
           </span>
         }
         secondaryTextLines={2}
-      />
+      >
+        <div className={css(styles.title)}>{response.title}</div>
+        <div className={css(styles.text)}>{response.text}</div>
+        {response.tagIds.length > 0 && (
+          <TagChips
+            tags={this.props.data.organization.tags}
+            tagIds={response.tagIds}
+          />
+        )}
+      </ListItem>
     ));
     return listItems;
   }
@@ -166,7 +188,6 @@ export default class CampaignCannedResponsesForm extends React.Component {
           <Divider />
         </List>
       );
-
     return (
       <GSForm
         schema={this.formSchema}
@@ -196,5 +217,34 @@ CampaignCannedResponsesForm.propTypes = {
   onSubmit: type.func,
   onChange: type.func,
   formValues: type.object,
-  customFields: type.array
+  customFields: type.array,
+  organizationId: type.string,
+  data: type.object
 };
+
+const queries = {
+  data: {
+    query: gql`
+      query getTags($organizationId: String!) {
+        organization(id: $organizationId) {
+          id
+          tags {
+            id
+            name
+            group
+            description
+            isDeleted
+          }
+        }
+      }
+    `,
+    options: ownProps => ({
+      variables: {
+        organizationId: ownProps.organizationId
+      },
+      fetchPolicy: "network-only"
+    })
+  }
+};
+
+export default loadData({ queries })(CampaignCannedResponsesForm);

--- a/src/components/CampaignCannedResponsesForm.jsx
+++ b/src/components/CampaignCannedResponsesForm.jsx
@@ -40,6 +40,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: theme.colors.gray,
     marginBottom: 8,
+    display: "-webkit-box",
+    WebkitBoxOrient: "vertical",
+    WebkitLineClamp: 2,
     overflow: "hidden",
     height: 32
   }
@@ -99,7 +102,6 @@ export class CampaignCannedResponsesForm extends React.Component {
                 });
                 this.setState({ showForm: false });
               }}
-              organizationId={this.props.organizationId}
               customFields={this.props.customFields}
               tags={this.props.data.organization.tags}
             />
@@ -163,11 +165,10 @@ export class CampaignCannedResponsesForm extends React.Component {
             </IconButton>
           </span>
         }
-        secondaryTextLines={2}
       >
         <div className={css(styles.title)}>{response.title}</div>
         <div className={css(styles.text)}>{response.text}</div>
-        {response.tagIds.length > 0 && (
+        {response.tagIds && response.tagIds.length > 0 && (
           <TagChips
             tags={this.props.data.organization.tags}
             tagIds={response.tagIds}

--- a/src/components/TagChips.jsx
+++ b/src/components/TagChips.jsx
@@ -1,0 +1,38 @@
+import React from "react";
+import TagChip from "./TagChip";
+import type from "prop-types";
+import { StyleSheet, css } from "aphrodite";
+
+const styles = StyleSheet.create({
+  tagChips: {
+    display: "flex",
+    flexWrap: "wrap"
+  }
+});
+
+const TagChips = ({ tags, tagIds, onRequestDelete }) => (
+  <div className={css(styles.tagChips)}>
+    {tagIds.map(id => {
+      const listedTag = tags.find(t => t.id === id);
+      return (
+        <TagChip
+          text={listedTag.name}
+          onRequestDelete={
+            onRequestDelete ? () => onRequestDelete(listedTag) : null
+          }
+          deleteIconStyle={{
+            marginBottom: "4px"
+          }}
+        />
+      );
+    })}
+  </div>
+);
+
+TagChips.propTypes = {
+  tags: type.array,
+  tagIds: type.array,
+  onRequestDelete: type.func
+};
+
+export default TagChips;

--- a/src/components/TagChips.jsx
+++ b/src/components/TagChips.jsx
@@ -15,15 +15,18 @@ const TagChips = ({ tags, tagIds, onRequestDelete }) => (
     {tagIds.map(id => {
       const listedTag = tags.find(t => t.id === id);
       return (
-        <TagChip
-          text={listedTag.name}
-          onRequestDelete={
-            onRequestDelete ? () => onRequestDelete(listedTag) : null
-          }
-          deleteIconStyle={{
-            marginBottom: "4px"
-          }}
-        />
+        listedTag && (
+          <TagChip
+            key={id}
+            text={listedTag.name}
+            onRequestDelete={
+              onRequestDelete ? () => onRequestDelete(listedTag) : null
+            }
+            deleteIconStyle={{
+              marginBottom: "4px"
+            }}
+          />
+        )
       );
     })}
   </div>

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -459,7 +459,8 @@ export class AdminCampaignEdit extends React.Component {
         expandAfterCampaignStarts: true,
         expandableBySuperVolunteers: true,
         extraProps: {
-          customFields: this.props.campaignData.campaign.customFields
+          customFields: this.props.campaignData.campaign.customFields,
+          organizationId: this.props.organizationData.organization.id
         }
       },
       {

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -79,6 +79,7 @@ const campaignInfoFragment = `
     id
     title
     text
+    tagIds
   }
   ingestMethodsAvailable {
     name

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -158,7 +158,7 @@ export class AssignmentTexterContact extends React.Component {
     }
   };
 
-  handleMessageFormSubmit = async ({ messageText }) => {
+  handleMessageFormSubmit = cannedResponseId => async ({ messageText }) => {
     const { contact, messageStatusFilter } = this.props;
     try {
       const message = this.createMessageToContact(messageText);
@@ -175,11 +175,17 @@ export class AssignmentTexterContact extends React.Component {
         // thinks they completed sending, but there are still waiting requests
         // This probably needs some interface tweaks to communicate something
         // to the texter.
-        this.props.mutations.sendMessage(message, contact.id).then(() => {
-          console.log("sentMessage", contact.id);
-        });
+        this.props.mutations
+          .sendMessage(message, contact.id, cannedResponseId)
+          .then(() => {
+            console.log("sentMessage", contact.id);
+          });
       } else {
-        await this.props.mutations.sendMessage(message, contact.id);
+        await this.props.mutations.sendMessage(
+          message,
+          contact.id,
+          cannedResponseId
+        );
         await this.handleSubmitSurveys();
       }
       this.props.onFinishContact(contact.id);
@@ -561,13 +567,18 @@ const mutations = {
       campaignContactId
     }
   }),
-  sendMessage: ownProps => (message, campaignContactId) => ({
+  sendMessage: ownProps => (message, campaignContactId, cannedResponseId) => ({
     mutation: gql`
       mutation sendMessage(
         $message: MessageInput!
         $campaignContactId: String!
+        $cannedResponseId: String
       ) {
-        sendMessage(message: $message, campaignContactId: $campaignContactId) {
+        sendMessage(
+          message: $message
+          campaignContactId: $campaignContactId
+          cannedResponseId: $cannedResponseId
+        ) {
           id
           messageStatus
           messages {
@@ -581,7 +592,8 @@ const mutations = {
     `,
     variables: {
       message,
-      campaignContactId
+      campaignContactId,
+      cannedResponseId
     }
   }),
   bulkSendMessages: ownProps => assignmentId => ({

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -52,6 +52,25 @@ export const campaignQuery = gql`
   ) {
     assignment(assignmentId: $assignmentId, contactId: $contactId) {
       id
+      userCannedResponses {
+        id
+        title
+        text
+        isUserCreated
+      }
+      campaignCannedResponses {
+        id
+        title
+        text
+        isUserCreated
+        tagIds
+      }
+      texter {
+        id
+        firstName
+        lastName
+        alias
+      }
       campaign {
         id
         title

--- a/src/server/api/canned-response.js
+++ b/src/server/api/canned-response.js
@@ -4,7 +4,8 @@ import { CannedResponse } from "../models";
 export const resolvers = {
   CannedResponse: {
     ...mapFieldsToModel(["id", "title", "text"], CannedResponse),
-    isUserCreated: cannedResponse => cannedResponse.user_id !== ""
+    isUserCreated: cannedResponse => cannedResponse.user_id !== "",
+    tagIds: cannedResponse => cannedResponse.tagIds || []
   }
 };
 

--- a/src/server/api/lib/utils.js
+++ b/src/server/api/lib/utils.js
@@ -30,3 +30,20 @@ export const capitalizeWord = word => {
   }
   return "";
 };
+
+export const groupCannedResponses = cannedResponses => {
+  const grouped = [];
+  let current = null;
+  cannedResponses.forEach(result => {
+    const res = { ...result };
+    if (!current || res.id !== current.id) {
+      res.tagIds = [];
+      grouped.push(res);
+      current = res;
+    }
+    if (res.tag_id) {
+      current.tagIds.push(res.tag_id);
+    }
+  });
+  return grouped;
+};

--- a/src/server/api/mutations/bulkSendMessages.js
+++ b/src/server/api/mutations/bulkSendMessages.js
@@ -84,7 +84,7 @@ export const bulkSendMessages = async (
     return sendMessage(
       undefined,
       { message: contactMessage, campaignContactId: contact.id },
-      { user }
+      { user, loaders }
     );
   });
 

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -5,6 +5,7 @@ import { Message, cacheableData } from "../../models";
 import { getSendBeforeTimeUtc } from "../../../lib/timezones";
 import { jobRunner } from "../../../extensions/job-runners";
 import { Tasks } from "../../../workers/tasks";
+import { updateContactTags } from "./updateContactTags";
 
 const JOBS_SAME_PROCESS = !!(
   process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
@@ -12,12 +13,12 @@ const JOBS_SAME_PROCESS = !!(
 
 export const sendMessage = async (
   _,
-  { message, campaignContactId },
-  { user }
+  { message, campaignContactId, cannedResponseId },
+  { user, loaders }
 ) => {
   // contact is mutated, so we don't use a loader
   let contact = await cacheableData.campaignContact.load(campaignContactId);
-  const campaign = await cacheableData.campaign.load(contact.campaign_id);
+  const campaign = await loaders.campaign.load(contact.campaign_id);
   if (
     contact.assignment_id !== parseInt(message.assignmentId) ||
     campaign.is_archived
@@ -28,7 +29,7 @@ export const sendMessage = async (
       message: "Your assignment has changed"
     });
   }
-  const organization = await cacheableData.organization.load(
+  const organization = await loaders.organization.load(
     campaign.organization_id
   );
   const orgFeatures = JSON.parse(organization.features || "{}");
@@ -132,7 +133,8 @@ export const sendMessage = async (
     contact,
     campaign,
     organization,
-    texter: user
+    texter: user,
+    cannedResponseId
   });
   if (!saveResult.message) {
     throw new GraphQLError(
@@ -150,6 +152,34 @@ export const sendMessage = async (
       organization,
       campaign
     });
+  }
+
+  if (cannedResponseId) {
+    const cannedResponses = await cacheableData.cannedResponse.query({
+      campaignId: campaign.id,
+      cannedResponseId
+    });
+    if (cannedResponses && cannedResponses.length) {
+      const cannedResponse = cannedResponses.find(
+        res => res.id === Number(cannedResponseId)
+      );
+      if (
+        cannedResponse &&
+        cannedResponse.tagIds &&
+        cannedResponse.tagIds.length
+      ) {
+        await updateContactTags(
+          null,
+          {
+            campaignContactId,
+            tags: cannedResponse.tagIds.map(t => ({
+              id: t
+            }))
+          },
+          { user, loaders }
+        );
+      }
+    }
   }
 
   if (initialMessageStatus === "needsMessage") {

--- a/src/server/api/mutations/updateContactTags.js
+++ b/src/server/api/mutations/updateContactTags.js
@@ -7,12 +7,12 @@ const ActionHandlers = require("../../../extensions/action-handlers");
 export const updateContactTags = async (
   _,
   { tags, campaignContactId },
-  { user }
+  { user, loaders }
 ) => {
   let contact;
   try {
     contact = await cacheableData.campaignContact.load(campaignContactId);
-    const campaign = await cacheableData.campaign.load(contact.campaign_id);
+    const campaign = await loaders.campaign.load(contact.campaign_id);
     await assignmentRequiredOrAdminRole(
       user,
       campaign.organization_id,
@@ -22,7 +22,7 @@ export const updateContactTags = async (
 
     await cacheableData.tagCampaignContact.save(campaignContactId, tags);
 
-    const organization = await cacheableData.organization.load(
+    const organization = await loaders.organization.load(
       campaign.organization_id
     );
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -310,13 +310,15 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
         id: undefined
       });
     }
-
+    // run in a transaction
+    // delete from tag_canned_response for campaign_id knex
     await r
       .table("canned_response")
       .getAll(id, { index: "campaign_id" })
       .filter({ user_id: "" })
       .delete();
     await CannedResponse.save(convertedResponses);
+    // also save tag_ids
     await cacheableData.cannedResponse.clearQuery({
       userId: "",
       campaignId: id
@@ -840,7 +842,7 @@ const rootMutations = {
         campaign,
         {}
       );
-
+      // join tag_canned_response, copy any tag_canned_response rows
       const originalCannedResponses = await r
         .knex("canned_response")
         .where({ campaign_id: oldCampaignId });

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -2,7 +2,7 @@ import GraphQLDate from "graphql-date";
 import GraphQLJSON from "graphql-type-json";
 import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
-
+import _ from "lodash";
 import { gzip, makeTree, getHighestRole } from "../../lib";
 import { capitalizeWord, groupCannedResponses } from "./lib/utils";
 import twilio from "./lib/twilio";
@@ -338,13 +338,13 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
         convertedResponses.map(async response => {
           const { tagIds, ...filteredResponse } = response;
           const responseId = await saveCannedResponse(filteredResponse);
-          return tagIds.map(t => ({
+          return (tagIds || []).map(t => ({
             tag_id: t,
             canned_response_id: responseId
           }));
         })
       );
-      await trx("tag_canned_response").insert(tagCannedResponses.flatten());
+      await trx("tag_canned_response").insert(_.flatten(tagCannedResponses));
     });
 
     await cacheableData.cannedResponse.clearQuery({

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -4,7 +4,7 @@ import { GraphQLError } from "graphql/error";
 import isUrl from "is-url";
 
 import { gzip, makeTree, getHighestRole } from "../../lib";
-import { capitalizeWord } from "./lib/utils";
+import { capitalizeWord, groupCannedResponses } from "./lib/utils";
 import twilio from "./lib/twilio";
 import ownedPhoneNumber from "./lib/owned-phone-number";
 
@@ -310,41 +310,43 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
         id: undefined
       });
     }
-    // run in a transaction
-    // delete from tag_canned_response for campaign_id knex
 
-    await r
-      .knex("tag_canned_response")
-      .whereIn(
-        "canned_response_id",
-        r
-          .knex("canned_response")
-          .select("id")
-          .where({ "canned_response.campaign_id": id })
-      )
-      .delete();
-    await r
-      .table("canned_response")
-      .getAll(id, { index: "campaign_id" })
-      .filter({ user_id: "" })
-      .delete();
-    const saveCannedResponse = cannedResponse => {
-      return CannedResponse.save(cannedResponse).then(
-        ({ id: cannedResponseId }) => cannedResponseId
+    // delete canned response / tag relations from tag_canned_response
+    await r.knex.transaction(async trx => {
+      await trx("tag_canned_response")
+        .whereIn(
+          "canned_response_id",
+          r
+            .knex("canned_response")
+            .select("id")
+            .where({ campaign_id: id })
+        )
+        .delete();
+      // delete canned responses
+      await trx("canned_response")
+        .where({ campaign_id: id })
+        .delete();
+
+      // save new canned responses and add their ids with related tag ids to tag_canned_response
+      const saveCannedResponse = async cannedResponse => {
+        const [res] = await trx("canned_response").insert(cannedResponse, [
+          "id"
+        ]);
+        return res.id;
+      };
+      const tagCannedResponses = await Promise.all(
+        convertedResponses.map(async response => {
+          const { tagIds, ...filteredResponse } = response;
+          const responseId = await saveCannedResponse(filteredResponse);
+          return tagIds.map(t => ({
+            tag_id: t,
+            canned_response_id: responseId
+          }));
+        })
       );
-    };
-    await Promise.all(
-      convertedResponses.map(async response => {
-        const { tagIds, ...filteredResponse } = response;
-        const responseId = await saveCannedResponse(filteredResponse);
-        const tagCannedResponses = tagIds.map(tid => ({
-          tag_id: tid,
-          canned_response_id: responseId
-        }));
-        return r.knex("tag_canned_response").insert(tagCannedResponses);
-      })
-    );
-    // also save tag_ids
+      await trx("tag_canned_response").insert(tagCannedResponses.flatten());
+    });
+
     await cacheableData.cannedResponse.clearQuery({
       userId: "",
       campaignId: id
@@ -868,20 +870,44 @@ const rootMutations = {
         campaign,
         {}
       );
-      // join tag_canned_response, copy any tag_canned_response rows
+
       const originalCannedResponses = await r
         .knex("canned_response")
-        .where({ campaign_id: oldCampaignId });
-      const copiedCannedResponsePromises = originalCannedResponses.map(
+        .leftJoin(
+          "tag_canned_response",
+          "canned_response.id",
+          "tag_canned_response.canned_response_id"
+        )
+        .where({ campaign_id: oldCampaignId })
+        .select("canned_response.*", "tag_canned_response.tag_id");
+      const groupedCannedResponses = groupCannedResponses(
+        originalCannedResponses
+      );
+      const tagCannedResponses = [];
+      const copiedCannedResponsePromises = groupedCannedResponses.map(
         response => {
-          return new CannedResponse({
-            campaign_id: newCampaignId,
-            title: response.title,
-            text: response.text
-          }).save();
+          return r
+            .knex("canned_response")
+            .insert(
+              {
+                campaign_id: newCampaignId,
+                title: response.title,
+                text: response.text
+              },
+              ["id"]
+            )
+            .then(([res]) => {
+              response.tagIds.forEach(t => {
+                tagCannedResponses.push({
+                  canned_response_id: res.id,
+                  tag_id: t
+                });
+              });
+            });
         }
       );
       await Promise.all(copiedCannedResponsePromises);
+      await r.knex("tag_canned_response").insert(tagCannedResponses);
 
       return newCampaign;
     },

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -312,12 +312,38 @@ async function editCampaign(id, campaign, loaders, user, origCampaignRecord) {
     }
     // run in a transaction
     // delete from tag_canned_response for campaign_id knex
+
+    await r
+      .knex("tag_canned_response")
+      .whereIn(
+        "canned_response_id",
+        r
+          .knex("canned_response")
+          .select("id")
+          .where({ "canned_response.campaign_id": id })
+      )
+      .delete();
     await r
       .table("canned_response")
       .getAll(id, { index: "campaign_id" })
       .filter({ user_id: "" })
       .delete();
-    await CannedResponse.save(convertedResponses);
+    const saveCannedResponse = cannedResponse => {
+      return CannedResponse.save(cannedResponse).then(
+        ({ id: cannedResponseId }) => cannedResponseId
+      );
+    };
+    await Promise.all(
+      convertedResponses.map(async response => {
+        const { tagIds, ...filteredResponse } = response;
+        const responseId = await saveCannedResponse(filteredResponse);
+        const tagCannedResponses = tagIds.map(tid => ({
+          tag_id: tid,
+          canned_response_id: responseId
+        }));
+        return r.knex("tag_canned_response").insert(tagCannedResponses);
+      })
+    );
     // also save tag_ids
     await cacheableData.cannedResponse.clearQuery({
       userId: "",

--- a/src/server/models/cacheable_queries/canned-response.js
+++ b/src/server/models/cacheable_queries/canned-response.js
@@ -23,6 +23,7 @@ const cannedResponseCache = {
         return JSON.parse(cannedData);
       }
     }
+    // rewrite to join to tags
     const dbResult = await r
       .table("canned_response")
       .getAll(campaignId, { index: "campaign_id" })

--- a/src/server/models/index.js
+++ b/src/server/models/index.js
@@ -61,6 +61,7 @@ const tableList = [
   "question_response",
   "tag",
   "tag_campaign_contact",
+  "tag_canned_response",
   "owned_phone_number",
   "user_cell",
   "user_organization",

--- a/src/server/models/tag-campaign-contact.js
+++ b/src/server/models/tag-campaign-contact.js
@@ -19,7 +19,7 @@ const TagCampaignContact = thinky.createModel(
     .allowExtra(false),
   {
     noAutoCreation: true,
-    depenencies: [Tag, CampaignContact]
+    dependencies: [Tag, CampaignContact]
   }
 );
 

--- a/src/server/models/tag-canned-response.js
+++ b/src/server/models/tag-canned-response.js
@@ -1,0 +1,22 @@
+import thinky from "./thinky";
+import { requiredString, timestamp } from "./custom-types";
+const type = thinky.type;
+import CannedResponse from "./canned-response";
+import Tag from "./tag";
+
+const TagCannedResponse = thinky.createModel(
+  "tag_canned_response",
+  type
+    .object()
+    .schema({
+      id: type.string(),
+      tag_id: requiredString(),
+      canned_response_id: requiredString(),
+      created_at: timestamp()
+    })
+    .allowExtra(false),
+  {
+    noAutoCreation: true,
+    dependencies: [Tag, CannedResponse]
+  }
+);


### PR DESCRIPTION
# Fixes # (issue)
#1645 
## Description

Built ui to add/remove tags to canned responses and have them appear in canned response list. Added join table tag_canned_response and built db mutations and queries to edit/fetch canned response data with corresponding tag id data.

(This does not include the application of the tags when a texter uses a canned response, which it has been suggested should be separated into another pr)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
