### PR TITLE
initialtext-guard message-handler: disable texting if the initial message is changed

### DIFF
--- a/src/integrations/message-handlers/initaltext-guard/index.js
+++ b/src/integrations/message-handlers/initaltext-guard/index.js
@@ -1,0 +1,88 @@
+import { getConfig } from "../../../server/api/lib/config";
+import { r, cacheableData, Message } from "../../../server/models";
+import serviceMap from "../../../server/api/lib/services";
+
+export const serverAdministratorInstructions = () => {
+  return {
+    description: `
+       If initial texts deviate from the original script then automatically
+       unassign the rest of the contacts and set max_contacts=0 for that
+       campaign.
+
+       VETTED_TEXTERs and above will not be blocked in the same way.
+    `,
+    setupInstructions: `Just enable it -- only works when caching is on`,
+    environmentVariables: []
+  };
+};
+
+// note this is NOT async
+export const available = organization => {
+  // without caching
+  return Boolean(r.redis);
+};
+
+// export const preMessageSave = async () => {};
+
+export const preMessageSave = async ({
+  messageToSave,
+  contact,
+  campaign,
+  texter
+}) => {
+  if (
+    !messageToSave.is_from_contact &&
+    contact &&
+    contact.message_status === "needsMessage" &&
+    contact.assignment_id &&
+    campaign &&
+    campaign.interactionSteps &&
+    texter
+  ) {
+    const initialScript = campaign.interactionSteps.filter(
+      is => is.parent_interaction_id === null
+    )[0].script;
+    let matchFailed = false;
+    try {
+      const regexScript = new RegExp(initialScript.replace(/\{[^}]*\}/, ".*"));
+      matchFailed = !messageToSave.text.match(regexScript);
+    } catch (err) {
+      // give up -- maybe the script had a special character
+      matchFailed = false;
+    }
+    if (matchFailed) {
+      // 0. check if they are a vetted texter NEED: texter
+      const vetted = await cacheableData.user.userHasRole(
+        texter,
+        orgId,
+        "VETTED_TEXTER"
+      );
+      if (vetted) {
+        return;
+      }
+      // 1. unassign the rest of the contacts
+      const contactIds = await r
+        .knex("campaign_contact")
+        .where({ assignment_id: contact.assignment_id })
+        .select("id");
+
+      await r
+        .knex("campaign_contact")
+        .where({ assignment_id: contact.assignment_id })
+        .update({ assignment_id: null });
+      // update cache? unassigned and.....
+      // 2. set max_contacts=0 on assignment and caching of contact ids
+      await r
+        .knex("assignment")
+        .where({ id: contact.assignment_id, campaign_id: campaign.id })
+        .update({ max_contacts: 0 });
+      // 3. mark message
+      Object.assign(messageToSave, {
+        error_code: -167
+      });
+      return {
+        messageToSave
+      };
+    }
+  }
+};

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -74,7 +74,10 @@ export const errorDescriptions = {
   30005: "Unknown destination handset",
   30006: "Landline or unreachable carrier",
   30007: "Message Delivery - Carrier violation",
-  30008: "Message Delivery - Unknown error"
+  30008: "Message Delivery - Unknown error",
+  "-166":
+    "Internal: Message blocked due to text match trigger (profanity-tagger)",
+  "-167": "Internal: Initial message altered (initialtext-guard)"
 };
 
 async function convertMessagePartsToMessage(messageParts) {

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -131,7 +131,8 @@ export const sendMessage = async (
     messageInstance,
     contact,
     campaign,
-    organization
+    organization,
+    texter: user
   });
   if (!saveResult.message) {
     throw new GraphQLError(

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -221,7 +221,8 @@ const messageCache = {
     messageInstance,
     contact,
     /* unreliable: */ campaign,
-    organization
+    organization,
+    texter
   }) => {
     // 0. Gathers any missing data in the case of is_from_contact: campaign_contact_id
     // 1. Saves the messageInstance
@@ -288,7 +289,8 @@ const messageCache = {
           newStatus,
           contact,
           campaign,
-          organization
+          organization,
+          texter
         });
         if (result.cancel) {
           return result; // return without saving
@@ -352,7 +354,8 @@ const messageCache = {
           newStatus,
           contact,
           campaign,
-          organization
+          organization,
+          texter
         });
         if (result) {
           if ("newStatus" in result) {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -626,21 +626,9 @@ export async function assignTexters(job) {
 
   if (campaign.is_started) {
     console.log("assignTexterscache1", job.campaign_id);
-    if (global.TEST_ENVIRONMENT) {
-      // await the full thing if we are testing to avoid async blocks
-      await cacheableData.campaignContact.updateCampaignAssignmentCache(
-        job.campaign_id
-      );
-    } else {
-      cacheableData.campaignContact
-        .updateCampaignAssignmentCache(job.campaign_id)
-        .then(res => {
-          console.log("assignTexterscache Loaded", job.campaign_id, res);
-        })
-        .catch(err => {
-          console.log("assignTexterscache Error", job.campaign_id, err);
-        });
-    }
+    await cacheableData.campaignContact.updateCampaignAssignmentCache(
+      job.campaign_id
+    );
   }
 
   if (job.id) {


### PR DESCRIPTION
## Description

If the initial message is modifiable this can create some risk with trolls masquerading as volunteers.  To mitigate this risk, if the initial message is modified, similar to a call center where the manager hears a troll using the call center and cutting off their phone line, this automatically unassigns messages for that campaign and marks the message.  It is allowed to be sent, preserving the texter's free ability to send whatever initial message they wish.
