### PR TITLE
some compliance options: TEXTER_TWOCLICK and texter-sidebox to allow editing initial text messages

### DIFF
--- a/src/components/AssignmentTexter/StyleControls.js
+++ b/src/components/AssignmentTexter/StyleControls.js
@@ -214,7 +214,6 @@ export const flexStyles = StyleSheet.create({
   sectionSend: {
     //sendButtonWrapper
     flex: `0 0 auto`,
-    height: "36px",
     display: "flex",
     flexDirection: "column",
     flexWrap: "wrap",

--- a/src/integrations/texter-sideboxes/components.js
+++ b/src/integrations/texter-sideboxes/components.js
@@ -98,6 +98,7 @@ export const renderSidebox = (
       settingsData={settingsData}
       {...parentComponent.props}
       {...(moreProps || {})}
+      parent={parentComponent}
       updateState={state => {
         // allows a component to preserve state across dialog open/close
         parentComponent.setState({ [`sideboxState${name}`]: state });
@@ -120,6 +121,7 @@ export const renderSummary = (
       settingsData={settingsData}
       {...parentComponent.props}
       {...(moreProps || {})}
+      parent={parentComponent}
       updateState={state => {
         // allows a component to preserve state across dialog open/close
         parentComponent.setState({ [`sideboxState${name}`]: state });

--- a/src/integrations/texter-sideboxes/default-editinitial/react-component.js
+++ b/src/integrations/texter-sideboxes/default-editinitial/react-component.js
@@ -1,0 +1,98 @@
+import type from "prop-types";
+import React from "react";
+import yup from "yup";
+import Form from "react-formal";
+
+export const displayName = () => "Allow editing of initial messages";
+
+export const showSidebox = ({ contact, messageStatusFilter }) =>
+  contact && messageStatusFilter === "needsMessage";
+
+const defaultMessagePre =
+  "It’s important not to automate sending texts to conform to FCC regulations. Please";
+const defaultLinkText = "don’t alter script messages";
+const defaultMessagePost =
+  "except in circumstances where a custom reply is necessary.";
+
+export class TexterSidebox extends React.Component {
+  setMessageEditable = () => {
+    const { parent } = this.props;
+    if (parent.state && parent.state.messageReadOnly) {
+      parent.setState({ messageReadOnly: false });
+      parent.closeSideboxDialog();
+    }
+  };
+
+  render() {
+    const { settingsData } = this.props;
+    return (
+      <div>
+        <p>
+          {settingsData.editInitialMessagePre || defaultMessagePre}{" "}
+          <a
+            style={{ textDecoration: "underline" }}
+            onClick={this.setMessageEditable}
+          >
+            {settingsData.editInitialLinkText || defaultLinkText}
+          </a>{" "}
+          {settingsData.editInitialMessagePost || defaultMessagePost}
+        </p>
+      </div>
+    );
+  }
+}
+
+TexterSidebox.propTypes = {
+  // data
+  contact: type.object,
+  campaign: type.object,
+  assignment: type.object,
+  texter: type.object,
+
+  // parent state
+  disabled: type.bool,
+  navigationToolbarChildren: type.object,
+  messageStatusFilter: type.string
+};
+
+export const adminSchema = () => ({
+  editInitialMessagePre: yup.string(),
+  editInitialLinkText: yup.string(),
+  editInitialMessagePost: yup.string()
+});
+
+export class AdminConfig extends React.Component {
+  render() {
+    return (
+      <div>
+        <p>
+          Some legal U.S. interpretations, suggest enabling this is important,
+          so it&rsquo;s default-on, but you can disable it.
+        </p>
+        <Form.Field
+          name="editInitialMessagePre"
+          label="Text before link"
+          hintText={`default: ${defaultMessagePre}`}
+          fullWidth
+        />
+        <Form.Field
+          name="editInitialLinkText"
+          label="Link text to enable editing "
+          hintText={`default: ${defaultLinkText}`}
+          fullWidth
+        />
+        <Form.Field
+          name="editInitialMessagePost"
+          label="Text after link"
+          hintText={`default: ${defaultMessagePost}`}
+          fullWidth
+        />
+      </div>
+    );
+  }
+}
+
+AdminConfig.propTypes = {
+  settingsData: type.object,
+  onToggle: type.func
+};

--- a/src/server/middleware/render-index.js
+++ b/src/server/middleware/render-index.js
@@ -105,6 +105,9 @@ export default function renderIndex(html, css, assetMap) {
       window.TWILIO_MULTI_ORG=${process.env.TWILIO_MULTI_ORG || false}
       window.DEPRECATED_TEXTERUI="${process.env.DEPRECATED_TEXTERUI || ""}"
       window.TEXTER_SIDEBOXES="${process.env.TEXTER_SIDEBOXES || ""}"
+      window.TEXTER_TWOCLICK=${getConfig("TEXTER_TWOCLICK", null, {
+        truthy: 1
+      }) || false}
       window.MAX_NUMBERS_PER_BUY_JOB=${getConfig("MAX_NUMBERS_PER_BUY_JOB") ||
         100};
     </script>


### PR DESCRIPTION
## Description

Some legal compliance interpretations require two clicks instead of a single click.  Also some interpretations suggest that the texter should be able to edit the initial message.  This allows either or both of these to be enabled with the appropriate environment variables.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
