### PR TITLE
Remove the whole-page scrollbar by fixing the sidebar height

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -13,7 +13,7 @@ const styles = StyleSheet.create({
     ...theme.layouts.multiColumn.container
   },
   sidebar: {
-    minHeight: "calc(100vh - 56px)"
+    minHeight: "calc(100vh - 65px)"
   },
   content: {
     ...theme.layouts.multiColumn.flexColumn,


### PR DESCRIPTION
## Description

The header height is defined as 65px in `src/components/TopNav.jsx`, but the sidebar height calculation incorrectly used 56px (in `src/components/AdminDashboard.jsx`).

This fixes the sidebar height calculation by using the correct header height.