### PR TITLE
Fix polling on the todos screen

### DIFF
--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -54,7 +54,7 @@ class TexterTodoList extends React.Component {
   componentDidMount() {
     this.props.data.refetch();
     // stopPolling is broken (at least in currently used version), so we roll our own so we can unmount correctly
-    if (this.props.data.currentUser.cacheable && !this.state.polling) {
+    if (!this.state.polling) {
       const self = this;
       this.setState({
         polling: setInterval(() => {


### PR DESCRIPTION
# Fixes #1712 
For more information, see: https://github.com/MoveOnOrg/Spoke/issues/1712

## Description

This fixes polling on the texter `todos` screen, making it so that the information is reloaded every 5 seconds as long as the screen is up.  This seems to have been broken by an older commit.

The fix here is to simply ignore the user's `cacheable` property, since (1) it's hard-coded to false right now, and (2) it doesn't matter.  The data here, by definition, needs to be queried every time so that we can see a fairly "live" view of the text messages that need to be dealt with.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
