### PR TITLE
Closes #1644: Adds an animated Gif sidebox when texter finishes message sends

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,4 +49,4 @@ TWILIO_MESSAGE_VALIDITY_PERIOD=
 DST_REFERENCE_TIMEZONE='America/New_York'
 PASSPORT_STRATEGY=local
 EXPERIMENTAL_TAGS=1
-TEXTER_SIDEBOXES=contact-reference,tag-contact
+TEXTER_SIDEBOXES=contact-reference,tag-contact,celebrate-finish

--- a/src/components/AssignmentTexter/Demo.jsx
+++ b/src/components/AssignmentTexter/Demo.jsx
@@ -23,9 +23,9 @@ export const tests = testName => {
       navigationToolbarChildren: {
         onNext: logFunction,
         onPrevious: logFunction,
-        title: "21 of 42",
+        title: "42 of 42",
         total: 42,
-        currentIndex: 21
+        currentIndex: 42
       },
       assignment: {
         campaign: {

--- a/src/integrations/texter-sideboxes/celebrate-finish/react-component.js
+++ b/src/integrations/texter-sideboxes/celebrate-finish/react-component.js
@@ -1,0 +1,60 @@
+import type from "prop-types";
+import React from "react";
+import yup from "yup";
+import TextField from "material-ui/TextField";
+
+export const displayName = () => "Display Animated GIF When Done Texting";
+
+export const showSidebox = ({ navigationToolbarChildren }) => {
+  // Only show the celebratory gif if the texter is on the last message
+  return (
+    navigationToolbarChildren.currentIndex >= navigationToolbarChildren.total
+  );
+};
+
+export class TexterSidebox extends React.Component {
+  render() {
+    const { settingsData } = this.props;
+    return (
+      <div>
+        <img
+          src={settingsData.animatedGifUrl}
+          alt="Animated GIF To Celebrate Being Done Texting"
+        />
+      </div>
+    );
+  }
+}
+
+TexterSidebox.propTypes = {
+  // data
+  settingsData: type.object,
+
+  // parent state
+  disabled: type.bool,
+  navigationToolbarChildren: type.object,
+  messageStatusFilter: type.string
+};
+
+export const adminSchema = () => ({
+  animatedGifUrl: yup.string().required()
+});
+
+export class AdminConfig extends React.Component {
+  render() {
+    return (
+      <TextField
+        floatingLabelText={"Link to animated Gif"}
+        value={this.props.settingsData.animatedGifUrl}
+        onChange={event => {
+          this.props.onToggle("animatedGifUrl", event.target.value);
+        }}
+      />
+    );
+  }
+}
+
+AdminConfig.propTypes = {
+  settingsData: type.object,
+  onToggle: type.func
+};


### PR DESCRIPTION
## Description

Adds a texter sidebox  that contains an animated gif as specified in the admin settings

The animated gif only displays when the texter is texting the last person -- I'm not 100% sure this is the expected/right behavior from issue #1644 (see screenshots)

I also didn't do much styling, as I'm not sure this is exactly what you're looking for, so I expect to make some updates here.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
  - Does RELEASE_NOTES.md need to be updated for this change?
- [ ] I have added tests that prove my fix is effective or that my feature works
  - I did not add any tests. I didn't see any other texter sideboxes being tested, but could do this with some guidance/suggestion
- [x] My PR is labeled [WIP] if it is in progress

# Screenshots
<img width="1440" alt="Screen Shot 2020-08-03 at 4 56 37 PM" src="https://user-images.githubusercontent.com/805610/89235314-30055080-d5ab-11ea-9c81-4e9fd9a5cabc.png">
<img width="1440" alt="Screen Shot 2020-08-03 at 4 56 42 PM" src="https://user-images.githubusercontent.com/805610/89235318-309de700-d5ab-11ea-87cb-b225056f0464.png">
<img width="1440" alt="Screen Shot 2020-08-03 at 4 56 49 PM" src="https://user-images.githubusercontent.com/805610/89235320-31367d80-d5ab-11ea-9d1b-d073cdf8fb8f.png">
<img width="1440" alt="Screen Shot 2020-08-03 at 4 56 56 PM" src="https://user-images.githubusercontent.com/805610/89235323-31cf1400-d5ab-11ea-912a-87cea8050d4d.png">
<img width="1440" alt="Screen Shot 2020-08-03 at 4 55 50 PM" src="https://user-images.githubusercontent.com/805610/89235307-2e3b8d00-d5ab-11ea-934a-a9f6ca058b25.png">
