### PR TITLE
Remove the scroll bars in every cell in the incoming-messages table

### DIFF
--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -123,7 +123,7 @@ export class IncomingMessageList extends Component {
       label: "Texter",
       style: {
         textOverflow: "ellipsis",
-        overflow: "scroll",
+        overflow: "hidden",
         whiteSpace: "pre-line"
       }
     },
@@ -132,7 +132,7 @@ export class IncomingMessageList extends Component {
       label: "To",
       style: {
         textOverflow: "ellipsis",
-        overflow: "scroll",
+        overflow: "hidden",
         whiteSpace: "pre-line"
       }
     },
@@ -141,7 +141,7 @@ export class IncomingMessageList extends Component {
       label: "Conversation Status",
       style: {
         textOverflow: "ellipsis",
-        overflow: "scroll",
+        overflow: "hidden",
         whiteSpace: "pre-line"
       },
       render: (columnKey, row) => MESSAGE_STATUSES[row.status].name
@@ -151,7 +151,7 @@ export class IncomingMessageList extends Component {
       label: "Latest Message",
       style: {
         textOverflow: "ellipsis",
-        overflow: "scroll",
+        overflow: "hidden",
         whiteSpace: "pre-line"
       },
       render: (columnKey, row) => {
@@ -189,7 +189,7 @@ export class IncomingMessageList extends Component {
       label: "View Conversation",
       style: {
         textOverflow: "ellipsis",
-        overflow: "scroll",
+        overflow: "hidden",
         whiteSpace: "pre-line"
       },
       render: (columnKey, row) =>


### PR DESCRIPTION
## Description

The incoming-messages table was set so that every cell had `overflow: scroll` set, meaning that every cell would have both horizontal and vertical scroll bars, even when they weren't necessary.

The styles also had `text-overflow: ellipsis`, so there's really no reason to force scrolling in the cell when the text will be cut off appropriately.

For all of these `overflow: scroll` styles, I've replaced them with `overflow: hidden`, as it is in a couple other places in that screen.

### Screenshots

Before (bad, scrollbars everywhere):
![table-broken](https://user-images.githubusercontent.com/4185421/89480586-bcf30a00-d763-11ea-80ff-07f550fd572a.png)

After (good, no scrollbars):
![table-fixed](https://user-images.githubusercontent.com/4185421/89480577-b82e5600-d763-11ea-85a9-ce6f1a4eaaff.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
