### PR TITLE
Log requests using morgan

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "minilog": "^3.0.1",
     "moment": "2.14.1",
     "moment-timezone": "^0.5.14",
+    "morgan": "^1.10.0",
     "nexmo": "^2.3.2",
     "node-abort-controller": "^1.0.4",
     "node-fetch": "^2.6.0",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -1,6 +1,7 @@
 import "babel-polyfill";
 import bodyParser from "body-parser";
 import express from "express";
+import morgan from "morgan";
 import appRenderer from "./middleware/app-renderer";
 import { graphqlExpress, graphiqlExpress } from "apollo-server-express";
 import { makeExecutableSchema, addMockFunctionsToSchema } from "graphql-tools";
@@ -52,6 +53,9 @@ const port = process.env.DEV_APP_PORT || process.env.PORT;
 
 // Don't rate limit heroku
 app.enable("trust proxy");
+
+// Log requests.
+app.use(morgan('combined'));
 
 // Serve static assets
 if (existsSync(process.env.ASSETS_DIR)) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3342,6 +3342,13 @@ base@^0.11.1:
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
 
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
+
 batch@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/batch/-/batch-0.6.1.tgz#dc34314f4e679318093fc760272525f94bf25c16"
@@ -10440,6 +10447,17 @@ moo@^0.5.0:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/moo/-/moo-0.5.1.tgz#7aae7f384b9b09f620b6abf6f74ebbcd1b65dbc4"
   integrity sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==
+
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
 
 move-concurrently@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
## Description

This makes Spoke log like a normal web server, including the source address, target URL, status code, byte count, and user agent.  This information is invaluable when troubleshooting web server issues.

### Example

You can see the standard morgan `combined` logs that were requested as part of the normal refresh process in the UI.

```
2:16:07 AM server.1  |  backend info Checking if zip code is needed
2:16:07 AM server.1  |  backend info Node app is running on port 8090
2:16:16 AM server.1  |  192.168.86.1 - - [06/Aug/2020:02:16:16 +0000] "POST /graphql HTTP/1.1" 200 984 "https://spoke.XXXX/admin/1/campaigns/1/edit" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
2:16:27 AM server.1  |  192.168.86.1 - - [06/Aug/2020:02:16:27 +0000] "POST /graphql HTTP/1.1" 200 7160 "https://spoke.XXXX/admin/1/campaigns/1/edit" "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.105 Safari/537.36"
```

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
