### PR TITLE
opt out record column in export: distinguishes between whether they opted out in this campaign or any campaign

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -759,6 +759,7 @@ export async function exportCampaign(job) {
         "contact[optOut]": optOuts.find(ele => ele.cell === contact.cell)
           ? "true"
           : "false",
+        "contact[optOutRecord]": contact.is_opted_out,
         "contact[messageStatus]": contact.message_status,
         "contact[errorCode]": contact.error_code,
         "contact[external_id]": contact.external_id,


### PR DESCRIPTION
optOut in export is whether the contact opted out in THAT campaign -- instead of whether in any one during the campaign's duration.