### PR TITLE
Remove the scroll bars in every cell in the people table

### DIFF
--- a/src/containers/PeopleList.jsx
+++ b/src/containers/PeopleList.jsx
@@ -58,7 +58,7 @@ export class PeopleList extends Component {
         label: "Email",
         style: {
           textOverflow: "ellipsis",
-          overflow: "scroll",
+          overflow: "hidden",
           whiteSpace: "pre-line"
         }
       },
@@ -67,7 +67,7 @@ export class PeopleList extends Component {
         label: "Role",
         style: {
           textOverflow: "ellipsis",
-          overflow: "scroll",
+          overflow: "hidden",
           whiteSpace: "pre-line"
         },
         render: this.renderRolesDropdown
@@ -77,7 +77,7 @@ export class PeopleList extends Component {
         label: "",
         style: {
           textOverflow: "ellipsis",
-          overflow: "scroll",
+          overflow: "hidden",
           whiteSpace: "pre-line"
         },
         render: this.renderEditButton
@@ -89,7 +89,7 @@ export class PeopleList extends Component {
         label: "",
         style: {
           textOverflow: "ellipsis",
-          overflow: "scroll",
+          overflow: "hidden",
           whiteSpace: "pre-line"
         },
         render: this.renderChangePasswordButton


### PR DESCRIPTION
## Description

(This is just like #1722, but for the PeopleList element.)

The people table was set so that every cell had `overflow: scroll` set, meaning that every cell would have both horizontal and vertical scroll bars, even when they weren't necessary.

The styles also had `text-overflow: ellipsis`, so there's really no reason to force scrolling in the cell when the text will be cut off appropriately.

For all of these `overflow: scroll` styles, I've replaced them with `overflow: hidden`.

## Screenshots

Before (bad, scrollbars):
![people-old](https://user-images.githubusercontent.com/4185421/89793995-7818fb80-daf4-11ea-8426-eebefac4365f.png)

After (good, no scrollbars):
![people-new](https://user-images.githubusercontent.com/4185421/89793919-646d9500-daf4-11ea-8f12-009a4648a4ae.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
