### PR TITLE
Ensure that interactions are copied deterministically

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -763,7 +763,8 @@ const rootMutations = {
 
       let interactions = await r
         .knex("interaction_step")
-        .where({ campaign_id: oldCampaignId, is_deleted: false });
+        .where({ campaign_id: oldCampaignId, is_deleted: false })
+        .orderBy("id"); // Ensure that the copy is deterministic.
 
       const interactionsArr = [];
       interactions.forEach((interaction, index) => {


### PR DESCRIPTION
## Description

It looks like the "id" is the most important thing when trying to order interaction steps, and if that's the case, then we have to copy them in the correct order.  Leaving out `orderBy` lets the database return them in any order, and we don't know what that will be.

I had an entire text campaign break down because all of my docs were now invalid because the buttons weren't where I said they would be, and people coming from the previous campaigns were just automatically clicking where they knew the buttons were supposed to be (support on the left, unknown in the middle, oppose on the right, for example).  It's not the biggest problem that I've run into with Spoke yet, but it certainly caused a huge headache.

Note that `src/server/models/cacheable_queries/campaign.js` defines the order in which the "interaction steps" will be returned, and it's sorted by `id`:

```
const dbInteractionSteps = async id => {
  const allSteps = await r
    .table("interaction_step")
    .getAll(id, { index: "campaign_id" })
    .filter({ is_deleted: false })
    .orderBy("id");
  const data = assembleAnswerOptions(allSteps);
  // console.log("cacheabledata.campaign.dbInteractionSteps", id, data);
  return data;
};
```

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
