### PR TITLE
Copy all relevant campaign properties when copying a campaign

### DIFF
--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -613,7 +613,6 @@ describe("graphql test suite", async () => {
         // The copy should not be archived.
         expect(copiedCampaign.is_archived).toEqual(false);
         // All of the other properties should be identical.
-        console.log(campaign, "vs.", copiedCampaign);
         expect(campaign.description).toEqual(copiedCampaign.description);
         if (typeof copiedCampaign.due_by === "number") {
           let parsedDate = new Date(copiedCampaign.due_by);

--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -528,8 +528,17 @@ describe("graphql test suite", async () => {
           description: "This is my new campaign",
           is_started: false,
           is_archived: false,
-          use_dynamic_assignment: true,
-          due_by: new Date()
+          due_by: new Date(),
+          features: '{ "MY_FEATURE": "value 1" }',
+          intro_html: "<p>This is my intro HTML.</p>",
+          primary_color: "#112233",
+          logo_image_url: "https://www.example.com/image1",
+          override_organization_texting_hours: true,
+          texting_hours_enforced: true,
+          texting_hours_start: 13,
+          texting_hours_end: 14,
+          timezone: "MY_TZ",
+          use_dynamic_assignment: true
         }).save();
         grandpaInteraction = new InteractionStep({
           campaign_id: campaign.id,
@@ -595,9 +604,33 @@ describe("graphql test suite", async () => {
         );
       });
       test("creates and returns a copy of the campaign", () => {
+        // The IDs should be different.
         expect(campaign.id).not.toEqual(copiedCampaign.id);
-        expect(campaign.description).toEqual(copiedCampaign.description);
+        // The title should start with the "COPY - " prefix.
         expect(copiedCampaign.title).toEqual(`COPY - ${campaign.title}`);
+        // All of the other properties should be identical.
+        expect(campaign.description).toEqual(copiedCampaign.description);
+        expect(campaign.due_by).toEqual(copiedCampaign.due_by);
+        expect(campaign.features).toEqual(copiedCampaign.features);
+        expect(campaign.intro_html).toEqual(copiedCampaign.intro_html);
+        expect(campaign.primary_color).toEqual(copiedCampaign.primary_color);
+        expect(campaign.logo_image_url).toEqual(copiedCampaign.logo_image_url);
+        expect(campaign.override_organization_texting_hours).toEqual(
+          copiedCampaign.override_organization_texting_hours
+        );
+        expect(campaign.texting_hours_enforced).toEqual(
+          copiedCampaign.texting_hours_enforced
+        );
+        expect(campaign.texting_hours_start).toEqual(
+          copiedCampaign.texting_hours_start
+        );
+        expect(campaign.texting_hours_end).toEqual(
+          copiedCampaign.texting_hours_end
+        );
+        expect(campaign.timezone).toEqual(copiedCampaign.timezone);
+        expect(campaign.use_dynamic_assignment).toEqual(
+          copiedCampaign.use_dynamic_assignment
+        );
       });
       test("the copied campaign has the same canned response as the original one", async () => {
         const originalCannedResponseP = queryHelper(

--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -608,18 +608,28 @@ describe("graphql test suite", async () => {
         expect(campaign.id).not.toEqual(copiedCampaign.id);
         // The title should start with the "COPY - " prefix.
         expect(copiedCampaign.title).toEqual(`COPY - ${campaign.title}`);
+        // The copy should not be started.
+        expect(copiedCampaign.is_started).toEqual(false);
+        // The copy should not be archived.
+        expect(copiedCampaign.is_archived).toEqual(false);
         // All of the other properties should be identical.
+        console.log(campaign, "vs.", copiedCampaign);
         expect(campaign.description).toEqual(copiedCampaign.description);
-        expect(campaign.due_by).toEqual(copiedCampaign.due_by);
+        if (typeof copiedCampaign.due_by === "number") {
+          let parsedDate = new Date(copiedCampaign.due_by);
+          expect(campaign.due_by).toEqual(parsedDate);
+        } else {
+          expect(campaign.due_by).toEqual(copiedCampaign.due_by);
+        }
         expect(campaign.features).toEqual(copiedCampaign.features);
         expect(campaign.intro_html).toEqual(copiedCampaign.intro_html);
         expect(campaign.primary_color).toEqual(copiedCampaign.primary_color);
         expect(campaign.logo_image_url).toEqual(copiedCampaign.logo_image_url);
-        expect(campaign.override_organization_texting_hours).toEqual(
-          copiedCampaign.override_organization_texting_hours
+        expect(!!campaign.override_organization_texting_hours).toEqual(
+          !!copiedCampaign.override_organization_texting_hours
         );
-        expect(campaign.texting_hours_enforced).toEqual(
-          copiedCampaign.texting_hours_enforced
+        expect(!!campaign.texting_hours_enforced).toEqual(
+          !!copiedCampaign.texting_hours_enforced
         );
         expect(campaign.texting_hours_start).toEqual(
           copiedCampaign.texting_hours_start
@@ -628,8 +638,8 @@ describe("graphql test suite", async () => {
           copiedCampaign.texting_hours_end
         );
         expect(campaign.timezone).toEqual(copiedCampaign.timezone);
-        expect(campaign.use_dynamic_assignment).toEqual(
-          copiedCampaign.use_dynamic_assignment
+        expect(!!campaign.use_dynamic_assignment).toEqual(
+          !!copiedCampaign.use_dynamic_assignment
         );
       });
       test("the copied campaign has the same canned response as the original one", async () => {

--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -529,7 +529,7 @@ describe("graphql test suite", async () => {
           is_started: false,
           is_archived: false,
           due_by: new Date(),
-          features: '{ "MY_FEATURE": "value 1" }',
+          features: JSON.stringify({ MY_FEATURE: "value 1" }),
           intro_html: "<p>This is my intro HTML.</p>",
           primary_color: "#112233",
           logo_image_url: "https://www.example.com/image1",
@@ -605,7 +605,7 @@ describe("graphql test suite", async () => {
       });
       test("creates and returns a copy of the campaign", () => {
         // The IDs should be different.
-        expect(campaign.id).not.toEqual(copiedCampaign.id);
+        expect(copiedCampaign.id).not.toEqual(campaign.id);
         // The title should start with the "COPY - " prefix.
         expect(copiedCampaign.title).toEqual(`COPY - ${campaign.title}`);
         // The copy should not be started.
@@ -613,32 +613,40 @@ describe("graphql test suite", async () => {
         // The copy should not be archived.
         expect(copiedCampaign.is_archived).toEqual(false);
         // All of the other properties should be identical.
-        expect(campaign.description).toEqual(copiedCampaign.description);
+        expect(copiedCampaign.description).toEqual(campaign.description);
         if (typeof copiedCampaign.due_by === "number") {
           let parsedDate = new Date(copiedCampaign.due_by);
-          expect(campaign.due_by).toEqual(parsedDate);
+          expect(parsedDate).toEqual(campaign.due_by);
         } else {
-          expect(campaign.due_by).toEqual(copiedCampaign.due_by);
+          expect(copiedCampaign.due_by).toEqual(campaign.due_by);
         }
-        expect(campaign.features).toEqual(copiedCampaign.features);
-        expect(campaign.intro_html).toEqual(copiedCampaign.intro_html);
-        expect(campaign.primary_color).toEqual(copiedCampaign.primary_color);
-        expect(campaign.logo_image_url).toEqual(copiedCampaign.logo_image_url);
-        expect(!!campaign.override_organization_texting_hours).toEqual(
-          !!copiedCampaign.override_organization_texting_hours
+        if (
+          typeof copiedCampaign.features === "object" &&
+          copiedCampaign.features
+        ) {
+          let jsonString = JSON.stringify(copiedCampaign.features);
+          expect(jsonString).toEqual(campaign.features);
+        } else {
+          expect(copiedCampaign.features).toEqual(campaign.features);
+        }
+        expect(copiedCampaign.intro_html).toEqual(campaign.intro_html);
+        expect(copiedCampaign.primary_color).toEqual(campaign.primary_color);
+        expect(copiedCampaign.logo_image_url).toEqual(campaign.logo_image_url);
+        expect(!!copiedCampaign.override_organization_texting_hours).toEqual(
+          !!campaign.override_organization_texting_hours
         );
-        expect(!!campaign.texting_hours_enforced).toEqual(
-          !!copiedCampaign.texting_hours_enforced
+        expect(!!copiedCampaign.texting_hours_enforced).toEqual(
+          !!campaign.texting_hours_enforced
         );
-        expect(campaign.texting_hours_start).toEqual(
-          copiedCampaign.texting_hours_start
+        expect(copiedCampaign.texting_hours_start).toEqual(
+          campaign.texting_hours_start
         );
-        expect(campaign.texting_hours_end).toEqual(
-          copiedCampaign.texting_hours_end
+        expect(copiedCampaign.texting_hours_end).toEqual(
+          campaign.texting_hours_end
         );
-        expect(campaign.timezone).toEqual(copiedCampaign.timezone);
-        expect(!!campaign.use_dynamic_assignment).toEqual(
-          !!copiedCampaign.use_dynamic_assignment
+        expect(copiedCampaign.timezone).toEqual(campaign.timezone);
+        expect(!!copiedCampaign.use_dynamic_assignment).toEqual(
+          !!campaign.use_dynamic_assignment
         );
       });
       test("the copied campaign has the same canned response as the original one", async () => {

--- a/__test__/backend.test.js
+++ b/__test__/backend.test.js
@@ -614,7 +614,10 @@ describe("graphql test suite", async () => {
         expect(copiedCampaign.is_archived).toEqual(false);
         // All of the other properties should be identical.
         expect(copiedCampaign.description).toEqual(campaign.description);
-        if (typeof copiedCampaign.due_by === "number") {
+        if (
+          typeof copiedCampaign.due_by === "number" ||
+          typeof copiedCampaign.due_by === "string"
+        ) {
           let parsedDate = new Date(copiedCampaign.due_by);
           expect(parsedDate).toEqual(campaign.due_by);
         } else {

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -166,17 +166,6 @@ class AdminCampaignStats extends React.Component {
     );
   }
 
-  renderCopyButton() {
-    return (
-      <RaisedButton
-        label="Copy Campaign"
-        onTouchTap={async () =>
-          await this.props.mutations.copyCampaign(this.props.params.campaignId)
-        }
-      />
-    );
-  }
-
   render() {
     const { data, params } = this.props;
     const { organizationId, campaignId } = params;
@@ -272,11 +261,26 @@ class AdminCampaignStats extends React.Component {
                         <RaisedButton
                           {...dataTest("copyCampaign")}
                           label="Copy Campaign"
-                          onTouchTap={async () =>
-                            await this.props.mutations.copyCampaign(
+                          onTouchTap={async () => {
+                            let result = await this.props.mutations.copyCampaign(
                               this.props.params.campaignId
-                            )
-                          }
+                            );
+                            if (
+                              window.confirm(
+                                "A new copy has been made.\nGo there now?"
+                              )
+                            ) {
+                              this.props.router.push(
+                                "/admin/" +
+                                  encodeURIComponent(organizationId) +
+                                  "/campaigns/" +
+                                  encodeURIComponent(
+                                    result.data.copyCampaign.id
+                                  ) +
+                                  "/edit"
+                              );
+                            }
+                          }}
                         />,
                         campaign.useOwnMessagingService ? (
                           <RaisedButton

--- a/src/containers/AdminCampaignStats.jsx
+++ b/src/containers/AdminCampaignStats.jsx
@@ -90,6 +90,8 @@ Stat.propTypes = {
 
 class AdminCampaignStats extends React.Component {
   state = {
+    copyCampaignId: null, // This is the ID of the most-recently created copy of the campaign.
+    copyMessageOpen: false, // This is true when the copy snackbar should be shown.
     exportMessageOpen: false,
     disableExportButton: false
   };
@@ -265,21 +267,10 @@ class AdminCampaignStats extends React.Component {
                             let result = await this.props.mutations.copyCampaign(
                               this.props.params.campaignId
                             );
-                            if (
-                              window.confirm(
-                                "A new copy has been made.\nGo there now?"
-                              )
-                            ) {
-                              this.props.router.push(
-                                "/admin/" +
-                                  encodeURIComponent(organizationId) +
-                                  "/campaigns/" +
-                                  encodeURIComponent(
-                                    result.data.copyCampaign.id
-                                  ) +
-                                  "/edit"
-                              );
-                            }
+                            this.setState({
+                              copyCampaignId: result.data.copyCampaign.id,
+                              copyMessageOpen: true
+                            });
                           }}
                         />,
                         campaign.useOwnMessagingService ? (
@@ -337,6 +328,24 @@ class AdminCampaignStats extends React.Component {
           autoHideDuration={5000}
           onRequestClose={() => {
             this.setState({ exportMessageOpen: false });
+          }}
+        />
+        <Snackbar
+          open={this.state.copyMessageOpen}
+          message="A new copy has been made."
+          action="Edit"
+          onActionClick={() => {
+            this.props.router.push(
+              "/admin/" +
+                encodeURIComponent(organizationId) +
+                "/campaigns/" +
+                encodeURIComponent(this.state.copyCampaignId) +
+                "/edit"
+            );
+          }}
+          autoHideDuration={5000}
+          onRequestClose={() => {
+            this.setState({ copyMessageOpen: false });
           }}
         />
       </div>

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -746,7 +746,18 @@ const rootMutations = {
         creator_id: user.id,
         title: "COPY - " + campaign.title,
         description: campaign.description,
-        due_by: campaign.dueBy,
+        due_by: campaign.due_by,
+        features: campaign.features,
+        intro_html: campaign.intro_html,
+        primary_color: campaign.primary_color,
+        logo_image_url: campaign.logo_image_url,
+        override_organization_texting_hours:
+          campaign.override_organization_texting_hours,
+        texting_hours_enforced: campaign.texting_hours_enforced,
+        texting_hours_start: campaign.texting_hours_start,
+        texting_hours_end: campaign.texting_hours_end,
+        timezone: campaign.timezone,
+        use_dynamic_assignment: campaign.use_dynamic_assignment,
         batch_size:
           campaign.batch_size ||
           Number(getConfig("DEFAULT_BATCHSIZE", organization) || 300),
@@ -754,6 +765,8 @@ const rootMutations = {
         is_archived: false,
         join_token: uuidv4()
       });
+      console.log("campaign:", campaign);
+      console.log("campaignInstance:", campaignInstance);
       const newCampaign = await campaignInstance.save();
       await r.knex("campaign_admin").insert({
         campaign_id: newCampaign.id
@@ -763,7 +776,8 @@ const rootMutations = {
 
       let interactions = await r
         .knex("interaction_step")
-        .where({ campaign_id: oldCampaignId, is_deleted: false });
+        .where({ campaign_id: oldCampaignId, is_deleted: false })
+        .orderBy("id"); // Ensure that the copy is deterministic.
 
       const interactionsArr = [];
       interactions.forEach((interaction, index) => {

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -765,8 +765,6 @@ const rootMutations = {
         is_archived: false,
         join_token: uuidv4()
       });
-      console.log("campaign:", campaign);
-      console.log("campaignInstance:", campaignInstance);
       const newCampaign = await campaignInstance.save();
       await r.knex("campaign_admin").insert({
         campaign_id: newCampaign.id


### PR DESCRIPTION
## Description

(If you take this one, then you can ignore #1736, which just fixes the interaction step ordering.)

I typically segment my data a bit and then copy the same campaign over and over, changing the list and the intro text a bit each time, but everything else generally stays the same.

I noticed some issues when copying a campaign, however:

1. There is no notification that the "Copy Campaign" button did anything; I mashed it many times before I realized what was happening.
2. Nothing is copied from "Basics" except the title.
3. Nothing is copied from "Dynamic Assignment".
4. Nothing is copied from "Texter Experience".
5. Nothing is copied from Texting Hours.
6. The questions and responses are not copied in the right order, but the order seems close to the correct order at times.

This patch addresses all of those issues.  To the best of my knowledge, all of a campaign's configuration is copied over to the new campaign.

In addition, we show a "confirm" box upon successful copy completion offering to take the user to the edit screen for the new campaign. If she accepts, then we'll re-route to that screen.  If she does not, then she'll stay where she is, but at least she'll know that the copy operation succeeded.

## Screenshots

Here is what it looks like once the copy has completed.
![copy-message](https://user-images.githubusercontent.com/4185421/89845659-13d65600-db4d-11ea-96b4-19c947ce61e3.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
