### PR TITLE
Left-justify outgoing message text and add some padding to the messag…

### DIFF
--- a/src/components/AssignmentTexter/MessageList.jsx
+++ b/src/components/AssignmentTexter/MessageList.jsx
@@ -54,7 +54,13 @@ const MessageList = function MessageList(props) {
           style={message.isFromContact ? received : sent}
           key={message.id}
           primaryText={message.text}
-          secondaryText={moment.utc(message.createdAt).fromNow()}
+          secondaryText={
+            <span
+              style={{ fontSize: "90%", display: "block", paddingTop: "5px" }}
+            >
+              {moment.utc(message.createdAt).fromNow()}
+            </span>
+          }
         />
       ))}
       {optOutItem}

--- a/src/components/AssignmentTexter/StyleControls.js
+++ b/src/components/AssignmentTexter/StyleControls.js
@@ -10,7 +10,7 @@ export const messageListStyles = {
     maxWidth: "574px"
   },
   messageSent: {
-    textAlign: "right",
+    textAlign: "left",
     marginLeft: "20%",
     marginRight: "10px",
     backgroundColor: "white",


### PR DESCRIPTION
…e text

# Fixes #1734

## Description

Changes the alignment of the text on received texts to also be left-aligned. If anyone has any advice on my implementation given material ui and it's constraints let me know. Would love that feedback.

### Screenshot
<img width="594" alt="Screen Shot 2020-08-12 at 9 08 46 PM" src="https://user-images.githubusercontent.com/3953117/90086523-3c428980-dce0-11ea-9a60-036593dbcb9d.png">


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
