### PR TITLE
Add support for Twilio error 21408

### DIFF
--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -62,6 +62,7 @@ const headerValidator = () => {
 export const errorDescriptions = {
   12400: "Internal (Twilio) Failure",
   21211: "Invalid 'To' Phone Number",
+  21408: "Attempt to send to disabled region",
   21602: "Message body is required",
   21610: "Attempt to send to unsubscribed recipient",
   21611: "Source number has exceeded max number of queued messages",


### PR DESCRIPTION
## Description

Twilio error 21408 happens when you try to send a message to a phone
number outside of your "Geo-Permissions" settings; I've experienced
this with trying to send to a Puerto Rico phone number.

Twilio's official "Possible Causes" are:

* You have attempted to send an SMS to a region that has not been
  enabled in your account's Geo-Permissions settings.

_Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change, and any blockers that make your change a WIP_

### Screenshots
Old, an unlabeled error:
![errors-old](https://user-images.githubusercontent.com/4185421/90264082-93e70f00-de1e-11ea-8f4c-4189da5937a0.png)

New, a labeled error:
![errors-new](https://user-images.githubusercontent.com/4185421/90264098-977a9600-de1e-11ea-89a6-ecc800266b42.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
