### PR TITLE
Freshworks widget texter sidebox

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,5 +50,5 @@ TWILIO_MESSAGE_VALIDITY_PERIOD=
 DST_REFERENCE_TIMEZONE='America/New_York'
 PASSPORT_STRATEGY=local
 EXPERIMENTAL_TAGS=1
-TEXTER_SIDEBOXES=celebration-gif,default-dynamicassignment,default-releasecontacts,contact-reference,tag-contact
+TEXTER_SIDEBOXES=celebration-gif,default-dynamicassignment,default-releasecontacts,contact-reference,tag-contact,freshworks-widget
 OWNER_CONFIGURABLE=ALL

--- a/src/extensions/texter-sideboxes/freshworks-widget/react-component.js
+++ b/src/extensions/texter-sideboxes/freshworks-widget/react-component.js
@@ -30,16 +30,11 @@ export class TexterSidebox extends React.Component {
   addGlobalFunction = widgetId => {
     if (typeof window.FreshworksWidget !== "function") {
       window.fwSettings = { widget_id: widgetId };
-      function init() {
-        if (typeof window.FreshworksWidget !== "function") {
-          const n = function(...args) {
-            n.q.push(args);
-          };
-          n.q = [];
-          window.FreshworksWidget = n;
-        }
-      }
-      init();
+      const n = (...args) => {
+        n.q.push(args);
+      };
+      n.q = [];
+      window.FreshworksWidget = n;
     }
   };
 

--- a/src/extensions/texter-sideboxes/freshworks-widget/react-component.js
+++ b/src/extensions/texter-sideboxes/freshworks-widget/react-component.js
@@ -1,0 +1,106 @@
+import type from "prop-types";
+import React from "react";
+import yup from "yup";
+import { css } from "aphrodite";
+import Form from "react-formal";
+import FlatButton from "material-ui/FlatButton";
+import {
+  flexStyles,
+  inlineStyles
+} from "../../../components/AssignmentTexter/StyleControls";
+
+export const displayName = () => "Freshworks Widget";
+
+export const showSidebox = () => true;
+
+export class TexterSidebox extends React.Component {
+  componentDidMount() {
+    // A Freshworks widget integration has two components:
+    // - a global function: `FreshworksWidget`
+    // - a <script> tag at the end of our <body> with a script from Freshworks. This script
+    // adds other DOM elements.
+    // We will add these two objects to the DOM, then never touch them. Removing then re-adding
+    // the script element adds duplicate DOM elements with every re-add.
+    const { settingsData } = this.props;
+    this.addGlobalFunction(settingsData.helpWidgetID);
+    this.addScriptElement(settingsData.helpWidgetID);
+    FreshworksWidget("hide", "launcher"); // Hide their button because it's in a weird spot.
+  }
+
+  addGlobalFunction = widgetId => {
+    if (typeof window.FreshworksWidget !== "function") {
+      window.fwSettings = { widget_id: widgetId };
+      function init() {
+        if (typeof window.FreshworksWidget !== "function") {
+          const n = function(...args) {
+            n.q.push(args);
+          };
+          n.q = [];
+          window.FreshworksWidget = n;
+        }
+      }
+      init();
+    }
+  };
+
+  addScriptElement = widgetId => {
+    if (!document.getElementById("FreshworksScript")) {
+      const script = document.createElement("script");
+      script.type = "text/javascript";
+      script.src = `https://widget.freshworks.com/widgets/${widgetId}.js`;
+      script.async = true;
+      script.defer = true;
+      script.id = "FreshworksScript";
+      document.body.appendChild(script);
+    }
+  };
+
+  render() {
+    const { settingsData } = this.props;
+
+    return (
+      <div>
+        <FlatButton
+          onClick={() => FreshworksWidget && FreshworksWidget("open")}
+          label={settingsData.helpButtonLabel || "Help"}
+          className={css(flexStyles.flatButton)}
+          labelStyle={inlineStyles.flatButtonLabel}
+        />
+      </div>
+    );
+  }
+}
+
+TexterSidebox.propTypes = {
+  settingsData: type.object
+};
+
+export const adminSchema = () => ({
+  helpButtonLabel: yup.string(),
+  helpWidgetID: yup.string()
+});
+
+export class AdminConfig extends React.Component {
+  render() {
+    return (
+      <div>
+        <Form.Field
+          name="helpButtonLabel"
+          label="Help Button Label"
+          hintText="default: Help"
+          fullWidth
+        />
+        <Form.Field
+          name="helpWidgetID"
+          label="Freshworks Widget ID"
+          fullWidth
+        />
+      </div>
+    );
+  }
+}
+
+AdminConfig.propTypes = {
+  settingsData: type.object,
+  onToggle: type.func
+};


### PR DESCRIPTION
# Fixes https://github.com/MoveOnOrg/Spoke/issues/1541

## Description

Add new file to the `texter-sidebox` folder that defines two new Components
- one for the texter sidebox UI
- one for the Admin
After initializing the third party widget we immediately call a function in their system to hide the "launcher" UI. We do this because their layout code puts the "launcher" button in a position that looks pretty bad on our UI.

So far the widget sidebox is not enabled by default - i.e. it's not included in the list of default TEXTER_SIDEBOXES [here](https://github.com/MoveOnOrg/Spoke/blob/c3aaed0af3591114427264c49bb39a919451acf6/src/extensions/texter-sideboxes/components.js#L7) or [here](https://github.com/MoveOnOrg/Spoke/blob/c3aaed0af3591114427264c49bb39a919451acf6/src/server/api/organization.js#L42.)

Here's what it looks like on desktop
![Screen Shot 2020-08-14 at 3 03 19 PM](https://user-images.githubusercontent.com/394818/90284181-91e17800-de3f-11ea-9595-6db369ceede2.png)
... and mobile
![Screen Shot 2020-08-14 at 3 03 36 PM](https://user-images.githubusercontent.com/394818/90284194-97d75900-de3f-11ea-9709-3a2445f78954.png)

I'm not aware of any place where we're documenting the various sidebox features. If such a place exists, I can add a full description of what this sidebox is for and how it works.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
