### PR TITLE
Make VAN database mode and timeout configurable; send phoneId with people/canvassResponses

### DIFF
--- a/__test__/extensions/action-handlers/ngpvan-action.test.js
+++ b/__test__/extensions/action-handlers/ngpvan-action.test.js
@@ -149,7 +149,7 @@ describe("ngpvn-action", () => {
         nock("https://api.securevan.com:443", {
           encodedQueryParams: true
         })
-          .get(`/v4/surveyQuestions?statuses=Active${extraParams}`)
+          .get(`/v4/surveyQuestions?statuses=Active${extraParams}&$top=200`)
           .reply(statusCode, {
             items: [
               {
@@ -236,7 +236,7 @@ describe("ngpvn-action", () => {
         nock("https://api.securevan.com:443", {
           encodedQueryParams: true
         })
-          .get("/v4/activistCodes?statuses=Active")
+          .get("/v4/activistCodes?statuses=Active&$top=200")
           .reply(200, {
             items: [
               {
@@ -270,7 +270,7 @@ describe("ngpvn-action", () => {
         nock("https://api.securevan.com:443", {
           encodedQueryParams: true
         })
-          .get("/v4/canvassResponses/resultCodes")
+          .get("/v4/canvassResponses/resultCodes?$top=200")
           .reply(200, [
             {
               resultCodeId: 18,
@@ -949,7 +949,11 @@ describe("ngpvn-action", () => {
     let postPeopleCanvassResponsesNock;
 
     beforeEach(async () => {
-      interactionStepValue = '{"hex":"#B22222","rgb":{"r":178,"g":34,"b":34}}';
+      interactionStepValue = {
+        canvassContext: {},
+        hex: "#B22222",
+        rgb: { r: 178, g: 34, b: 34 }
+      };
       interactionStep = {
         id: "77",
         answer_actions_data: JSON.stringify({
@@ -963,7 +967,8 @@ describe("ngpvn-action", () => {
 
       contact = {
         custom_fields: JSON.stringify({
-          VanID: "8675309"
+          VanID: "8675309",
+          VanPhoneId: "3"
         })
       };
 
@@ -973,6 +978,7 @@ describe("ngpvn-action", () => {
     });
 
     beforeEach(async () => {
+      interactionStepValue.canvassContext.phoneId = "3";
       makePostPeopleCanvassResponsesNock = ({ statusCode = 204 } = {}) =>
         nock("https://api.securevan.com:443", {
           encodedQueryParams: true
@@ -1095,11 +1101,45 @@ describe("ngpvn-action", () => {
         };
 
         body = {
+          canvassContext: {},
           willVote: true
         };
       });
 
       it("calls the people endpoint", async () => {
+        const postPeopleCanvassResponsesNock = nock(
+          "https://api.securevan.com:443",
+          {
+            encodedQueryParams: true
+          }
+        )
+          .post(`/v4/people/8675309/canvassResponses`, JSON.stringify(body))
+          .reply(204);
+
+        await NgpVanAction.postCanvassResponse(contact, organization, body);
+
+        postPeopleCanvassResponsesNock.done();
+      });
+    });
+
+    describe("when the contact has a VanPhoneId", () => {
+      beforeEach(async () => {
+        contact = {
+          custom_fields: JSON.stringify({
+            VanID: "8675309",
+            VanPhoneId: "789"
+          })
+        };
+
+        body = {
+          canvassContext: {
+            phoneId: "789"
+          },
+          willVote: true
+        };
+      });
+
+      it("calls the people endpoint and includes VanPhoneId in the canvass context", async () => {
         const postPeopleCanvassResponsesNock = nock(
           "https://api.securevan.com:443",
           {

--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -426,9 +426,12 @@ describe("ngpvan", () => {
       expect(config.getConfig.mock.calls).toEqual([
         ["NGP_VAN_WEBHOOK_BASE_URL", organization],
         ["NGP_VAN_API_BASE_URL", organization],
+        ["NGP_VAN_TIMEOUT", organization],
         ["NGP_VAN_APP_NAME", organization],
         ["NGP_VAN_API_KEY", organization],
+        ["NGP_VAN_DATABASE_MODE", organization],
         ["NGP_VAN_EXPORT_JOB_TYPE_ID", organization],
+        ["NGP_VAN_TIMEOUT", organization],
         ["NGP_VAN_CAUTIOUS_CELL_PHONE_SELECTION", organization]
       ]);
 

--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -716,9 +716,10 @@ describe("ngpvan", () => {
     let inputRow;
 
     beforeEach(() => {
-      getCellFromRowSpy = jest
-        .spyOn(ngpvan, "getCellFromRow")
-        .mockReturnValue("12024561414");
+      getCellFromRowSpy = jest.spyOn(ngpvan, "getCellFromRow").mockReturnValue({
+        number: "12024561414",
+        id: "123"
+      });
       getZipFromRowSpy = jest
         .spyOn(ngpvan, "getZipFromRow")
         .mockReturnValue("07052");
@@ -744,6 +745,7 @@ describe("ngpvan", () => {
       expect(getZipFromRowSpy.mock.calls).toEqual([[inputRow]]);
       expect(transformedRow.row).toEqual({
         VanID: "abc",
+        VanPhoneId: "123",
         external_id: "abc",
         cell: "12024561414",
         zip: "07052",
@@ -767,14 +769,28 @@ describe("ngpvan", () => {
 
   describe("getCellFromRow", () => {
     each([
-      [{ CellPhone: "2024561111", CellPhoneDialingPrefix: "1" }, "12024561111"],
       [
         {
           CellPhone: "2024561111",
+          CellPhoneId: "772024561111",
+          CellPhoneDialingPrefix: "1"
+        },
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
+      ],
+      [
+        {
+          CellPhone: "2024561111",
+          CellPhoneId: "772024561111",
           CellPhoneDialingPrefix: "1",
           CellPhoneCountryCode: "US"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
@@ -785,160 +801,270 @@ describe("ngpvan", () => {
         undefined
       ],
       [
-        { OptInPhone: "2024561111", OptInPhoneDialingPrefix: "1" },
-        "12024561111"
+        {
+          OptInPhone: "2024561111",
+          OptInPhoneId: "772024561111",
+          OptInPhoneDialingPrefix: "1"
+        },
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           OptInPhone: "2024561111",
+          OptInPhoneId: "772024561111",
           OptInPhoneDialingPrefix: "1",
           IsOptInPhoneACellExchange: "1"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           OptInPhone: "2024561111",
+          OptInPhoneId: "772024561111",
           OptInPhoneDialingPrefix: "1",
           IsOptInPhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           OptInPhone: "2024561111",
+          OptInPhoneId: "772024561111",
           OptInPhoneDialingPrefix: "1",
           IsOptInPhoneACellExchange: "a"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
-      [{ Phone: "2024561111", PhoneDialingPrefix: "1" }, "12024561111"],
       [
         {
           Phone: "2024561111",
+          PhoneId: "772024561111",
+          PhoneDialingPrefix: "1"
+        },
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
+      ],
+      [
+        {
+          Phone: "2024561111",
+          PhoneId: "772024561111",
           PhoneDialingPrefix: "1",
           IsPhoneACellExchange: "1"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           Phone: "2024561111",
+          PhoneId: "772024561111",
           PhoneDialingPrefix: "1",
           IsPhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           Phone: "2024561111",
+          PhoneId: "772024561111",
           PhoneDialingPrefix: "1",
           IsPhoneACellExchange: "a"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
-      [{ HomePhone: "2024561111", HomePhoneDialingPrefix: "1" }, "12024561111"],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
+          HomePhoneDialingPrefix: "1"
+        },
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
+      ],
+      [
+        {
+          HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "1"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "a"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "1",
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "0",
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "a",
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "0"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ],
       [
         {
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "1"
         },
-        "12024561414"
+        {
+          number: "12024561414",
+          id: "772024561414"
+        }
       ],
       [
         {
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "0"
         },
-        "12024561414"
+        {
+          number: "12024561414",
+          id: "772024561414"
+        }
       ],
       [
         {
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "a"
         },
-        "12024561414"
+        {
+          number: "12024561414",
+          id: "772024561414"
+        }
       ],
-      [{ WorkPhone: "2024561414", WorkPhoneDialingPrefix: "1" }, "12024561414"],
+      [
+        {
+          WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
+          WorkPhoneDialingPrefix: "1"
+        },
+        {
+          number: "12024561414",
+          id: "772024561414"
+        }
+      ],
       [
         {
           HomePhone: "2024561111",
+          HomePhoneId: "772024561111",
           HomePhoneDialingPrefix: "1",
           IsHomePhoneACellExchange: "0",
           WorkPhone: "2024561414",
+          WorkPhoneId: "772024561414",
           WorkPhoneDialingPrefix: "1",
           IsWorkPhoneACellExchange: "1"
         },
-        "12024561111"
+        {
+          number: "12024561111",
+          id: "772024561111"
+        }
       ]
     ]).test("getZipFromRow( %j ) returns %s", (row, allegedPhone) => {
       expect(getCellFromRow(row, false)).toEqual(allegedPhone);
@@ -946,16 +1072,27 @@ describe("ngpvan", () => {
     describe("when cautious is true", () => {
       each([
         [
-          { CellPhone: "2024561111", CellPhoneDialingPrefix: "1" },
-          "12024561111"
+          {
+            CellPhone: "2024561111",
+            CellPhoneId: "772024561111",
+            CellPhoneDialingPrefix: "1"
+          },
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
             CellPhone: "2024561111",
+            CellPhoneId: "772024561111",
             CellPhoneDialingPrefix: "1",
             CellPhoneCountryCode: "US"
           },
-          "12024561111"
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
@@ -969,10 +1106,14 @@ describe("ngpvan", () => {
         [
           {
             OptInPhone: "2024561111",
+            OptInPhoneId: "772024561111",
             OptInPhoneDialingPrefix: "1",
             IsOptInPhoneACellExchange: "1"
           },
-          "12024561111"
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
@@ -990,14 +1131,25 @@ describe("ngpvan", () => {
           },
           undefined
         ],
-        [{ Phone: "2024561111", PhoneDialingPrefix: "1" }, undefined],
         [
           {
             Phone: "2024561111",
+            PhoneId: "772024561111",
+            PhoneDialingPrefix: "1"
+          },
+          undefined
+        ],
+        [
+          {
+            Phone: "2024561111",
+            PhoneId: "772024561111",
             PhoneDialingPrefix: "1",
             IsPhoneACellExchange: "1"
           },
-          "12024561111"
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
@@ -1019,10 +1171,14 @@ describe("ngpvan", () => {
         [
           {
             HomePhone: "2024561111",
+            HomePhoneId: "772024561111",
             HomePhoneDialingPrefix: "1",
             IsHomePhoneACellExchange: "1"
           },
-          "12024561111"
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
@@ -1052,13 +1208,17 @@ describe("ngpvan", () => {
         [
           {
             HomePhone: "2024561111",
+            HomePhoneId: "772024561111",
             HomePhoneDialingPrefix: "1",
             IsHomePhoneACellExchange: "1",
             WorkPhone: "2024561414",
             WorkPhoneDialingPrefix: "1",
             IsWorkPhoneACellExchange: "0"
           },
-          "12024561111"
+          {
+            number: "12024561111",
+            id: "772024561111"
+          }
         ],
         [
           {
@@ -1085,10 +1245,14 @@ describe("ngpvan", () => {
         [
           {
             WorkPhone: "2024561414",
+            WorkPhoneId: "772024561414",
             WorkPhoneDialingPrefix: "1",
             IsWorkPhoneACellExchange: "1"
           },
-          "12024561414"
+          {
+            number: "12024561414",
+            id: "772024561414"
+          }
         ],
         [
           {
@@ -1110,13 +1274,18 @@ describe("ngpvan", () => {
         [
           {
             HomePhone: "2024561111",
+            HomePhoneId: "772024561111",
             HomePhoneDialingPrefix: "1",
             IsHomePhoneACellExchange: "0",
             WorkPhone: "2024561414",
+            WorkPhoneId: "772024561414",
             WorkPhoneDialingPrefix: "1",
             IsWorkPhoneACellExchange: "1"
           },
-          "12024561414"
+          {
+            number: "12024561414",
+            id: "772024561414"
+          }
         ]
       ]).test("getZipFromRow( %j ) returns %s", (row, allegedPhone) => {
         expect(getCellFromRow(row, true)).toEqual(allegedPhone);

--- a/__test__/extensions/contact-loaders/ngpvan/util.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/util.test.js
@@ -126,7 +126,8 @@ describe("ngpvan/util", () => {
       } finally {
         expect(config.getConfig.mock.calls).toEqual([
           ["NGP_VAN_APP_NAME", organization],
-          ["NGP_VAN_API_KEY", organization]
+          ["NGP_VAN_API_KEY", organization],
+          ["NGP_VAN_DATABASE_MODE", organization]
         ]);
         validator(auth, error);
       }

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -69,7 +69,7 @@ export const postCanvassResponse = async (contact, organization, body) => {
   return httpRequest(url, {
     method: "POST",
     retries: 0,
-    timeout: 32000,
+    timeout: Van.getNgpVanTimeout(organization),
     headers: {
       Authorization: Van.getAuth(organization),
       "Content-Type": "application/json"
@@ -107,7 +107,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/contactTypes`,
     {
       method: "GET",
-      timeout: 32000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -125,7 +125,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     `https://api.securevan.com/v4/canvassResponses/inputTypes`,
     {
       method: "GET",
-      timeout: 32000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -208,7 +208,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/surveyQuestions?statuses=Active${cycleFilter}`,
     {
       method: "GET",
-      timeout: 32000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -226,7 +226,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/activistCodes?statuses=Active`,
     {
       method: "GET",
-      timeout: 32000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization)
       }
@@ -244,7 +244,7 @@ export async function getClientChoiceData(organization) {
     `https://api.securevan.com/v4/canvassResponses/resultCodes`,
     {
       method: "GET",
-      timeout: 32000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization)
       }

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -37,11 +37,13 @@ export function clientChoiceDataCacheKey(organization) {
   return `${organization.id}`;
 }
 
-export const postCanvassResponse = async (contact, organization, body) => {
+export const postCanvassResponse = async (contact, organization, bodyInput) => {
   let vanId;
+  let vanPhoneId;
   try {
     const customFields = JSON.parse(contact.custom_fields || "{}");
     vanId = customFields.VanID || customFields.vanid;
+    vanPhoneId = customFields.VanPhoneId || customFields.vanPhoneId;
   } catch (caughtException) {
     // eslint-disable-next-line no-console
     console.error(
@@ -58,6 +60,13 @@ export const postCanvassResponse = async (contact, organization, body) => {
     return {};
   }
 
+  const body = {
+    ...bodyInput
+  };
+
+  if (vanPhoneId) {
+    body.canvassContext.phoneId = vanPhoneId;
+  }
   const url = Van.makeUrl(`v4/people/${vanId}/canvassResponses`, organization);
 
   // eslint-disable-next-line no-console

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -104,7 +104,7 @@ export async function processAction({
 
 async function getContactTypeIdAndInputTypeId(organization) {
   const contactTypesPromise = httpRequest(
-    `https://api.securevan.com/v4/canvassResponses/contactTypes`,
+    Van.makeUrl(`v4/canvassResponses/contactTypes`),
     {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
@@ -122,7 +122,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
     });
 
   const inputTypesPromise = httpRequest(
-    `https://api.securevan.com/v4/canvassResponses/inputTypes`,
+    Van.makeUrl(`v4/canvassResponses/inputTypes`),
     {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
@@ -205,7 +205,7 @@ export async function getClientChoiceData(organization) {
   const cycle = await getConfig("NGP_VAN_ELECTION_CYCLE_FILTER", organization);
   const cycleFilter = (cycle && `&cycle=${cycle}`) || "";
   const surveyQuestionsPromise = httpRequest(
-    `https://api.securevan.com/v4/surveyQuestions?statuses=Active${cycleFilter}`,
+    Van.makeUrl(`v4/surveyQuestions?statuses=Active${cycleFilter}&$top=200`),
     {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
@@ -223,7 +223,7 @@ export async function getClientChoiceData(organization) {
     });
 
   const activistCodesPromise = httpRequest(
-    `https://api.securevan.com/v4/activistCodes?statuses=Active`,
+    Van.makeUrl(`v4/activistCodes?statuses=Active&$top=200`),
     {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
@@ -241,7 +241,7 @@ export async function getClientChoiceData(organization) {
     });
 
   const canvassResultCodesPromise = httpRequest(
-    `https://api.securevan.com/v4/canvassResponses/resultCodes`,
+    Van.makeUrl(`v4/canvassResponses/resultCodes?$top=200`),
     {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -119,7 +119,7 @@ export async function getClientChoiceData(organization, campaign, user) {
         Authorization: Van.getAuth(organization)
       },
       retries: 0,
-      timeout: 5000
+      timeout: Van.getNgpVanTimeout(organization)
     });
 
     responseJson = await response.json();
@@ -268,7 +268,7 @@ export async function processContactLoad(job, maxContacts, organization) {
     const response = await HttpRequest(url, {
       method: "POST",
       retries: 0,
-      timeout: 5000,
+      timeout: Van.getNgpVanTimeout(organization),
       headers: {
         Authorization: Van.getAuth(organization),
         "Content-Type": "application/json"
@@ -319,7 +319,7 @@ export async function processContactLoad(job, maxContacts, organization) {
     vanResponse = await HttpRequest(downloadUrl, {
       method: "GET",
       retries: 0,
-      timeout: 5000
+      timeout: Van.getNgpVanTimeout(organization)
     });
   } catch (error) {
     await exports.handleFailedContactLoad(

--- a/src/extensions/contact-loaders/ngpvan/util.js
+++ b/src/extensions/contact-loaders/ngpvan/util.js
@@ -1,11 +1,13 @@
 import { getConfig } from "../../../server/api/lib/config";
 
 export const DEFAULT_NGP_VAN_API_BASE_URL = "https://api.securevan.com";
+export const DEFAULT_NGP_VAN_DATABASE_MODE = 0;
 
 export default class Van {
   static getAuth = organization => {
     const appName = getConfig("NGP_VAN_APP_NAME", organization);
     const apiKey = getConfig("NGP_VAN_API_KEY", organization);
+    const databaseMode = getConfig("NGP_VAN_DATABASE_MODE", organization);
 
     if (!appName || !apiKey) {
       throw new Error(
@@ -13,7 +15,9 @@ export default class Van {
       );
     }
 
-    const buffer = Buffer.from(`${appName}:${apiKey}|0`);
+    const buffer = Buffer.from(
+      `${appName}:${apiKey}|${databaseMode || DEFAULT_NGP_VAN_DATABASE_MODE}`
+    );
     return `Basic ${buffer.toString("base64")}`;
   };
 

--- a/src/extensions/contact-loaders/ngpvan/util.js
+++ b/src/extensions/contact-loaders/ngpvan/util.js
@@ -2,6 +2,7 @@ import { getConfig } from "../../../server/api/lib/config";
 
 export const DEFAULT_NGP_VAN_API_BASE_URL = "https://api.securevan.com";
 export const DEFAULT_NGP_VAN_DATABASE_MODE = 0;
+export const DEFAULT_NGPVAN_TIMEOUT = 32000;
 
 export default class Van {
   static getAuth = organization => {
@@ -26,5 +27,9 @@ export default class Van {
       getConfig("NGP_VAN_API_BASE_URL", organization) ||
       DEFAULT_NGP_VAN_API_BASE_URL;
     return `${baseUrl}/${pathAndQuery}`;
+  };
+
+  static getNgpVanTimeout = organization => {
+    return getConfig("NGP_VAN_TIMEOUT", organization) || DEFAULT_NGPVAN_TIMEOUT;
   };
 }

--- a/src/lib/parse_csv.js
+++ b/src/lib/parse_csv.js
@@ -86,7 +86,8 @@ export const parseCSV = (file, onCompleteCallback, options) => {
   //   returns the header that should be used for the column. An example
   //   would be to transform first_name to firstName, which is a required
   //   field in Spoke.
-  const { rowTransformer, headerTransformer } = options || {};
+  const { rowTransformer, headerTransformer, additionalCustomFields = [] } =
+    options || {};
   Papa.parse(file, {
     header: true,
     ...(headerTransformer && { transformHeader: headerTransformer }),
@@ -127,9 +128,10 @@ export const parseCSV = (file, onCompleteCallback, options) => {
       } else {
         const { validationStats, validatedData } = getValidatedData(data);
 
-        const customFields = fields.filter(
+        let customFields = fields.filter(
           field => topLevelUploadFields.indexOf(field) === -1
         );
+        customFields = [...customFields, ...additionalCustomFields];
 
         const contactsWithCustomFields = organizationCustomFields(
           validatedData,


### PR DESCRIPTION
## Description

- We had previously hard coded database mode to `0` (my voters). But sometimes people want to use my campaign. I added the environment variable `NGP_VAN_DATABASE_MODE` which can be set to 0 for my voters or 1 for my campaign.  If it's not specified, Spoke will default it to 0.
- Timeout for all VAN calls was hardcoded before, in some cases to 5 seconds. Now it defaults to 32 seconds for all calls to the VAN API, and it's configurable with `NGP_VAN_TIMEOUT`.
- Send phoneId in canvassContext in people/canvassResponses call. This is necessary because some updates disqualify the person, rather than the affected phone number, if we don't pass the phoneId. Confirmed with VAN that it's innocuous to always send it. VAN will use it only if applicable.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
