### PR TITLE
Small phone inventory improvements

### DIFF
--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -166,7 +166,8 @@ class AdminPhoneNumberInventory extends React.Component {
             {...dataTest("areaCode")}
           />
           <Form.Field label="Limit" name="limit" {...dataTest("limit")} />
-          {this.props.data.organization.twilioMessageServiceSid ? (
+          {this.props.data.organization.twilioMessageServiceSid
+            && !this.props.data.organization.campaignPhoneNumbersEnabled ? (
             <Form.Field
               label="Add to this organization's Messaging Service"
               name="addToOrganizationMessagingService"
@@ -264,6 +265,7 @@ const queries = {
         organization(id: $organizationId) {
           id
           twilioMessageServiceSid
+          campaignPhoneNumbersEnabled
           phoneNumberCounts {
             areaCode
             state

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -49,7 +49,9 @@ class AdminPhoneNumberInventory extends React.Component {
       buyNumbersDialogOpen: false,
       buyNumbersFormValues: {
         addToOrganizationMessagingService: false
-      }
+      },
+      sortCol: 'areaCode',
+      sortOrder: 'asc'
     };
   }
 
@@ -150,6 +152,17 @@ class AdminPhoneNumberInventory extends React.Component {
     ];
   }
 
+  sortTable(table, key, order) {
+    table.sort((a, b) => {
+      if (order == 'desc') {
+        return a[key] < b[key] ? 1 : -1;
+      }
+      if (order == 'asc') {
+        return a[key] > b[key] ? 1 : -1;
+      }
+    });
+  }
+
   renderBuyNumbersForm() {
     return (
       <GSForm
@@ -216,16 +229,14 @@ class AdminPhoneNumberInventory extends React.Component {
         availableCount: 0
       }));
     const tableData = [...newAreaCodeRows, ...phoneNumberCounts];
+    this.sortTable(tableData, this.state.sortCol, this.state.sortOrder);
     const handleSortOrderChange = (key, order) => {
-      tableData.sort((a,b) => {
-        if (order == 'asc') {
-          return a[key] < b[key] ? 1 : -1;
-        }
-        if (order == 'desc') {
-          return a[key] > b[key] ? 1 : -1;
-        }
-      })
-    }
+      this.setState({
+        sortCol: key,
+        sortOrder: order
+      });
+      this.sortTable(tableData, key, order);
+    };
     return (
       <div>
         <DataTables
@@ -235,7 +246,7 @@ class AdminPhoneNumberInventory extends React.Component {
           count={tableData.length}
           showFooterToolbar={false}
           showRowHover
-          initialSort={{column: 'areaCode', order: 'desc'}}
+          initialSort={{column: 'areaCode', order: 'asc'}}
           onSortOrderChange={handleSortOrderChange}
         />
         <FloatingActionButton


### PR DESCRIPTION
## Description

Two minor improvements in here:

1. Hides the "Add to this organization's Messaging Service" toggle if the Campaign Phone Numbers feature is turned on. If that feature is enabled, then numbers added to the messaging service can't actually be used for campaigns, so the option just causes confusion.

2. Fixes sorting for the inventor table so that it's sorted on initial load and stays sorted when numbers are added.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
