### PR TITLE
leading - in campaign search excludes the search term

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -45,14 +45,23 @@ export function addCampaignsFilterToQuery(
     }
 
     if ("searchString" in campaignsFilter && campaignsFilter.searchString) {
+      var neg =
+        campaignsFilter.searchString.length > 0 &&
+        campaignsFilter.searchString[0] === "-";
       const searchStringWithPercents = (
         "%" +
-        campaignsFilter.searchString +
+        campaignsFilter.searchString.slice(neg) +
         "%"
       ).toLocaleLowerCase();
-      query = query.andWhere(
-        r.knex.raw(`${title} like ?`, [searchStringWithPercents])
-      );
+      if (neg) {
+        query = query.andWhere(
+          r.knex.raw(`${title} not like ?`, [searchStringWithPercents])
+        );
+      } else {
+        query = query.andWhere(
+          r.knex.raw(`${title} like ?`, [searchStringWithPercents])
+        );
+      }
     }
 
     if (resultSize && !pageSize) {


### PR DESCRIPTION
# Fixes # (issue)
https://github.com/MoveOnOrg/Spoke/issues/1640

## Description

I added support for this by checking if the search term starts with a "-", if so it filters out campaigns that match the rest of the search term.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
Looks like there is no search documentation. Should I add it?
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
