### PR TITLE
Lp clear org and extension caches

### DIFF
--- a/src/components/OrganizationFeatureSettings.jsx
+++ b/src/components/OrganizationFeatureSettings.jsx
@@ -1,22 +1,10 @@
 import type from "prop-types";
 import React from "react";
-import orderBy from "lodash/orderBy";
-import Slider from "./Slider";
-import Divider from "material-ui/Divider";
-import AutoComplete from "material-ui/AutoComplete";
-import IconButton from "material-ui/IconButton";
-import RaisedButton from "material-ui/RaisedButton";
 import GSForm from "../components/forms/GSForm";
 import yup from "yup";
 import Form from "react-formal";
-import OrganizationJoinLink from "./OrganizationJoinLink";
-import CampaignFormSectionHeading from "./CampaignFormSectionHeading";
-import { StyleSheet, css } from "aphrodite";
-import theme from "../styles/theme";
 import Toggle from "material-ui/Toggle";
-import DeleteIcon from "material-ui/svg-icons/action/delete";
 import { dataTest } from "../lib/attributes";
-import { dataSourceItem } from "./utils";
 
 const configurableFields = {
   ACTION_HANDLERS: {

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -395,16 +395,6 @@ class Settings extends React.Component {
                 saveLabel="Save settings"
                 saveDisabled={!this.state.settings}
               />
-              <h2>DEBUG Zone</h2>
-              <p>Only take actions here if you know what you&rquo;re doing</p>
-              <RaisedButton
-                label="Clear Cached Organization And Extension Caches"
-                secondary
-                style={inlineStyles.dialogButton}
-                onTouchTap={
-                  this.props.mutations.clearCachedOrgAndExtensionCaches
-                }
-              />
             </CardText>
           </Card>
         ) : null}
@@ -418,6 +408,8 @@ class Settings extends React.Component {
               showExpandableButton={true}
             />
             <CardText expandable>
+              <h2>DEBUG Zone</h2>
+              <p>Only take actions here if you know what you&rsquo;re doing</p>
               <RaisedButton
                 label="Clear Cached Organization And Extension Caches"
                 secondary

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -408,6 +408,27 @@ class Settings extends React.Component {
             </CardText>
           </Card>
         ) : null}
+
+        {this.props.data.organization && this.props.params.adminPerms ? (
+          <Card>
+            <CardHeader
+              title="External configuration"
+              style={{ backgroundColor: theme.colors.green }}
+              actAsExpander={true}
+              showExpandableButton={true}
+            />
+            <CardText expandable>
+              <RaisedButton
+                label="Clear Cached Organization And Extension Caches"
+                secondary
+                style={inlineStyles.dialogButton}
+                onTouchTap={
+                  this.props.mutations.clearCachedOrgAndExtensionCaches
+                }
+              />
+            </CardText>
+          </Card>
+        ) : null}
       </div>
     );
   }


### PR DESCRIPTION
## Description

This PR provides a button in the UI and a mutation for administrators to remove the cached organization object from the redis cache, which is necessary when 

* they use a SQL client to modify `organization.features`
* metadata changes in an external resource, such as NGP VAN (the use cases in VAN is that a saved list was added or survey questions or activists code were modified; Spoke's VAN integration won't go back to VAN through the API if those metadata are present in the cache).

<img width="1146" alt="Screen Shot 2020-08-24 at 9 52 15 AM" src="https://user-images.githubusercontent.com/1637288/91052483-87697000-e5ef-11ea-9c76-2afbdf352cb7.png">



# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
