### PR TITLE
Add importing of response tags

### DIFF
--- a/docs/HOWTO_IMPORT_GOOGLE_DOCS_SCRIPTS_TO_IMPORT.md
+++ b/docs/HOWTO_IMPORT_GOOGLE_DOCS_SCRIPTS_TO_IMPORT.md
@@ -70,7 +70,7 @@ It's a horrible idea to publish live secrets to Github. You should never do that
 
 ## Create script documents
 
-1. Create a script from a Google Doc Spoke script template - see for example https://docs.google.com/document/d/1zKRbDU9vwetJlfWYgSGd1taBEVj_QrI7bhu4snvHlmg/edit
+1. Create a script from a Google Doc Spoke script template - see for example https://docs.google.com/document/d/1gFji2Vh_0svb4j7VUtmJZkqNhRWt3htp_bdGoWh6S6w/edit
 2. Copy the template, create a new draft doc with that and save it, then edit the new script doc, not the template :)
 3. Share the script document with your API user.
    - Go to the document in Google Docs.

--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -340,7 +340,7 @@ const makeCannedResponsesList = cannedResponsesParagraphs => {
       if (textParagraph.isParagraphItalic) {
         // Italic = tag.
         const tagId = textParagraph.text.match(/^\d*\b/);
-        if (!!tagId[0]) {
+        if (tagId && !!tagId[0]) {
           cannedResponse.tagIds.push(tagId[0])
         }
       }

--- a/src/server/api/lib/import-script.js
+++ b/src/server/api/lib/import-script.js
@@ -320,7 +320,8 @@ const makeCannedResponsesList = cannedResponsesParagraphs => {
   const cannedResponses = [];
   while (cannedResponsesParagraphs[0]) {
     const cannedResponse = {
-      text: []
+      text: [],
+      tagIds: []
     };
 
     const paragraph = cannedResponsesParagraphs.shift();
@@ -336,7 +337,17 @@ const makeCannedResponsesList = cannedResponsesParagraphs => {
       !cannedResponsesParagraphs[0].isParagraphBold
     ) {
       const textParagraph = cannedResponsesParagraphs.shift();
-      cannedResponse.text.push(textParagraph.text);
+      if (textParagraph.isParagraphItalic) {
+        // Italic = tag.
+        const tagId = textParagraph.text.match(/^\d*\b/);
+        if (!!tagId[0]) {
+          cannedResponse.tagIds.push(tagId[0])
+        }
+      }
+      else {
+        // Regular text, add to response.
+        cannedResponse.text.push(textParagraph.text);
+      }
     }
 
     if (!cannedResponse.text[0]) {
@@ -355,32 +366,62 @@ const replaceCannedResponsesInDatabase = async (
   campaignId,
   cannedResponses
 ) => {
+  const convertedResponses = [];
+  for (let index = 0; index < cannedResponses.length; index++) {
+    const response = cannedResponses[index];
+    convertedResponses.push({
+      ...response,
+      text: response.text.join("\n"),
+      campaign_id: campaignId,
+      id: undefined
+    });
+  }
+
+  // delete canned response / tag relations from tag_canned_response
   await r.knex.transaction(async trx => {
-    try {
-      await r
+    await trx("tag_canned_response")
+      .whereIn(
+        "canned_response_id",
+        r
         .knex("canned_response")
-        .transacting(trx)
+        .select("id")
         .where({
           campaign_id: campaignId
         })
-        .whereNull("user_id")
-        .delete();
+      )
+      .delete();
+    // delete canned responses
+    await trx("canned_response")
+      .where({
+        campaign_id: campaignId
+      })
+      .whereNull("user_id")
+      .delete();
 
-      for (const cannedResponse of cannedResponses) {
-        await r.knex
-          .insert({
-            campaign_id: campaignId,
-            user_id: null,
-            title: cannedResponse.title,
-            text: cannedResponse.text.join("\n")
-          })
-          .into("canned_response")
-          .transacting(trx);
-      }
-    } catch (exception) {
-      console.log(exception);
-      throw exception;
-    }
+    // save new canned responses and add their ids with related tag ids to tag_canned_response
+    const saveCannedResponse = async cannedResponse => {
+      const [res] = await trx("canned_response").insert(
+        cannedResponse, [
+          "id"
+        ]);
+      return res.id;
+    };
+    const tagCannedResponses = await Promise.all(
+      convertedResponses.map(async response => {
+        const {
+          tagIds,
+          ...filteredResponse
+        } = response;
+        const responseId = await saveCannedResponse(
+          filteredResponse);
+        return (tagIds || []).map(t => ({
+          tag_id: t,
+          canned_response_id: responseId
+        }));
+      })
+    );
+    await trx("tag_canned_response").insert(_.flatten(
+    tagCannedResponses));
   });
 };
 


### PR DESCRIPTION
## Description

Based off #1705, adds importing of associated tags with canned responses for the google doc importer.

One flag: I'm using _italicized_ text to indicate the tags in the Canned Response section, which is the same formatting used to indicate action handlers in the Interactions section. If we were to ever add a feature for directly associating action handlers with canned responses, that could be an issue. But I'm assuming that won't be the case and this will be fine.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
