### PR TITLE
Allow admins and supervols to see organization settings

### DIFF
--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -339,6 +339,7 @@ class Settings extends React.Component {
         <div>{this.renderTextingHoursForm()}</div>
         {window.TWILIO_MULTI_ORG && this.renderTwilioAuthForm()}
         {this.props.data.organization &&
+        this.props.data.organization.texterUIConfig &&
         this.props.data.organization.texterUIConfig.sideboxChoices.length ? (
           <Card>
             <CardHeader

--- a/src/server/api/mutations/clearCachedOrgAndExtensionCaches.js
+++ b/src/server/api/mutations/clearCachedOrgAndExtensionCaches.js
@@ -9,7 +9,7 @@ export const clearCachedOrgAndExtensionCaches = async (
   { organizationId },
   { user }
 ) => {
-  await accessRequired(user, organizationId, "ADMIN", true);
+  await accessRequired(user, organizationId, "OWNER");
 
   if (!r.redis) {
     return "Redis not configured. No need to clear organization caches";

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -208,16 +208,17 @@ export const resolvers = {
     texterUIConfig: async (organization, _, { user }) => {
       try {
         await accessRequired(user, organization.id, "OWNER");
-        const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
-        // note this is global, since we need the set that's globally enabled/allowed to choose from
-        const sideboxChoices = getSideboxChoices();
-        return {
-          options,
-          sideboxChoices
-        };
       } catch (caught) {
         return null;
       }
+
+      const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
+      // note this is global, since we need the set that's globally enabled/allowed to choose from
+      const sideboxChoices = getSideboxChoices();
+      return {
+        options,
+        sideboxChoices
+      };
     },
     cacheable: (org, _, { user }) =>
       //quanery logic.  levels are 0, 1, 2

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -206,14 +206,18 @@ export const resolvers = {
     textingHoursStart: organization => organization.texting_hours_start,
     textingHoursEnd: organization => organization.texting_hours_end,
     texterUIConfig: async (organization, _, { user }) => {
-      await accessRequired(user, organization.id, "OWNER");
-      const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
-      // note this is global, since we need the set that's globally enabled/allowed to choose from
-      const sideboxChoices = getSideboxChoices();
-      return {
-        options,
-        sideboxChoices
-      };
+      try {
+        await accessRequired(user, organization.id, "OWNER");
+        const options = getConfig("TEXTER_UI_SETTINGS", organization) || null;
+        // note this is global, since we need the set that's globally enabled/allowed to choose from
+        const sideboxChoices = getSideboxChoices();
+        return {
+          options,
+          sideboxChoices
+        };
+      } catch (caught) {
+        return null;
+      }
     },
     cacheable: (org, _, { user }) =>
       //quanery logic.  levels are 0, 1, 2


### PR DESCRIPTION
## Description

Supervols and admins were getting a graphql error when they tried to navigate to the organization | settings panel. That was happening because we weren't handling the case where someone with less privilege than an owner requested TexterUIConfig on the organization object. Now, that doesn't cause an error, and attempting to request it will return null. In that case, `Texter UI Defaults` doesn't render on organization settings.

This PR also restricts the new cache reset button to owners.  I made that change based on feedback from one of the Spoke user organizations.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
