### PR TITLE
8.2 PR -- scaling improvements

### DIFF
--- a/docs/HOWTO-use-message-handlers.md
+++ b/docs/HOWTO-use-message-handlers.md
@@ -68,7 +68,7 @@ The best way to make a new message handler is something like this in the codebas
 
 ```
 cd src/extensions/message-handlers
-cp -rp initaltext-guard <NEW_STRATEGY_NAME>
+cp -rp initaltext-guard <NEW_NAME>
 ```
 
 Then edit index.js in that directory.

--- a/docs/HOWTO-use-texter-sideboxes.md
+++ b/docs/HOWTO-use-texter-sideboxes.md
@@ -115,7 +115,7 @@ The best way to make a new texter sidebox is to copy an existing one and then ed
 
 ```
 cd src/extensions/texter-sideboxes
-cp -rp celebration-gif <NEW_STRATEGY_NAME>
+cp -rp celebration-gif <NEW_NAME>
 ```
 
 Then edit react-component.js in that directory.

--- a/migrations/20190207220000_init_db.js
+++ b/migrations/20190207220000_init_db.js
@@ -220,7 +220,7 @@ const initialize = async (knex, Promise) => {
       create: t => {
         t.increments("id");
         t.text("cell").notNullable();
-        t.integer("assignment_id").notNullable();
+        t.integer("assignment_id");
         t.integer("organization_id").notNullable();
         t.text("reason_code")
           .notNullable()

--- a/migrations/20200826173603_optout_assignmentid_null.js
+++ b/migrations/20200826173603_optout_assignmentid_null.js
@@ -1,0 +1,23 @@
+exports.up = async knex => {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  if (!isSqlite) {
+    await knex.schema.alterTable("opt_out", table => {
+      table
+        .integer("assignment_id")
+        .alter()
+        .nullable();
+    });
+  }
+};
+
+exports.down = async knex => {
+  const isSqlite = /sqlite/.test(knex.client.config.client);
+  if (!isSqlite) {
+    await knex.schema.alterTable("opt_out", table => {
+      table
+        .integer("assignment_id")
+        .alter()
+        .notNullable();
+    });
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spoke",
-  "version": "8.1.0",
+  "version": "9.0.0",
   "description": "Spoke",
   "main": "src/server",
   "engines": {

--- a/src/api/assignment.js
+++ b/src/api/assignment.js
@@ -8,7 +8,7 @@ export const schema = `
     texter: User
     campaign: Campaign
     contacts(contactsFilter: ContactsFilter): [CampaignContact]
-    contactsCount(contactsFilter: ContactsFilter): Int
+    contactsCount(contactsFilter: ContactsFilter, hasAny: Boolean): Int
     hasUnassignedContactsForTexter: Int
     userCannedResponses: [CannedResponse]
     campaignCannedResponses: [CannedResponse]

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -128,7 +128,6 @@ export class AssignmentSummary extends Component {
       id: campaignId,
       title,
       description,
-      dueBy,
       primaryColor,
       logoImageUrl,
       introHtml,
@@ -154,7 +153,7 @@ export class AssignmentSummary extends Component {
           <CardTitle
             title={title}
             titleStyle={{ color: cardTitleTextColor }}
-            subtitle={`${description} - ${moment(dueBy).format("MMM D YYYY")}`}
+            subtitle={description}
             subtitleStyle={{ color: cardTitleTextColor }}
             style={{
               backgroundColor: primaryColor

--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -8,6 +8,8 @@ import loadData from "./hoc/load-data";
 import gql from "graphql-tag";
 import { withRouter } from "react-router";
 
+let refreshOnReturn = false;
+
 class TexterTodoList extends React.Component {
   constructor(props) {
     super(props);
@@ -45,7 +47,10 @@ class TexterTodoList extends React.Component {
       .filter(ele => ele !== null);
   }
   componentDidMount() {
-    this.props.data.refetch();
+    console.log("TexterTodoList componentDidMount");
+    if (refreshOnReturn) {
+      this.props.data.refetch();
+    }
     // stopPolling is broken (at least in currently used version), so we roll our own so we can unmount correctly
     if (
       this.props.data &&
@@ -67,6 +72,8 @@ class TexterTodoList extends React.Component {
       clearInterval(this.state.polling);
       this.setState({ polling: null });
     }
+    // not state: maintain this forever after
+    refreshOnReturn = true;
   }
 
   termsAgreed() {

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -43,10 +43,8 @@ export const available = organization => {
   }
 };
 
-// export const preMessageSave = async () => {};
-
-export const postMessageSave = async ({ message, organization }) => {
-  if (message.is_from_contact) {
+export const preMessageSave = async ({ messageToSave, organization }) => {
+  if (messageToSave.is_from_contact) {
     const config = Buffer.from(
       getConfig("AUTO_OPTOUT_REGEX_LIST_BASE64", organization) ||
         DEFAULT_AUTO_OPTOUT_REGEX_LIST_BASE64,
@@ -55,26 +53,47 @@ export const postMessageSave = async ({ message, organization }) => {
     const regexList = JSON.parse(config || "[]");
     const matches = regexList.filter(matcher => {
       const re = new RegExp(matcher.regex, "i");
-      return String(message.text).match(re);
+      return String(messageToSave.text).match(re);
     });
-
+    console.log("auto-optout", matches, messageToSave.text, regexList);
     if (matches.length) {
-      console.log("auto-optout MATCH", message.campaign_contact_id, matches);
-      const reason = matches[0].reason || "auto_optout";
-      // FUTURE: if we change assignment_id as NOT NULLable,
-      // then we can skip this load
-      const contact = await cacheableData.campaignContact.load(
-        message.campaign_contact_id
+      console.log(
+        "auto-optout MATCH",
+        messageToSave.campaign_contact_id,
+        matches
       );
-      // OPTOUT
-      await cacheableData.optOut.save({
-        cell: message.contact_number,
-        campaignContactId: message.campaign_contact_id,
-        assignmentId: contact.assignment_id,
-        campaign: { organization_id: organization.id },
-        noReply: true,
-        reason
-      });
+      const reason = matches[0].reason || "auto_optout";
+      return {
+        contactUpdates: { is_opted_out: true, error_code: -133 },
+        hanlderContext: { autoOptOutReason: reason }
+      };
     }
+  }
+};
+
+export const postMessageSave = async ({
+  message,
+  organization,
+  handlerContext
+}) => {
+  if (message.is_from_contact && handlerContext.autoOptOutReason) {
+    // FUTURE: if we change assignment_id as NOT NULLable,
+    // then we can skip this load
+    const contact = await cacheableData.campaignContact.load(
+      message.campaign_contact_id,
+      { cacheOnly: true }
+    );
+    // OPTOUT
+    await cacheableData.optOut.save({
+      cell: message.contact_number,
+      campaignContactId: message.campaign_contact_id,
+      assignmentId: (contact && contact.assignment_id) || null,
+      campaign: { organization_id: organization.id },
+      noReply: true,
+      reason: handlerContext.autoOptOutReason,
+      // RISKY: we depend on the contactUpdates in preMessageSave
+      // but this can relieve a lot of database pressure
+      noContactUpdate: true
+    });
   }
 };

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -63,9 +63,11 @@ export const preMessageSave = async ({ messageToSave, organization }) => {
         matches
       );
       const reason = matches[0].reason || "auto_optout";
+      messageToSave.error_code = -133;
       return {
         contactUpdates: { is_opted_out: true, error_code: -133 },
-        hanlderContext: { autoOptOutReason: reason }
+        handlerContext: { autoOptOutReason: reason },
+        messageToSave
       };
     }
   }
@@ -77,8 +79,11 @@ export const postMessageSave = async ({
   handlerContext
 }) => {
   if (message.is_from_contact && handlerContext.autoOptOutReason) {
-    // FUTURE: if we change assignment_id as NOT NULLable,
-    // then we can skip this load
+    console.log(
+      "auto-optout.postMessageSave",
+      message.campaign_contact_id,
+      handlerContext.autoOptOutReason
+    );
     const contact = await cacheableData.campaignContact.load(
       message.campaign_contact_id,
       { cacheOnly: true }

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -59,12 +59,14 @@ export const postMessageSave = async ({ message, organization }) => {
     });
 
     if (matches.length) {
-      console.log("auto-optout MATCH", matches);
+      console.log("auto-optout MATCH", message.campaign_contact_id, matches);
       const reason = matches[0].reason || "auto_optout";
-      // OPTOUT
+      // FUTURE: if we change assignment_id as NOT NULLable,
+      // then we can skip this load
       const contact = await cacheableData.campaignContact.load(
         message.campaign_contact_id
       );
+      // OPTOUT
       await cacheableData.optOut.save({
         cell: message.contact_number,
         campaignContactId: message.campaign_contact_id,

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -33,23 +33,10 @@ export function addWhereClauseForContactsFilterMessageStatusIrrespectiveOfPastDu
   return query;
 }
 
-export function getContacts(
-  assignment,
-  contactsFilter,
-  organization,
-  campaign,
-  forCount = false
-) {
-  // / returns list of contacts eligible for contacting _now_ by a particular user
+export function getCampaignOffsets(campaign, organization, timezoneFilter) {
   const textingHoursEnforced = organization.texting_hours_enforced;
   const textingHoursStart = organization.texting_hours_start;
   const textingHoursEnd = organization.texting_hours_end;
-
-  // 24-hours past due - why is this 24 hours offset?
-  const includePastDue = contactsFilter && contactsFilter.includePastDue;
-  const pastDue =
-    campaign.due_by &&
-    Number(campaign.due_by) + 24 * 60 * 60 * 1000 < Number(new Date());
   const config = { textingHoursStart, textingHoursEnd, textingHoursEnforced };
 
   if (campaign.override_organization_texting_hours) {
@@ -65,8 +52,39 @@ export function getContacts(
       timezone
     };
   }
-
   const [validOffsets, invalidOffsets] = getOffsets(config);
+  const defaultIsValid = defaultTimezoneIsBetweenTextingHours(config);
+  if (timezoneFilter === true && defaultIsValid) {
+    // missing timezone ok
+    validOffsets.push("");
+  } else if (timezoneFilter === false && !defaultIsValid) {
+    invalidOffsets.push("");
+  }
+
+  return {
+    validOffsets,
+    invalidOffsets
+  };
+}
+
+export function getContacts(
+  assignment,
+  contactsFilter,
+  organization,
+  campaign,
+  forCount = false
+) {
+  // / returns list of contacts eligible for contacting _now_ by a particular user
+  // 24-hours past due - why is this 24 hours offset?
+  const includePastDue = contactsFilter && contactsFilter.includePastDue;
+  const pastDue =
+    campaign.due_by &&
+    Number(campaign.due_by) + 24 * 60 * 60 * 1000 < Number(new Date());
+  const { validOffsets, invalidOffsets } = getCampaignOffsets(
+    campaign,
+    organization,
+    contactsFilter && contactsFilter.validTimezone
+  );
   if (
     !includePastDue &&
     pastDue &&
@@ -87,16 +105,8 @@ export function getContacts(
       const validTimezone = contactsFilter.validTimezone;
       if (validTimezone !== null) {
         if (validTimezone === true) {
-          if (defaultTimezoneIsBetweenTextingHours(config)) {
-            // missing timezone ok
-            validOffsets.push("");
-          }
           query = query.whereIn("timezone_offset", validOffsets);
         } else if (validTimezone === false) {
-          if (!defaultTimezoneIsBetweenTextingHours(config)) {
-            // missing timezones are not ok to text
-            invalidOffsets.push("");
-          }
           query = query.whereIn("timezone_offset", invalidOffsets);
         }
       }
@@ -187,7 +197,7 @@ export const resolvers = {
     },
     contactsCount: async (
       assignment,
-      { contactsFilter },
+      { contactsFilter, hasAny },
       { loaders },
       apolloRequestContext
     ) => {
@@ -214,12 +224,84 @@ export const resolvers = {
       const organization = await loaders.organization.load(
         campaign.organization_id
       );
-
-      return await r.getCount(
-        getContacts(assignment, contactsFilter, organization, campaign, true)
-      );
+      if (assignment.tzStatusCounts) {
+        // TODO: when there is no contacts filter
+        if (
+          contactsFilter &&
+          contactsFilter.messageStatus &&
+          !assignment.tzStatusCounts[contactsFilter.messageStatus]
+        ) {
+          return 0; // that was easy
+        }
+        const { validOffsets, invalidOffsets } = getCampaignOffsets(
+          campaign,
+          organization,
+          contactsFilter && contactsFilter.validTimezone
+        );
+        if (contactsFilter && !contactsFilter.messageStatus) {
+          // ASSUME: invalidTimezones
+          const invalidTzCount = Object.keys(assignment.tzStatusCounts)
+            .map(m => ({ key: m, val: assignment.tzStatusCounts[m] })) // .entries post-node10.x
+            .filter(
+              ({ key, val }) =>
+                key === "needsMessage" || key === "needsResponse"
+            )
+            .map(({ key, val }) =>
+              val
+                .filter(x => invalidOffsets.indexOf(x.tz) !== -1)
+                .map(x => Number(x.count))
+                .reduce((a, b) => {
+                  console.log("reduce", a, b);
+                  return a + b;
+                }, 0)
+            )
+            .reduce((a, b) => a + b, 0);
+          console.log(
+            "invalidTimezones",
+            invalidTzCount,
+            Object.values(assignment.tzStatusCounts).map(arr =>
+              arr
+                .filter(x => invalidOffsets.indexOf(x.tz) !== -1)
+                .map(x => Number(x.count))
+                .reduce((a, b) => a + b, 0)
+            ),
+            assignment.tzStatusCounts
+          );
+          return invalidTzCount;
+        }
+        // ASSUME: messageStatus with validTimezones
+        if (
+          contactsFilter &&
+          contactsFilter.messageStatus &&
+          contactsFilter.validTimezones
+        ) {
+          return assignment.tzStatusCounts[contactsFilter.messageStatus]
+            .filter(x => validOffsets.indexOf(x.tz) !== -1)
+            .map(x => Number(x.count))
+            .reduce((a, b) => a + b, 0);
+        }
+      }
+      if (hasAny) {
+        const exists = await getContacts(
+          assignment,
+          contactsFilter,
+          organization,
+          campaign,
+          true
+        )
+          .select("campaign_contact.id")
+          .first();
+        return exists ? 1 : 0;
+      } else {
+        return await r.getCount(
+          getContacts(assignment, contactsFilter, organization, campaign, true)
+        );
+      }
     },
     contacts: async (assignment, { contactsFilter }, { loaders }) => {
+      if (assignment.contacts) {
+        return assignment.contacts;
+      }
       const campaign = await cacheableData.campaign.load(
         assignment.campaign_id
       );

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -88,6 +88,7 @@ export const errorDescriptions = {
   "-3": "Spoke failed to send the message and will try again.",
   "-4": "Spoke failed to send the message and will try again.",
   "-5": "Spoke failed to send the message and will NOT try again.",
+  "-133": "Auto-optout (no error)",
   "-166":
     "Internal: Message blocked due to text match trigger (profanity-tagger)",
   "-167": "Internal: Initial message altered (initialtext-guard)"

--- a/src/server/api/mutations/sendMessage.js
+++ b/src/server/api/mutations/sendMessage.js
@@ -11,6 +11,12 @@ const JOBS_SAME_PROCESS = !!(
   process.env.JOBS_SAME_PROCESS || global.JOBS_SAME_PROCESS
 );
 
+const newError = (message, code) => {
+  const err = new GraphQLError(message);
+  err.code = code;
+  return err;
+};
+
 export const sendMessage = async (
   _,
   { message, campaignContactId, cannedResponseId },
@@ -24,10 +30,7 @@ export const sendMessage = async (
     campaign.is_archived
   ) {
     console.error("Error: assignment changed");
-    throw new GraphQLError({
-      status: 400,
-      message: "Your assignment has changed"
-    });
+    throw newError("Your assignment has changed", "SENDERR_ASSIGNMENTCHANGED");
   }
   const organization = await loaders.organization.load(
     campaign.organization_id
@@ -40,10 +43,10 @@ export const sendMessage = async (
   });
 
   if (optOut) {
-    throw new GraphQLError({
-      status: 400,
-      message: "Skipped sending because this contact was already opted out"
-    });
+    throw newError(
+      "Skipped sending because this contact was already opted out",
+      "SENDERR_OPTEDOUT"
+    );
   }
   // const zipData = await r.table('zip_code')
   //   .get(contact.zip)
@@ -65,10 +68,7 @@ export const sendMessage = async (
   const { contactNumber, text } = message;
 
   if (text.length > (process.env.MAX_MESSAGE_LENGTH || 99999)) {
-    throw new GraphQLError({
-      status: 400,
-      message: "Message was longer than the limit"
-    });
+    throw newError("Message was longer than the limit", "SENDERR_MAXLEN");
   }
 
   const replaceCurlyApostrophes = rawText =>
@@ -100,10 +100,10 @@ export const sendMessage = async (
 
   const sendBeforeDate = sendBefore ? sendBefore.toDate() : null;
   if (sendBeforeDate && sendBeforeDate <= Date.now()) {
-    throw new GraphQLError({
-      status: 400,
-      message: "Outside permitted texting time for this recipient"
-    });
+    throw newError(
+      "Outside permitted texting time for this recipient",
+      "SENDERR_OFFHOURS"
+    );
   }
   const serviceName =
     orgFeatures.service ||
@@ -137,8 +137,9 @@ export const sendMessage = async (
     cannedResponseId
   });
   if (!saveResult.message) {
-    throw new GraphQLError(
-      `Message send error ${saveResult.texterError || ""}`
+    throw newError(
+      `Message send error ${saveResult.texterError || ""}`,
+      "SENDERR_SAVEFAIL"
     );
   }
   contact.message_status = saveResult.contactStatus;

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1190,9 +1190,8 @@ const rootMutations = {
         campaignContactId,
         contact.campaign_id
       );
-      await cacheableData.campaignContact.clear(campaignContactId.toString());
 
-      return cacheableData.campaignContact.load(campaignContactId);
+      return cacheableData.campaignContact.updateCacheForOptOut(contact);
     },
     deleteQuestionResponses: async (
       _,

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -208,13 +208,16 @@ app.use(
     formatError: error => {
       log.error({
         userId: request.user && request.user.id,
+        code:
+          (error && error.originalError && error.originalError.code) ||
+          "INTERNAL_SERVER_ERROR",
         error,
         msg: "GraphQL error"
       });
       telemetry
         .formatRequestError(error, request)
         // drop if this fails
-        .catch()
+        .catch(() => {})
         .then(() => {});
       return error;
     }

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -244,6 +244,9 @@ const campaignContactCache = {
       // which seems slightly burdensome per-contact
       // FUTURE: Maybe we will revisit this after we see performance data
     }
+    if (opts && opts.cacheOnly) {
+      return null;
+    }
     return await CampaignContact.get(id);
   },
   loadMany: async (

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -414,6 +414,21 @@ const campaignContactCache = {
     return false;
   },
   getMessageStatus,
+  updateCacheForOptOut: async contact => {
+    const newContact = {
+      ...contact,
+      is_opted_out: true
+    };
+    if (r.redis && CONTACT_CACHE_ENABLED) {
+      const contactKey = cacheKey(contact.id);
+      await r.redis
+        .multi()
+        .set(contactKey, JSON.stringify(newContact))
+        .expire(contactKey, 43200)
+        .execAsync();
+    }
+    return newContact;
+  },
   updateAssignmentCache: async (
     contactId,
     newAssignmentId,

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -239,6 +239,7 @@ const messageCache = {
     let activeCellFound = null;
     let matchError = null;
     let contactUpdates = {};
+    let handlerContext = {};
 
     if (messageInstance.is_from_contact) {
       // console.log("messageCache SAVE lookup");
@@ -323,6 +324,9 @@ const messageCache = {
           if (result.contactUpdates) {
             Object.assign(contactUpdates, result.contactUpdates);
           }
+          if (result.handlerContext) {
+            Object.assign(handlerContext, result.handlerContext);
+          }
         }
       }
     }
@@ -381,7 +385,8 @@ const messageCache = {
           campaign,
           campaignId,
           organization,
-          texter
+          texter,
+          handlerContext
         });
         if (result) {
           if ("newStatus" in result) {

--- a/src/server/models/cacheable_queries/opt-out.js
+++ b/src/server/models/cacheable_queries/opt-out.js
@@ -123,12 +123,12 @@ const optOutCache = {
       }
     }
     // database
-    await new OptOut({
+    await r.knex("opt_out").insert({
       assignment_id: assignmentId,
       organization_id: organizationId,
       reason_code: reason,
       cell
-    }).save();
+    });
 
     // update all organization/instance's active campaigns as well
     const updateOrgOrInstanceOptOuts = !sharingOptOuts

--- a/src/server/models/cacheable_queries/opt-out.js
+++ b/src/server/models/cacheable_queries/opt-out.js
@@ -112,6 +112,7 @@ const optOutCache = {
     campaign,
     assignmentId,
     reason,
+    noContactUpdate,
     noReply
   }) => {
     const organizationId = campaign.organization_id;
@@ -129,6 +130,17 @@ const optOutCache = {
       reason_code: reason,
       cell
     });
+
+    if (noContactUpdate && r.redis) {
+      // this is a risky feature which will not update campaign_contacts
+      // Only use this when you are confident that at least the campaign's
+      // campaign_contact record will update.
+      // The first use-case was for auto-optout, where we update the contact
+      // during message save
+      // We only allow it when the cache is set, so other campaigns are still
+      // (mostly) assured to get the opt-out
+      return;
+    }
 
     // update all organization/instance's active campaigns as well
     const updateOrgOrInstanceOptOuts = !sharingOptOuts

--- a/src/server/models/opt-out.js
+++ b/src/server/models/opt-out.js
@@ -12,7 +12,7 @@ const OptOut = thinky.createModel(
     .schema({
       id: type.string(),
       cell: requiredString(),
-      assignment_id: requiredString(),
+      assignment_id: optionalString(),
       organization_id: requiredString(),
       reason_code: optionalString(),
       created_at: timestamp()


### PR DESCRIPTION
Wut!  We just (stealth) released 8.1 -- why the quick second release?  Well, we deploy 8.1 at MoveOn on production and it was doing great for two days.  On the third day there was a final set of tweaks and we deployed that and we got a product validation from our campaign folks -- and thus we cut the release for 8.1 on Wednesday 8/26.  Well, Murphy's law -- two hours after we finished up the release we started hitting production issues.  We have not yet scaled up for our "hockeystick" (where the participation graph looks like a hockey stick and surges) period and honestly, I asked our campaign manager "try to break Spoke this week" -- well, the texting team sent over 1million messages with 70K sent in a 5minute period and our database started failing.

We will be upgrading this weekend and the great thing about Spoke is it scales "linearly" -- if you double the resources, then you can roughly double the contacts/texters-per-day metrics.

But because of the timing it was ambiguous whether we 'just' hit scaling issues yesterday or whether there were bugs in Spoke 8.1.  I spent the day tracking everything that went wrong and have determined that it was scaling.  I did some urgent improvements to make our queries more efficient and I'll be focusing on more improvements so the application can do its part in keeping scaling costs as low as possible.  But these last set are pretty impactful -- even without upgrading our system with almost the same texting volume as yesterday we are seeing half the database load.

Changes:
* This does include a schema change on the `opt_out` table (please see instructions for migrating)
* Drastically improves the query efficiency for the Texter Todos page
* Removes some liability of thrashing with auto-optout updating.