### PR TITLE
Canned response search

### DIFF
--- a/__test__/components/AssignmentTexter/Survey.test.js
+++ b/__test__/components/AssignmentTexter/Survey.test.js
@@ -14,6 +14,23 @@ describe("Survey component", () => {
           value: "Foo is an animal",
           interactionStepId: 3,
           nextInteractionStep: { script: "foo" }
+        },
+        {
+          value: "Foo is a mineral",
+          interactionStepId: 3,
+          nextInteractionStep: { script: "bar" }
+        },
+        {
+          value: "Foo is a vegetable",
+          interactionStepId: 3,
+          nextInteractionStep: { script: "fizz" }
+        }
+      ],
+      filteredAnswerOptions: [
+        {
+          value: "Foo is a mineral",
+          interactionStepId: 3,
+          nextInteractionStep: { script: "bar" }
         }
       ]
     }
@@ -48,6 +65,6 @@ describe("Survey component", () => {
         interactionStep: currentInteractionStep,
         answerIndex: 0
       })
-    ).toBe("foo");
+    ).toBe("bar");
   });
 });

--- a/__test__/lib/search-helpers.test.js
+++ b/__test__/lib/search-helpers.test.js
@@ -1,0 +1,37 @@
+import { searchFor } from "../../src/lib/search-helpers";
+
+const objects = [
+  {
+    field1: "red",
+    field2: { inner: "purple" }
+  },
+  {
+    field1: "blue",
+    field2: { inner: "yellow" }
+  },
+  {
+    field1: "green",
+    field2: { inner: " blue " }
+  }
+];
+
+describe("searchFor", () => {
+  test("returns correct object based on one property", () => {
+    const result = searchFor("blue", objects, ["field1"]);
+    expect(result).toEqual([{ field1: "blue", field2: { inner: "yellow" } }]);
+  });
+
+  test("returns correct objects based on different (nested) properties", () => {
+    const result = searchFor("blue", objects, ["field1", "field2.inner"]);
+    expect(result).toEqual([
+      {
+        field1: "blue",
+        field2: { inner: "yellow" }
+      },
+      {
+        field1: "green",
+        field2: { inner: " blue " }
+      }
+    ]);
+  });
+});

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -89,6 +89,13 @@ export class AssignmentTexterContactControls extends React.Component {
     window.addEventListener("orientationchange", this.onResize);
   }
 
+  componentWillUnmount() {
+    document.body.removeEventListener("keyup", this.onKeyUp);
+    document.body.removeEventListener("keypress", this.blockWithCtrl);
+    window.removeEventListener("resize", this.onResize);
+    window.removeEventListener("orientationchange", this.onResize);
+  }
+
   componentWillUpdate(nextProps, nextState) {
     // we refresh sideboxes here because we need to compare previous state
     const newPopups = [];
@@ -103,13 +110,6 @@ export class AssignmentTexterContactControls extends React.Component {
     newPopups.forEach(sb => {
       nextState.sideboxOpens[sb] = (nextState.sideboxOpens[sb] || 0) + 1;
     });
-  }
-
-  componentWillUnmount() {
-    document.body.removeEventListener("keyup", this.onKeyUp);
-    document.body.removeEventListener("keypress", this.blockWithCtrl);
-    window.removeEventListener("resize", this.onResize);
-    window.removeEventListener("orientationchange", this.onResize);
   }
 
   getStartingMessageText() {

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -346,10 +346,16 @@ export class AssignmentTexterContactControls extends React.Component {
 
   handleOpenAnswerPopover = event => {
     event.preventDefault();
-    this.setState({
+    const newState = {
       answerPopoverAnchorEl: event.currentTarget,
-      answerPopoverOpen: true
-    });
+      answerPopoverOpen: true,
+      filteredCannedResponses: this.props.campaign.cannedResponses
+    };
+    if (this.state.currentInteractionStep) {
+      this.state.currentInteractionStep.question.filteredAnswerOptions = this.state.currentInteractionStep.question.answerOptions;
+      newState.currentInteractionStep = this.state.currentInteractionStep;
+    }
+    this.setState(newState);
   };
 
   handleCloseAnswerPopover = () => {

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -344,11 +344,13 @@ export class AssignmentTexterContactControls extends React.Component {
 
   handleMessageFormChange = ({ messageText }) => this.setState({ messageText });
 
-  handleOpenAnswerPopover = event => {
+  handleOpenAnswerResponsePopover = event => {
     event.preventDefault();
     const newState = {
       answerPopoverAnchorEl: event.currentTarget,
       answerPopoverOpen: true,
+      responsePopoverAnchorEl: event.currentTarget,
+      responsePopoverOpen: true,
       filteredCannedResponses: this.props.campaign.cannedResponses
     };
     if (this.state.currentInteractionStep) {
@@ -358,21 +360,11 @@ export class AssignmentTexterContactControls extends React.Component {
     this.setState(newState);
   };
 
-  handleCloseAnswerPopover = () => {
+  handleCloseAnswerResponsePopover = () => {
     this.setState({
       answerPopoverOpen: false
     });
-  };
 
-  handleOpenResponsePopover = event => {
-    event.preventDefault();
-    this.setState({
-      responsePopoverAnchorEl: event.currentTarget,
-      responsePopoverOpen: true
-    });
-  };
-
-  handleCloseResponsePopover = () => {
     // delay to avoid accidental tap pass-through with focusing on
     // the text field -- this is annoying on mobile where the keyboard
     // pops up, inadvertantly
@@ -464,7 +456,7 @@ export class AssignmentTexterContactControls extends React.Component {
         anchorEl={this.state.answerPopoverAnchorEl}
         anchorOrigin={{ horizontal: "left", vertical: "bottom" }}
         targetOrigin={{ horizontal: "left", vertical: "bottom" }}
-        onRequestClose={this.handleCloseAnswerPopover}
+        onRequestClose={this.handleCloseAnswerResponsePopover}
       >
         <SearchBar
           onRequestSearch={this.handleSearchChange}
@@ -479,7 +471,7 @@ export class AssignmentTexterContactControls extends React.Component {
           currentInteractionStep={this.state.currentInteractionStep}
           listHeader={otherResponsesLink}
           questionResponses={questionResponses}
-          onRequestClose={this.handleCloseAnswerPopover}
+          onRequestClose={this.handleCloseAnswerResponsePopover}
         />
         <ScriptList
           scripts={this.state.filteredCannedResponses}
@@ -828,7 +820,9 @@ export class AssignmentTexterContactControls extends React.Component {
             </span>
           }
           role="button"
-          onClick={!disabled ? this.handleOpenAnswerPopover : noAction => {}}
+          onClick={
+            !disabled ? this.handleOpenAnswerResponsePopover : noAction => {}
+          }
           className={css(flexStyles.flatButton)}
           labelStyle={inlineStyles.flatButtonLabel}
           backgroundColor={

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -240,11 +240,10 @@ export class AssignmentTexterContactControls extends React.Component {
     // filter answerOptions for this step's question
     const answerOptions = this.state.currentInteractionStep.question
       .answerOptions;
-    const keysToSearch = ["value", "nextInteractionStep.script"];
     const filteredAnswerOptions = searchFor(
       searchValue,
       answerOptions,
-      keysToSearch
+      ["value", "nextInteractionStep.script"]
     );
     this.state.currentInteractionStep.question.filteredAnswerOptions = filteredAnswerOptions;
 

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -425,7 +425,9 @@ export class AssignmentTexterContactControls extends React.Component {
     const {
       answerPopoverOpen,
       questionResponses,
-      cannedResponseScript
+      cannedResponseScript,
+      currentInteractionStep,
+      filteredCannedResponses
     } = this.state;
     const { messages } = contact;
 
@@ -435,9 +437,9 @@ export class AssignmentTexterContactControls extends React.Component {
     );
 
     const otherResponsesLink =
-      this.state.currentInteractionStep &&
-      this.state.currentInteractionStep.question.answerOptions.length > 6 &&
-      campaign.cannedResponses.length ? (
+      currentInteractionStep &&
+      currentInteractionStep.question.filteredAnswerOptions.length > 6 &&
+      filteredCannedResponses.length ? (
         <div className={css(flexStyles.popoverLink)}>
           <a
             href="#otherresponses"
@@ -446,6 +448,19 @@ export class AssignmentTexterContactControls extends React.Component {
             Other Responses
           </a>
         </div>
+      ) : null;
+
+    const searchBar =
+      currentInteractionStep &&
+      currentInteractionStep.question.answerOptions.length +
+        campaign.cannedResponses.length >
+        5 ? (
+        <SearchBar
+          onRequestSearch={this.handleSearchChange}
+          onChange={this.handleSearchChange}
+          value={""}
+          hintText={"Search replies..."}
+        />
       ) : null;
 
     return (
@@ -458,23 +473,18 @@ export class AssignmentTexterContactControls extends React.Component {
         targetOrigin={{ horizontal: "left", vertical: "bottom" }}
         onRequestClose={this.handleCloseAnswerResponsePopover}
       >
-        <SearchBar
-          onRequestSearch={this.handleSearchChange}
-          onChange={this.handleSearchChange}
-          value={""}
-          hintText={"Search replies..."}
-        />
+        {searchBar}
         <Survey
           contact={contact}
           interactionSteps={availableInteractionSteps}
           onQuestionResponseChange={this.handleQuestionResponseChange}
-          currentInteractionStep={this.state.currentInteractionStep}
+          currentInteractionStep={currentInteractionStep}
           listHeader={otherResponsesLink}
           questionResponses={questionResponses}
           onRequestClose={this.handleCloseAnswerResponsePopover}
         />
         <ScriptList
-          scripts={this.state.filteredCannedResponses}
+          scripts={filteredCannedResponses}
           showAddScriptButton={false}
           customFields={campaign.customFields}
           currentCannedResponseScript={cannedResponseScript}

--- a/src/components/AssignmentTexter/Survey.jsx
+++ b/src/components/AssignmentTexter/Survey.jsx
@@ -162,7 +162,7 @@ class AssignmentTexterSurveys extends Component {
             style={styles.pastQuestionsLink}
           />
         ) : null}
-        {step.question.answerOptions.map((answerOption, index) => (
+        {step.question.filteredAnswerOptions.map((answerOption, index) => (
           <ListItem
             value={answerOption.value}
             onClick={() => {

--- a/src/components/AssignmentTexter/Survey.jsx
+++ b/src/components/AssignmentTexter/Survey.jsx
@@ -40,8 +40,8 @@ class AssignmentTexterSurveys extends Component {
   }
 
   getNextScript({ interactionStep, answerIndex }) {
-    const answerOption = interactionStep.question.answerOptions[answerIndex];
-
+    const answerOption =
+      interactionStep.question.filteredAnswerOptions[answerIndex];
     const { nextInteractionStep } = answerOption;
     return nextInteractionStep ? nextInteractionStep.script : null;
   }
@@ -137,7 +137,7 @@ class AssignmentTexterSurveys extends Component {
   }
 
   renderCurrentStep(step, oldStyle) {
-    const { onRequestClose, questionResponses, listHeader } = this.props;
+    const { questionResponses, listHeader } = this.props;
     if (oldStyle) {
       return this.renderStep(step, 1);
     }

--- a/src/components/AssignmentTexter/Survey.jsx
+++ b/src/components/AssignmentTexter/Survey.jsx
@@ -137,7 +137,7 @@ class AssignmentTexterSurveys extends Component {
   }
 
   renderCurrentStep(step, oldStyle) {
-    const { questionResponses, listHeader } = this.props;
+    const { onRequestClose, questionResponses, listHeader } = this.props;
     if (oldStyle) {
       return this.renderStep(step, 1);
     }

--- a/src/lib/search-helpers.js
+++ b/src/lib/search-helpers.js
@@ -1,8 +1,6 @@
-// pathsToSearch can search nested fields with ["field.subfield"]. Use [""] if objectsToSearch is an array of strings.
+// pathsToSearch can search nested fields with ["field.subfield"].
 export function searchFor(query, objectsToSearch, pathsToSearch) {
-  const results = [];
-
-  objectsToSearch.forEach(o => {
+  return objectsToSearch.filter(o => {
     for (let j = 0; j < pathsToSearch.length; j++) {
       const keys = pathsToSearch[j].split(".");
       let value = o;
@@ -14,11 +12,9 @@ export function searchFor(query, objectsToSearch, pathsToSearch) {
         value &&
         value.toLowerCase().indexOf(query.trim().toLowerCase()) !== -1
       ) {
-        results.push(o);
-        break; // Don't add it more than once if it matches on multiple fields.
+        return true;
       }
     }
+    return false;
   });
-
-  return results;
 }

--- a/src/lib/search-helpers.js
+++ b/src/lib/search-helpers.js
@@ -1,0 +1,24 @@
+// pathsToSearch can search nested fields with ["field.subfield"]. Use [""] if objectsToSearch is an array of strings.
+export function searchFor(query, objectsToSearch, pathsToSearch) {
+  const results = [];
+
+  objectsToSearch.forEach(o => {
+    for (let j = 0; j < pathsToSearch.length; j++) {
+      const keys = pathsToSearch[j].split(".");
+      let value = o;
+      while (keys.length > 0) {
+        value = value[keys.shift()];
+      }
+
+      if (
+        value &&
+        value.toLowerCase().indexOf(query.trim().toLowerCase()) !== -1
+      ) {
+        results.push(o);
+        break; // Don't add it more than once if it matches on multiple fields.
+      }
+    }
+  });
+
+  return results;
+}


### PR DESCRIPTION
# Fixes #1790 
## Description
This change adds a search field to the Survey/Responses popover in the Texter experience. The search field updates the available Survey Answers and Canned Responses as the user enters characters. Search terms are checked against the title, and the response text.

![Screen Shot 2020-08-31 at 12 06 41 PM](https://user-images.githubusercontent.com/394818/91743085-43451500-eb85-11ea-87f3-55ae56d486e4.png)

![Screen Shot 2020-08-31 at 12 27 20 PM](https://user-images.githubusercontent.com/394818/91743130-56f07b80-eb85-11ea-8482-ed6c630be888.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
