### PR TITLE
two additional custom fields for tracking the contact by id

### DIFF
--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -29,14 +29,25 @@ const CAPITALIZE_FIELDS = [
   "texterAliasOrFirstName"
 ];
 
+const SYSTEM_FIELDS = ["contactId", "contactIdBase62"];
+
 // TODO: This will include zipCode even if you ddin't upload it
 export const allScriptFields = (customFields, includeDeprecated) =>
   TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS)
     .concat(customFields)
+    .concat(SYSTEM_FIELDS)
     .concat(includeDeprecated ? DEPRECATED_SCRIPT_FIELDS : []);
 
 const capitalize = str => {
   const strTrimmed = str.trim();
+  if (
+    strTrimmed.charAt(0).toUpperCase() == strTrimmed.charAt(0) &&
+    /[a-z]/.test(strTrimmed)
+  ) {
+    // first letter is upper-cased and some lowercase
+    // so then let's return as-is.
+    return strTrimmed;
+  }
   return strTrimmed.charAt(0).toUpperCase() + strTrimmed.slice(1).toLowerCase();
 };
 
@@ -48,6 +59,20 @@ const getScriptFieldValue = (contact, texter, fieldName) => {
     result = texter.firstName;
   } else if (fieldName === "texterLastName") {
     result = texter.lastName;
+  } else if (fieldName === "contactId") {
+    result = String(contact.id);
+  } else if (fieldName === "contactIdBase62") {
+    let n = Number(contact.id);
+    if (n === 0) {
+      return "0";
+    }
+    const digits =
+      "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    result = "";
+    while (n > 0) {
+      result = digits[n % digits.length] + result;
+      n = parseInt(n / digits.length, 10);
+    }
   } else if (TOP_LEVEL_UPLOAD_FIELDS.indexOf(fieldName) !== -1) {
     result = contact[fieldName];
   } else {


### PR DESCRIPTION
Contact id is occasionally useful to track the contact e.g. in URLs, etc.  base62 is even shorter for that.

This also de-force-capitalizes a name if there is at least one lower case character and the first letter is already capitalized -- so names with unusual casing can be preserved.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
