### PR TITLE
filter contact fields to just what is in scripts and cannedresponses

### DIFF
--- a/src/lib/interaction-step-helpers.js
+++ b/src/lib/interaction-step-helpers.js
@@ -106,6 +106,17 @@ export function makeTree(interactionSteps, id = null) {
   };
 }
 
+export function getUsedScriptFields(allInteractionSteps, key) {
+  // problem: also need all the canned response fields
+  const usedFields = {};
+  allInteractionSteps.forEach(is => {
+    is[key].replace(/\{([^}]+)\}/g, (m, scriptField) => {
+      usedFields[scriptField] = 1;
+    });
+  });
+  return usedFields;
+}
+
 export function assembleAnswerOptions(allInteractionSteps) {
   // creates recursive array required for the graphQL query with 'answerOptions' key
   const interactionStepsCopy = allInteractionSteps.map(is => ({

--- a/src/lib/scripts.js
+++ b/src/lib/scripts.js
@@ -29,6 +29,19 @@ const CAPITALIZE_FIELDS = [
   "texterAliasOrFirstName"
 ];
 
+export const coreFields = {
+  firstName: 1,
+  lastName: 1,
+  texterFirstName: 1,
+  texterLastName: 1,
+  texterAliasOrFirstName: 1,
+  cell: 1,
+  zip: 1,
+  external_id: 1,
+  contactId: 1,
+  contactIdBase62: 1
+};
+
 // TODO: This will include zipCode even if you ddin't upload it
 export const allScriptFields = (customFields, includeDeprecated) =>
   TOP_LEVEL_UPLOAD_FIELDS.concat(TEXTER_SCRIPT_FIELDS)

--- a/src/server/models/cacheable_queries/campaign.js
+++ b/src/server/models/cacheable_queries/campaign.js
@@ -1,6 +1,9 @@
 import { r, Campaign } from "../../models";
 import { modelWithExtraProps } from "./lib";
-import { assembleAnswerOptions } from "../../../lib/interaction-step-helpers";
+import {
+  assembleAnswerOptions,
+  getUsedScriptFields
+} from "../../../lib/interaction-step-helpers";
 import { getFeatures } from "../../api/lib/config";
 import organizationCache from "./organization";
 
@@ -82,6 +85,10 @@ const loadDeep = async id => {
     // console.log('campaign loaddeep', campaign)
     campaign.customFields = await dbCustomFields(id);
     campaign.interactionSteps = await dbInteractionSteps(id);
+    campaign.usedFields = getUsedScriptFields(
+      campaign.interactionSteps,
+      "script"
+    );
     campaign.contactTimezones = await dbContactTimezones(id);
     campaign.contactsCount = await r.getCount(
       r.knex("campaign_contact").where("campaign_id", id)

--- a/src/server/models/cacheable_queries/canned-response.js
+++ b/src/server/models/cacheable_queries/canned-response.js
@@ -1,6 +1,6 @@
 import { r } from "../../models";
 import { groupCannedResponses } from "../../api/lib/utils";
-
+import { getUsedScriptFields } from "../../../lib/interaction-step-helpers";
 // Datastructure:
 // * regular GET/SET with JSON ordered list of the objects {id,title,text}
 // * keyed by campaignId-userId pairs -- userId is '' for global campaign records
@@ -50,6 +50,9 @@ const cannedResponseCache = {
         user_id: cannedRes.user_id,
         tagIds: cannedRes.tagIds
       }));
+      if (cacheData.length) {
+        cacheData[0].usedFields = getUsedScriptFields(cacheData, "text");
+      }
       await r.redis
         .multi()
         .set(cacheKey(campaignId, userId), JSON.stringify(cacheData))


### PR DESCRIPTION
To reduce the information sent to the texter, we filter out fields that aren't used in scripts or canned responses.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
