### PR TITLE
job to update optouts regularly in case the update fails and for autoupdates where it does not update by default

### DIFF
--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -2,7 +2,7 @@
 // that are tracked in the database via the JobRequest table.
 // See src/extensions/job-runners/README.md for more details
 
-import { r } from "../server/models";
+import { r, cacheableData } from "../server/models";
 import { sleep, getNextJob } from "./lib";
 import { log } from "../lib";
 import {
@@ -232,6 +232,29 @@ export async function handleIncomingMessages() {
   }
 }
 
+export async function updateOptOuts(event, awsContext) {
+  // Especially for auto-optouts, campaign_contact.is_opted_out is not
+  // always updated and depends on this batch job to run
+  // We avoid it in-process to avoid db-write thrashing on optouts
+  // so they don't appear in queries
+  await cacheableData.optOut.updateIsOptedOuts(query =>
+    query
+      .join("opt_out", {
+        "opt_out.cell": "campaign_contact.cell",
+        ...(!process.env.OPTOUTS_SHARE_ALL_ORGS
+          ? { "opt_out.organization_id": "campaign.organization_id" }
+          : {})
+      })
+      .where(
+        "opt_out.created_at",
+        ">",
+        new Date(
+          new Date() - ((event && event.milliseconds_past) || 1000 * 60 * 60) // default 1 hour back
+        )
+      )
+  );
+}
+
 export async function runDatabaseMigrations(event, dispatcher, eventCallback) {
   console.log("inside runDatabaseMigrations1");
   console.log("inside runDatabaseMigrations2", event);
@@ -279,7 +302,8 @@ const syncProcessMap = {
   handleIncomingMessages,
   checkMessageQueue,
   fixOrgless,
-  clearOldJobs
+  clearOldJobs,
+  updateOptOuts
 };
 
 export async function dispatchProcesses(event, dispatcher, eventCallback) {


### PR DESCRIPTION
Auto-optout message handler does not trigger an is_opted_out across campaigns to avoid db thrashing with campaign_contact updates, so this is a job that batch-updates those contacts

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
