### PR TITLE
speed up deduplication query

### DIFF
--- a/__test__/extensions/contact-loaders/csv-upload.test.js
+++ b/__test__/extensions/contact-loaders/csv-upload.test.js
@@ -54,6 +54,13 @@ const dupeContacts = [
     custom_fields: '{"custom1": "abc"}'
   },
   {
+    first_name: "second",
+    last_name: "thirdlast",
+    cell: "+12125550100",
+    zip: "10025",
+    custom_fields: '{"custom1": "xyz"}'
+  },
+  {
     first_name: "fdsa",
     last_name: "yyyy",
     cell: "+12125550100",
@@ -111,7 +118,7 @@ describe("ingest-contact-loader method: csv-upload backend", async () => {
     expect(dbContacts[0].last_name).toBe("xxxx");
     expect(dbContacts[0].custom_fields).toBe('{"custom1": "abc"}');
   });
-  it("csv-upload:processContactLoad dedupe", async () => {
+  it("csv-upload:processContactLoad dedupe last wins", async () => {
     const job = {
       payload: await gzip(JSON.stringify({ contacts: dupeContacts })),
       campaign_id: testCampaign.id,
@@ -127,7 +134,7 @@ describe("ingest-contact-loader method: csv-upload backend", async () => {
       .where("campaign_id", testCampaign.id)
       .first();
     expect(dbContacts.length).toBe(1);
-    expect(adminResult.duplicate_contacts_count).toBe(1);
+    expect(adminResult.duplicate_contacts_count).toBe(2);
     expect(adminResult.contacts_count).toBe(1);
     expect(dbContacts[0].first_name).toBe("fdsa");
     expect(dbContacts[0].last_name).toBe("yyyy");


### PR DESCRIPTION
# Fixes Deduplication query too slow

## Description

This query is better than one with so many joins.  Thanks to @hiemanshu  for this improvement!

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
