### PR TITLE
Stop needMessageCount input from zeroing-out

### DIFF
--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -374,6 +374,7 @@ export default class CampaignTextersForm extends React.Component {
             <Form.Field
               {...dataTest("texterAssignment")}
               name={`texters[${index}].assignment.needsMessageCount`}
+              mapToValue={_ => texter.assignment.needsMessageCount}
               hintText="Contacts"
               fullWidth
               onFocus={() => this.setState({ focusedTexterId: texter.id })}


### PR DESCRIPTION
# Fixes # (issue)
https://github.com/MoveOnOrg/Spoke/issues/1587

## Description

I added React Formal's `mapToValue` method to override the value retrieved by `name`, which can become stale as new texters are added.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
