### PR TITLE
Per-org VAN settings

### DIFF
--- a/src/api/organization.js
+++ b/src/api/organization.js
@@ -77,6 +77,7 @@ export const schema = gql`
     twilioAuthToken: String
     twilioMessageServiceSid: String
     fullyConfigured: Boolean
+    vanEnabled: Boolean!
     phoneInventoryEnabled: Boolean!
     campaignPhoneNumbersEnabled: Boolean!
     pendingPhoneNumberJobs: [BuyPhoneNumbersJobRequest]

--- a/src/components/OrganizationFeatureSettings.jsx
+++ b/src/components/OrganizationFeatureSettings.jsx
@@ -195,7 +195,26 @@ const configurableFields = {
         </div>
       );
     }
-  }
+  },
+  NGP_VAN_API_KEY_ENCRYPTED: {
+    category: 'ngpvan',
+    schema: () =>
+      yup
+        .string()
+        .nullable()
+        .max(64)
+        .notRequired(),
+    ready: true,
+    component: props => {
+      return (
+        <Form.Field
+          label="NGPVAN API Key"
+          name="NGP_VAN_API_KEY_ENCRYPTED"
+          fullWidth
+        />
+      );
+    }
+  },
 };
 
 export default class OrganizationFeatureSettings extends React.Component {

--- a/src/components/OrganizationFeatureSettings.jsx
+++ b/src/components/OrganizationFeatureSettings.jsx
@@ -101,9 +101,9 @@ const configurableFields = {
   DEFAULT_BATCHSIZE: {
     schema: () =>
       yup
-        .number()
-        .integer()
-        .notRequired(),
+        .number().integer()
+        .notRequired().nullable()
+        .transform(val => isNaN(val) ? null : val),
     ready: true,
     component: props => {
       return (
@@ -122,7 +122,10 @@ const configurableFields = {
     }
   },
   DEFAULT_RESPONSEWINDOW: {
-    schema: () => yup.number().notRequired(),
+    schema: () => yup
+      .number().integer()
+      .notRequired().nullable()
+      .transform(val => isNaN(val) ? null : val),
     ready: true,
     component: props => {
       return (
@@ -145,9 +148,9 @@ const configurableFields = {
   MAX_CONTACTS_PER_TEXTER: {
     schema: () =>
       yup
-        .number()
-        .integer()
-        .notRequired(),
+        .number().integer()
+        .notRequired().nullable()
+        .transform(val => isNaN(val) ? null : val),
     ready: true,
     component: props => {
       return (
@@ -174,9 +177,9 @@ const configurableFields = {
   MAX_MESSAGE_LENGTH: {
     schema: () =>
       yup
-        .number()
-        .integer()
-        .notRequired(),
+        .number().integer()
+        .notRequired().notRequired()
+        .transform(val => isNaN(val) ? null : val),
     ready: true,
     component: props => {
       return (

--- a/src/components/OrganizationFeatureSettings.jsx
+++ b/src/components/OrganizationFeatureSettings.jsx
@@ -178,7 +178,7 @@ const configurableFields = {
     schema: () =>
       yup
         .number().integer()
-        .notRequired().notRequired()
+        .notRequired().nullable()
         .transform(val => isNaN(val) ? null : val),
     ready: true,
     component: props => {
@@ -240,7 +240,11 @@ export class OrganizationFeatureSettings extends React.Component {
           ...this.props,
           ...this.state
         });
-        return this.fields[f].component({ ...this.props, parent: this });
+        return (
+          <div key={f}>
+            {this.fields[f].component({ ...this.props, parent: this })}
+          </div>
+        );
       });
     return (
       <div>

--- a/src/components/forms/GSSelectField.jsx
+++ b/src/components/forms/GSSelectField.jsx
@@ -5,18 +5,25 @@ import { MenuItem } from "material-ui/Menu";
 import GSFormField from "./GSFormField";
 
 export default class GSSelectField extends GSFormField {
-  createMenuItems() {
-    return this.props.choices.map(({ value, label }) => (
+  createMenuItems(choices) {
+    return choices.map(({ value, label }) => (
       <MenuItem value={value} key={value} primaryText={label} />
     ));
   }
 
   render() {
+    const {
+      choices,
+      errors,
+      invalid,
+      ...extraProps
+    } = this.props;
+
     return (
       <SelectField
-        children={this.createMenuItems()}
+        children={this.createMenuItems(choices)}
         floatingLabelText={this.props.label}
-        {...this.props}
+        {...extraProps}
         onChange={(event, index, value) => {
           this.props.onChange(value);
         }}

--- a/src/components/forms/GSSubmitButton.jsx
+++ b/src/components/forms/GSSubmitButton.jsx
@@ -11,12 +11,12 @@ const styles = {
 
 const GSSubmitButton = props => {
   let icon = "";
-  const extraProps = {};
-  if (props.isSubmitting) {
+  const { isSubmitting, ...extraProps } = props;
+  if (isSubmitting) {
     extraProps.disabled = true;
     icon = (
       <CircularProgress
-        size={0.5}
+        size={25}
         style={{
           verticalAlign: "middle",
           display: "inline-block"
@@ -26,12 +26,11 @@ const GSSubmitButton = props => {
   }
 
   return (
-    <div style={styles.button} {...props}>
+    <div style={styles.button}>
       <RaisedButton
         primary
         type="submit"
         value="submit"
-        {...props}
         {...extraProps}
       />
       {icon}

--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -4,7 +4,13 @@ import GSFormField from "./GSFormField";
 
 export default class GSTextField extends GSFormField {
   render() {
-    let value = this.props.value;
+    const {
+      value,
+      errors,
+      invalid,
+      ...extraProps
+    } = this.props;
+
     return (
       <TextField
         floatingLabelText={this.floatingLabelText()}
@@ -12,7 +18,7 @@ export default class GSTextField extends GSFormField {
           zIndex: 0
         }}
         onFocus={event => event.target.select()}
-        {...this.props}
+        {...extraProps}
         value={value}
         onChange={event => {
           this.props.onChange(event.target.value);

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -404,9 +404,8 @@ class Settings extends React.Component {
                     schema: () =>
                       yup
                         .string()
-                        .nullable()
                         .max(64)
-                        .notRequired(),
+                        .notRequired().nullable(),
                     ready: true,
                     component: props => {
                       return (
@@ -419,13 +418,11 @@ class Settings extends React.Component {
                     }
                   },
                   NGP_VAN_APP_NAME: {
-                    category: 'ngpvan',
                     schema: () =>
                       yup
                         .string()
-                        .nullable()
-                        .max(32)
-                        .notRequired(),
+                        .notRequired().nullable()
+                        .max(32),
                     ready: true,
                     component: props => {
                       return (
@@ -433,6 +430,28 @@ class Settings extends React.Component {
                           label="NGPVAN App Name"
                           name="NGP_VAN_APP_NAME"
                           fullWidth
+                        />
+                      );
+                    }
+                  },
+                  NGP_VAN_DATABASE_MODE: {
+                    schema: () =>
+                      yup.number()
+                        .oneOf([0, 1, null])
+                        .nullable()
+                        .transform(val => isNaN(val) ? null : val),
+                    ready: true,
+                    component: props => {
+                      return (
+                        <Form.Field
+                          type="select"
+                          label="NGP VAN Database Mode"
+                          name="NGP_VAN_DATABASE_MODE"
+                          choices={[
+                            {value: "", label: ""},
+                            {value: "0", label: "My Voters"},
+                            {value: "1", label: "My Campaign"},
+                          ]}
                         />
                       );
                     }

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -380,21 +380,7 @@ class Settings extends React.Component {
             />
             <CardText expandable>
               <OrganizationFeatureSettings
-                category='defaults'
-                formValues={this.props.data.organization}
                 organization={this.props.data.organization}
-                parentState={this.state.settings}
-                onSubmit={async () => {
-                  const { settings } = this.state;
-                  await this.props.mutations.editOrganization({
-                    settings: settings.defaults
-                  });
-                  this.setState({ settings: null });
-                }}
-                onChange={formValues => {
-                  console.log("change", formValues);
-                  this.setState(formValues);
-                }}
                 saveLabel="Save settings"
               />
             </CardText>
@@ -412,22 +398,47 @@ class Settings extends React.Component {
             />
             <CardText expandable>
               <OrganizationFeatureSettings
-                category='ngpvan'
-                formValues={this.props.data.organization}
                 organization={this.props.data.organization}
-                parentState={this.state.settings}
-                onSubmit={async () => {
-                  const { settings } = this.state;
-                  await this.props.mutations.editOrganization({
-                    settings: settings.ngpvan
-                  });
-                  this.setState({ settings: null });
+                fields={{
+                  NGP_VAN_API_KEY_ENCRYPTED: {
+                    schema: () =>
+                      yup
+                        .string()
+                        .nullable()
+                        .max(64)
+                        .notRequired(),
+                    ready: true,
+                    component: props => {
+                      return (
+                        <Form.Field
+                          label="NGPVAN API Key"
+                          name="NGP_VAN_API_KEY_ENCRYPTED"
+                          fullWidth
+                        />
+                      );
+                    }
+                  },
+                  NGP_VAN_APP_NAME: {
+                    category: 'ngpvan',
+                    schema: () =>
+                      yup
+                        .string()
+                        .nullable()
+                        .max(32)
+                        .notRequired(),
+                    ready: true,
+                    component: props => {
+                      return (
+                        <Form.Field
+                          label="NGPVAN App Name"
+                          name="NGP_VAN_APP_NAME"
+                          fullWidth
+                        />
+                      );
+                    }
+                  },
                 }}
-                onChange={formValues => {
-                  console.log("change", formValues);
-                  this.setState(formValues);
-                }}
-                saveLabel="Save settings"
+                saveLabel="Save VAN Settings"
               />
             </CardText>
           </Card>

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -49,7 +49,9 @@ const inlineStyles = {
 const formatTextingHours = hour => moment(hour, "H").format("h a");
 class Settings extends React.Component {
   state = {
-    formIsSubmitting: false
+    formIsSubmitting: false,
+    textingHoursDialogOpen: false,
+    twilioDialogOpen: false
   };
 
   handleSubmitTextingHoursForm = async ({

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -375,17 +375,19 @@ class Settings extends React.Component {
             <CardHeader
               title="Overriding default settings"
               style={{ backgroundColor: theme.colors.green }}
-              actAsExpander={true}
-              showExpandableButton={true}
+              actAsExpander
+              showExpandableButton
             />
             <CardText expandable>
               <OrganizationFeatureSettings
+                category='defaults'
                 formValues={this.props.data.organization}
                 organization={this.props.data.organization}
+                parentState={this.state.settings}
                 onSubmit={async () => {
                   const { settings } = this.state;
                   await this.props.mutations.editOrganization({
-                    settings
+                    settings: settings.defaults
                   });
                   this.setState({ settings: null });
                 }}
@@ -394,7 +396,6 @@ class Settings extends React.Component {
                   this.setState(formValues);
                 }}
                 saveLabel="Save settings"
-                saveDisabled={!this.state.settings}
               />
             </CardText>
           </Card>

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -401,6 +401,38 @@ class Settings extends React.Component {
           </Card>
         ) : null}
 
+        {this.props.data.organization &&
+        this.props.data.organization.settings ? (
+          <Card>
+            <CardHeader
+              title="NGP VAN API Settings"
+              style={{ backgroundColor: theme.colors.green }}
+              actAsExpander
+              showExpandableButton
+            />
+            <CardText expandable>
+              <OrganizationFeatureSettings
+                category='ngpvan'
+                formValues={this.props.data.organization}
+                organization={this.props.data.organization}
+                parentState={this.state.settings}
+                onSubmit={async () => {
+                  const { settings } = this.state;
+                  await this.props.mutations.editOrganization({
+                    settings: settings.ngpvan
+                  });
+                  this.setState({ settings: null });
+                }}
+                onChange={formValues => {
+                  console.log("change", formValues);
+                  this.setState(formValues);
+                }}
+                saveLabel="Save settings"
+              />
+            </CardText>
+          </Card>
+        ) : null}
+
         {this.props.data.organization && this.props.params.adminPerms ? (
           <Card>
             <CardHeader

--- a/src/containers/Settings.jsx
+++ b/src/containers/Settings.jsx
@@ -402,7 +402,7 @@ class Settings extends React.Component {
         ) : null}
 
         {this.props.data.organization &&
-        this.props.data.organization.settings ? (
+        this.props.data.organization.vanEnabled ? (
           <Card>
             <CardHeader
               title="NGP VAN API Settings"
@@ -490,6 +490,7 @@ const queries = {
           twilioAccountSid
           twilioAuthToken
           twilioMessageServiceSid
+          vanEnabled
         }
       }
     `,

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -362,9 +362,10 @@ export async function getClientChoiceData(organization) {
 // process.env.ACTION_HANDLERS
 export async function available(organization) {
   let result =
-    !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
-    !!getConfig("NGP_VAN_API_KEY", organization) &&
-    !!getConfig("NGP_VAN_APP_NAME", organization);
+    (
+      !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) ||
+      !!getConfig("NGP_VAN_API_KEY", organization)
+    ) && !!getConfig("NGP_VAN_APP_NAME", organization);
 
   if (!result) {
     // eslint-disable-next-line no-console

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -362,6 +362,7 @@ export async function getClientChoiceData(organization) {
 // process.env.ACTION_HANDLERS
 export async function available(organization) {
   let result =
+    !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
     !!getConfig("NGP_VAN_API_KEY", organization) &&
     !!getConfig("NGP_VAN_APP_NAME", organization);
 

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -58,6 +58,7 @@ export async function available(organization, user) {
   // / then it's better to allow the result to be cached
 
   const result =
+    !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
     !!getConfig("NGP_VAN_API_KEY", organization) &&
     !!getConfig("NGP_VAN_APP_NAME", organization) &&
     !!getConfig("NGP_VAN_WEBHOOK_BASE_URL", organization);

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -58,8 +58,10 @@ export async function available(organization, user) {
   // / then it's better to allow the result to be cached
 
   const result =
-    !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
-    !!getConfig("NGP_VAN_API_KEY", organization) &&
+    (
+      !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) ||
+      !!getConfig("NGP_VAN_API_KEY", organization)
+    ) &&
     !!getConfig("NGP_VAN_APP_NAME", organization) &&
     !!getConfig("NGP_VAN_WEBHOOK_BASE_URL", organization);
 

--- a/src/extensions/contact-loaders/ngpvan/util.js
+++ b/src/extensions/contact-loaders/ngpvan/util.js
@@ -1,4 +1,4 @@
-import { getConfig } from "../../../server/api/lib/config";
+import { getConfig, hasConfig } from "../../../server/api/lib/config";
 
 export const DEFAULT_NGP_VAN_API_BASE_URL = "https://api.securevan.com";
 export const DEFAULT_NGP_VAN_DATABASE_MODE = 0;
@@ -7,7 +7,9 @@ export const DEFAULT_NGPVAN_TIMEOUT = 32000;
 export default class Van {
   static getAuth = organization => {
     const appName = getConfig("NGP_VAN_APP_NAME", organization);
-    const apiKey = getConfig("NGP_VAN_API_KEY", organization);
+    const apiKey = hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)
+      ? getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)
+      : getConfig("NGP_VAN_API_KEY", organization);
     const databaseMode = getConfig("NGP_VAN_DATABASE_MODE", organization);
 
     if (!appName || !apiKey) {

--- a/src/extensions/message-handlers/ngpvan/index.js
+++ b/src/extensions/message-handlers/ngpvan/index.js
@@ -21,6 +21,7 @@ export const serverAdministratorInstructions = () => {
 };
 
 export const available = organization =>
+  !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
   !!getConfig("NGP_VAN_API_KEY", organization) &&
   !!getConfig("NGP_VAN_APP_NAME", organization);
 

--- a/src/extensions/message-handlers/ngpvan/index.js
+++ b/src/extensions/message-handlers/ngpvan/index.js
@@ -21,9 +21,10 @@ export const serverAdministratorInstructions = () => {
 };
 
 export const available = organization =>
-  !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) &&
-  !!getConfig("NGP_VAN_API_KEY", organization) &&
-  !!getConfig("NGP_VAN_APP_NAME", organization);
+  (
+    !!getConfig("NGP_VAN_API_KEY_ENCRYPTED", organization) ||
+    !!getConfig("NGP_VAN_API_KEY", organization)
+  ) && !!getConfig("NGP_VAN_APP_NAME", organization);
 
 // export const preMessageSave = async () => {};
 

--- a/src/server/api/lib/crypto.js
+++ b/src/server/api/lib/crypto.js
@@ -11,26 +11,29 @@ const crypto = require("crypto");
 const secret = process.env.SESSION_SECRET || global.SESSION_SECRET;
 const algorithm = "aes-256-cbc";
 
-if (!secret) {
-  throw new Error(
-    "The SESSION_SECRET environment variable must be set to use crypto functions!"
-  );
-}
-
 // The encryption key must be exactly 32 (bytes). We pad the SESSION_SECRET to
 // 32 characters because in the default development environment it is shorter.
 // In production environments the SESSION_SECRET should be a long random sring.
-if (secret.length < 32) {
+if (secret && secret.length < 32) {
   // eslint-disable-next-line no-console
   console.warn(
     "Using short (insecure) SESSION_SECRET. Fine for testing, bad for production."
   );
 }
-const key = Buffer.concat([Buffer.from(secret)], 32);
+
+const getKey = () => {
+  if (!secret) {
+    throw new Error(
+      "The SESSION_SECRET environment variable must be set to use crypto functions!"
+    );
+  }
+  return Buffer.concat([Buffer.from(secret)], 32);
+}
+
 
 const symmetricEncrypt = value => {
   const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
+  const cipher = crypto.createCipheriv(algorithm, getKey(), iv);
   let encrypted = cipher.update(value, "utf8", "buffer");
   encrypted = Buffer.concat([encrypted, cipher.final("buffer")]);
   return iv.toString("hex") + ":" + encrypted.toString("hex");
@@ -40,7 +43,7 @@ const symmetricDecrypt = encrypted => {
   let parts = encrypted.split(":");
   const iv = Buffer.from(parts.shift(), "hex");
   const encryptedValue = Buffer.from(parts.join(":"), "hex");
-  const decipher = crypto.createDecipheriv(algorithm, key, iv);
+  const decipher = crypto.createDecipheriv(algorithm, getKey(), iv);
   let decrypted = decipher.update(encryptedValue, "buffer", "utf8");
   return decrypted + decipher.final("utf8");
 };

--- a/src/server/api/mutations/editOrganization.js
+++ b/src/server/api/mutations/editOrganization.js
@@ -1,4 +1,5 @@
 import { getConfig, getFeatures } from "../lib/config";
+import { symmetricEncrypt } from "../lib/crypto";
 import { accessRequired } from "../errors";
 import { r, cacheableData } from "../../models";
 import { getAllowed } from "../organization";
@@ -22,9 +23,14 @@ export const editOrganization = async (_, { id, organization }, { user }) => {
       if (
         newFeatureValues.hasOwnProperty(f) &&
         // don't save default values that aren't already overridden
-        (features.hasOwnProperty(f) || getConfig(f) != newFeatureValues[f])
+        (features.hasOwnProperty(f) || getConfig(f) != newFeatureValues[f]) &&
+        // don't save Encrypted placeholder
+        newFeatureValues[f] !== '<Encrypted>'
       ) {
         features[f] = newFeatureValues[f];
+        if (f.endsWith('_ENCRYPTED')) {
+          features[f] = symmetricEncrypt(newFeatureValues[f]);
+        }
       }
     });
     unsetFeatures.forEach(f => {

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -293,6 +293,20 @@ export const resolvers = {
       }
       return true;
     },
+    vanEnabled: async (organization, _, { user }) => {
+      await accessRequired(user, organization.id, "SUPERVOLUNTEER");
+      return (
+        getConfig("ACTION_HANDLERS", organization, {
+          default: ''
+        }).includes('ngpvan-action') ||
+        getConfig("CONTACT_LOADERS", organization, {
+          default: ''
+        }).includes('ngpvan') ||
+        getConfig("MESSAGE_HANDLERS", organization, {
+          default: ''
+        }).includes('ngpvan')
+      );
+    },
     phoneInventoryEnabled: async (organization, _, { user }) => {
       await accessRequired(user, organization.id, "SUPERVOLUNTEER", true);
       return (

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -18,6 +18,7 @@ export const ownerConfigurable = {
   MAX_CONTACTS_PER_TEXTER: 1,
   MAX_MESSAGE_LENGTH: 1,
   NGP_VAN_API_KEY_ENCRYPTED: 1,
+  NGP_VAN_APP_NAME: 1,
   // MESSAGE_HANDLERS: 1,
   // There is already an endpoint and widget for this:
   // opt_out_message: 1

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -16,7 +16,8 @@ export const ownerConfigurable = {
   DEFAULT_BATCHSIZE: 1,
   DEFAULT_RESPONSEWINDOW: 1,
   MAX_CONTACTS_PER_TEXTER: 1,
-  MAX_MESSAGE_LENGTH: 1
+  MAX_MESSAGE_LENGTH: 1,
+  NGP_VAN_API_KEY_ENCRYPTED: 1,
   // MESSAGE_HANDLERS: 1,
   // There is already an endpoint and widget for this:
   // opt_out_message: 1
@@ -179,7 +180,9 @@ export const resolvers = {
       const unsetFeatures = [];
       getAllowed(organization, user).forEach(f => {
         if (features.hasOwnProperty(f)) {
-          visibleFeatures[f] = features[f];
+          visibleFeatures[f] = f.endsWith('_ENCRYPTED')
+            ? '<Encrypted>'
+            : features[f];
         } else if (getConfig(f)) {
           visibleFeatures[f] = getConfig(f);
         } else {

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -19,6 +19,7 @@ export const ownerConfigurable = {
   MAX_MESSAGE_LENGTH: 1,
   NGP_VAN_API_KEY_ENCRYPTED: 1,
   NGP_VAN_APP_NAME: 1,
+  NGP_VAN_DATABASE_MODE: 1,
   // MESSAGE_HANDLERS: 1,
   // There is already an endpoint and widget for this:
   // opt_out_message: 1

--- a/src/server/models/cacheable_queries/organization.js
+++ b/src/server/models/cacheable_queries/organization.js
@@ -1,6 +1,5 @@
 import { r } from "../../models";
 import { getConfig, hasConfig } from "../../api/lib/config";
-import { symmetricDecrypt } from "../../api/lib/crypto";
 
 const cacheKey = orgId => `${process.env.CACHE_PREFIX || ""}org-${orgId}`;
 
@@ -22,7 +21,7 @@ const organizationCache = {
     // Note, allows unencrypted auth tokens to be (manually) stored in the db
     // @todo: decide if this is necessary, or if UI/envars is sufficient.
     const authToken = hasOrgToken
-      ? symmetricDecrypt(getConfig("TWILIO_AUTH_TOKEN_ENCRYPTED", organization))
+      ? getConfig("TWILIO_AUTH_TOKEN_ENCRYPTED", organization)
       : getConfig("TWILIO_AUTH_TOKEN", organization);
     const accountSid = hasConfig("TWILIO_ACCOUNT_SID", organization)
       ? getConfig("TWILIO_ACCOUNT_SID", organization)


### PR DESCRIPTION
# Fixes #1693 

## Description

This PR will add a form for VAN API settings to the organization settings page, and encrypt the API key before storing it in the database. It also attempts to make it easier to add other encrypted configuration in the future, by doing two things:
1. Make the `OrganizationFeatureSettings` component more reusable by taking fields as a prop (so that different fields can be shown in different blocks). It also moves the logic and submit handling fully into the component.
2. Transparently encrypting/decrypting org features variables that end in `_ENCRYPTED`

Also made some minor tweaks to fix a bunch of React warnings/errors that have plagued the Settings page.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
