### PR TITLE
Allow admins to see phone inventory

### DIFF
--- a/src/components/AdminDashboard.jsx
+++ b/src/components/AdminDashboard.jsx
@@ -66,6 +66,7 @@ class AdminDashboard extends React.Component {
 
     // HACK: Setting params.adminPerms helps us hide non-supervolunteer functionality
     params.adminPerms = hasRole("ADMIN", roles || []);
+    params.ownerPerms = hasRole("OWNER", roles || []);
 
     let sections = [
       {
@@ -96,7 +97,7 @@ class AdminDashboard extends React.Component {
       {
         name: "Phone Numbers",
         path: "phone-numbers",
-        role: "OWNER"
+        role: "ADMIN"
       }
     ];
 

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -39,6 +39,7 @@ const inlineStyles = {
 class AdminPhoneNumberInventory extends React.Component {
   static propTypes = {
     data: PropTypes.object,
+    params: PropTypes.object,
     mutations: PropTypes.object
   };
 
@@ -249,13 +250,16 @@ class AdminPhoneNumberInventory extends React.Component {
           initialSort={{column: 'areaCode', order: 'asc'}}
           onSortOrderChange={handleSortOrderChange}
         />
-        <FloatingActionButton
-          {...dataTest("buyPhoneNumbers")}
-          style={theme.components.floatingButton}
-          onTouchTap={this.handleBuyNumbersOpen}
-        >
-          <ContentAdd />
-        </FloatingActionButton>
+        {this.props.params.ownerPerms ? (
+          <FloatingActionButton
+            {...dataTest("buyPhoneNumbers")}
+            style={theme.components.floatingButton}
+            onTouchTap={this.handleBuyNumbersOpen}
+          >
+            <ContentAdd />
+          </FloatingActionButton>
+        ) : null}
+
         <Dialog
           title="Buy Numbers"
           modal={false}

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -316,7 +316,7 @@ export const resolvers = {
       return configured;
     },
     pendingPhoneNumberJobs: async (organization, _, { user }) => {
-      await accessRequired(user, organization.id, "OWNER", true);
+      await accessRequired(user, organization.id, "ADMIN", true);
       const jobs = await r
         .knex("job_request")
         .where({


### PR DESCRIPTION
## Description

Allows users with the Admin role to see the Phone Inventory page. Owner perm still required to buy new numbers.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
