### PR TITLE
Fix org creation

### DIFF
--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -764,13 +764,13 @@ const rootMutations = {
 
       return await Organization.get(organizationId);
     },
-    createInvite: async (_, { user }) => {
+    createInvite: async (_, { invite }, { user }) => {
       if (
         (user && user.is_superadmin) ||
         !getConfig("SUPPRESS_SELF_INVITE", null, { truthy: true })
       ) {
         const inviteInstance = new Invite({
-          is_valid: true,
+          is_valid: invite.is_valid,
           hash: uuidv4()
         });
         const newInvite = await inviteInstance.save();


### PR DESCRIPTION
## Description

With the new Organization Dashboard, creating new org was still not working with `SUPPRESS_SELF_INVITE` on. The cause was a missing parameter in the `createInvite` mutation that resulted in it not receiving the user, so it couldn't check for `is_superadmin`.

I also changed it to use the `is_valid` value from the invite input (which is now being passed in).

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
