### PR TITLE
Add a searchbar to the docs microsite

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,5 +21,6 @@
     }
   </script>
   <script src="//cdn.jsdelivr.net/npm/docsify/lib/docsify.min.js"></script>
+  <script src="//unpkg.com/docsify/lib/plugins/search.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Add a searchbar at the top of the sidebar for the docs microsite to let you search our docs by any word in them
<img width="299" alt="Screen Shot 2020-09-10 at 3 51 16 PM" src="https://user-images.githubusercontent.com/3953117/92803894-7c4b6980-f37d-11ea-9a67-e0968a23fa6f.png">
