### PR TITLE
Use readonly for conversations/message review queries

### DIFF
--- a/src/components/CampaignDynamicAssignmentForm.jsx
+++ b/src/components/CampaignDynamicAssignmentForm.jsx
@@ -158,7 +158,7 @@ export default class CampaignDynamicAssignmentForm extends React.Component {
                   extraProps={listedTag => ({
                     backgroundColor: theme.colors.lightGray,
                     onClick: evt => {
-                      if (evt.ctrlKey) {
+                      if (evt.ctrlKey || evt.altKey) {
                         this.onChange({
                           batchPolicies: [...batchPolicies, listedTag.id]
                         });

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -1,4 +1,5 @@
 import { mapFieldsToModel } from "./lib/utils";
+import { getConfig } from "./lib/config";
 import { Assignment, r, cacheableData } from "../models";
 import { getOffsets, defaultTimezoneIsBetweenTextingHours } from "../../lib";
 import { getDynamicAssignmentBatchPolicies } from "../../extensions/dynamicassignment-batches";
@@ -29,6 +30,11 @@ export function addWhereClauseForContactsFilterMessageStatusIrrespectiveOfPastDu
       );
   } else {
     query.whereIn("message_status", messageStatusFilter.split(","));
+  }
+  if (getConfig("CONVERSATIONS_RECENT")) {
+    query.whereRaw(
+      "campaign_contact.id > (SELECT max(id)-20000000 from campaign_contact)"
+    );
   }
   return query;
 }

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -466,7 +466,7 @@ export const resolvers = {
                 "SUM(CASE WHEN campaign_contact.message_status = 'needsMessage' THEN 1 ELSE 0 END) as needs_message_count"
               ),
               r.knex.raw(
-                "SUM(CASE WHEN campaign_contact.message_status = 'needsResponse' THEN 1 ELSE 0 END) as unrepliedcount"
+                "SUM(CASE WHEN campaign_contact.message_status = 'needsResponse' AND NOT campaign_contact.is_opted_out THEN 1 ELSE 0 END) as unrepliedcount"
               ),
               r.knex.raw("COUNT(*) as contacts_count")
             )

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -159,9 +159,11 @@ export async function getConversations(
     return { query: offsetLimitQuery };
   }
 
-  offsetLimitQuery = offsetLimitQuery.orderBy("cc_id", "desc");
-
   if (cursor.limit || cursor.offset) {
+    if (!getConfig("CONVERSATIONS_RECENT")) {
+      offsetLimitQuery = offsetLimitQuery.orderBy("cc_id", "desc");
+    }
+
     offsetLimitQuery = offsetLimitQuery
       .limit(cursor.limit)
       .offset(cursor.offset);

--- a/src/server/api/conversations.js
+++ b/src/server/api/conversations.js
@@ -90,7 +90,7 @@ function getConversationsJoinsAndWhereClause(
     if (contactsFilter.tags) {
       const tags = contactsFilter.tags;
 
-      let tagsSubquery = r.knex
+      let tagsSubquery = r.knexReadOnly
         .select(1)
         .from("tag_campaign_contact")
         .whereRaw(
@@ -143,7 +143,7 @@ export async function getConversations(
   /* Query #1 == get campaign_contact.id for all the conversations matching
    * the criteria with offset and limit. */
   const starttime = new Date();
-  let offsetLimitQuery = r.knex.select("campaign_contact.id as cc_id");
+  let offsetLimitQuery = r.knexReadOnly.select("campaign_contact.id as cc_id");
 
   offsetLimitQuery = getConversationsJoinsAndWhereClause(
     offsetLimitQuery,
@@ -187,7 +187,7 @@ export async function getConversations(
   });
   /* Query #2 -- get all the columns we need, including messages, using the
    * cc_ids from Query #1 to scope the results to limit, offset */
-  let query = r.knex.select(
+  let query = r.knexReadOnly.select(
     "campaign_contact.id as cc_id",
     "campaign_contact.first_name as cc_first_name",
     "campaign_contact.last_name as cc_last_name",
@@ -271,7 +271,7 @@ export async function getConversations(
 
   // tags query
   if (includeTags) {
-    const tagsQuery = r.knex
+    const tagsQuery = r.knexReadOnly
       .select(
         "tag_campaign_contact.campaign_contact_id as campaign_contact_id",
         "tag.name as name",
@@ -304,7 +304,7 @@ export async function getConversations(
     Number(new Date()) - Number(starttime)
   );
   const conversationsCountQuery = getConversationsJoinsAndWhereClause(
-    r.knex,
+    r.knexReadOnly,
     organizationId,
     {
       campaignsFilter,


### PR DESCRIPTION
This is experimental.  It includes a couple changes:

1. If DB_READONLY_HOST is set, then conversations queries will use that endpoint
2. CONVERSATIONS_RECENT adds some volatile changes -- it stops ordering conversations queries -- this makes for faster results but can have application consequences with pagination -- the pagination/ordering is not reliable
3. Allows alt-key for easter egg on take-conversations split assignment setup for adding a second dynamic assignment batch