### PR TITLE
Add ability to reorder survey questions via buttons "bump", "top" and "bottom" WIP

### DIFF
--- a/src/components/CampaignInteractionStepsForm.jsx
+++ b/src/components/CampaignInteractionStepsForm.jsx
@@ -162,6 +162,52 @@ export default class CampaignInteractionStepsForm extends React.Component {
     };
   }
 
+  bumpStep(id) {
+    return () => {
+      const step = this.state.interactionSteps.find(is => is.id === id);
+      var livingSiblings = [];
+      var otherRelatives = [];
+      for (let is of this.state.interactionSteps) {
+        if (
+          is.parentInteractionId !== step.parentInteractionId ||
+          step.isDeleted
+        ) {
+          otherRelatives.push(is);
+        } else {
+          livingSiblings.push(is);
+        }
+      }
+      const i = livingSiblings.findIndex(is => is.id === id);
+      if (i > 0) {
+        livingSiblings.splice(i, 1);
+        livingSiblings.splice(i - 1, 0, step);
+        this.setState({
+          interactionSteps: otherRelatives.concat(livingSiblings)
+        });
+      }
+    };
+  }
+
+  topStep(id) {
+    return () => {
+      const target = this.state.interactionSteps.filter(x => x.id === id);
+      const others = this.state.interactionSteps.filter(x => x.id !== id);
+      this.setState({
+        interactionSteps: target.concat(others)
+      });
+    };
+  }
+
+  bottomStep(id) {
+    return () => {
+      const target = this.state.interactionSteps.filter(x => x.id === id);
+      const others = this.state.interactionSteps.filter(x => x.id !== id);
+      this.setState({
+        interactionSteps: others.concat(target)
+      });
+    };
+  }
+
   handleFormChange(event) {
     const handler =
       event.answerActions &&
@@ -209,6 +255,28 @@ export default class CampaignInteractionStepsForm extends React.Component {
 
     return (
       <div>
+        {interactionStep.parentInteractionId ? (
+          <div>
+            <DeleteIcon
+              style={styles.pullRight}
+              onTouchTap={this.deleteStep(interactionStep.id).bind(this)}
+            />
+            <RaisedButton
+              label="Bump"
+              onTouchTap={this.bumpStep(interactionStep.id).bind(this)}
+            />
+            <RaisedButton
+              label="Top"
+              onTouchTap={this.topStep(interactionStep.id).bind(this)}
+            />
+            <RaisedButton
+              label="Bottom"
+              onTouchTap={this.bottomStep(interactionStep.id).bind(this)}
+            />
+          </div>
+        ) : (
+          ""
+        )}
         <Card
           style={styles.interactionStep}
           ref={interactionStep.id}
@@ -248,14 +316,6 @@ export default class CampaignInteractionStepsForm extends React.Component {
                   label="Answer"
                   fullWidth
                   hintText="Answer to the previous question"
-                />
-              ) : (
-                ""
-              )}
-              {interactionStep.parentInteractionId ? (
-                <DeleteIcon
-                  style={styles.pullRight}
-                  onTouchTap={this.deleteStep(interactionStep.id).bind(this)}
                 />
               ) : (
                 ""


### PR DESCRIPTION
# Fixes # (issue)
https://github.com/MoveOnOrg/Spoke/issues/1564

## Description

I added 3 buttons that allow users to reorder survey questions.
- Bump: lifts the question above its first sibling that precedes it.
- Top: lifts the question to be the first of its siblings.
- Bottom: lowers the question to be the last of its siblings.

This is a work in progress. WIP. Styling isn't perfect, and no drag and drop for now. Will need to test a bit more.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
