### PR TITLE
allow disable loading of contact cache: 

### DIFF
--- a/src/server/api/mutations/startCampaign.js
+++ b/src/server/api/mutations/startCampaign.js
@@ -63,7 +63,7 @@ export const startCampaign = async (
     campaignId: id
   });
 
-  if (r.redis) {
+  if (r.redis && !getConfig("DISABLE_CONTACT_CACHELOAD")) {
     // some asynchronous cache-priming:
     await jobRunner.dispatchTask(Tasks.CAMPAIGN_START_CACHE, {
       campaign: campaignRefreshed,


### PR DESCRIPTION
which has negative effects (table locking) when dynamic assignment starts too soon after starting a large campaign

Currently this just allows a switch to disable this.  Long-term we might decide to disable this by default.