### PR TITLE
Simplify exports

### DIFF
--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -710,12 +710,12 @@ export async function exportCampaign(job) {
       .getAll(assignment.id, { index: "assignment_id" });
 
     const contacts = await r
-      .knex("campaign_contact")
+      .knexReadOnly("campaign_contact")
       .leftJoin("zip_code", "zip_code.zip", "campaign_contact.zip")
       .select()
       .where("assignment_id", assignment.id);
     const messages = await r
-      .knex("message")
+      .knexReadOnly("message")
       .leftJoin(
         "campaign_contact",
         "campaign_contact.id",
@@ -742,7 +742,7 @@ export async function exportCampaign(job) {
     finalCampaignMessages = finalCampaignMessages.concat(convertedMessages);
     let convertedContacts = contacts.map(async contact => {
       const tags = await r
-        .knex("tag_campaign_contact")
+        .knexReadOnly("tag_campaign_contact")
         .where("campaign_contact_id", contact.id)
         .leftJoin("tag", "tag.id", "tag_campaign_contact.tag_id");
 
@@ -857,6 +857,7 @@ export async function exportCampaign(job) {
 
   await defensivelyDeleteJob(job);
 }
+
 export async function importScript(job) {
   const payload = await unzipPayload(job);
   try {

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -707,11 +707,11 @@ export async function exportCampaign(job) {
       "campaign_contact.id",
       "campaign_contact.campaign_id",
       "campaign_contact.assignment_id",
-      {texterFirst: "user.first_name"},
-      {texterLast: "user.last_name"},
-      {texterEmail: "user.email"},
-      {texterCell: "user.cell"},
-      {texterAlias: "user.alias"},
+      { texterFirst: "user.first_name" },
+      { texterLast: "user.last_name" },
+      { texterEmail: "user.email" },
+      { texterCell: "user.cell" },
+      { texterAlias: "user.alias" },
       "user.extra",
       "campaign_contact.external_id",
       "campaign_contact.first_name",
@@ -723,7 +723,7 @@ export async function exportCampaign(job) {
       "campaign_contact.custom_fields",
       "campaign_contact.is_opted_out",
       "campaign_contact.message_status",
-      "campaign_contact.error_code",
+      "campaign_contact.error_code"
     ])
     .select()
     .where("campaign_contact.campaign_id", campaign.id);
@@ -736,10 +736,13 @@ export async function exportCampaign(job) {
     // Add question response columns
     const responses = {};
     Object.keys(allQuestions).forEach(stepId => {
-      const {value=""} = questionResponses.find(response => {
-        return response.campaign_contact_id === row.id
-          && response.interaction_step_id === Number(stepId)
-      }) || {};
+      const { value = "" } =
+        questionResponses.find(response => {
+          return (
+            response.campaign_contact_id === row.id &&
+            response.interaction_step_id === Number(stepId)
+          );
+        }) || {};
       responses[`question[${allQuestions[stepId]}]`] = value;
     });
 
@@ -747,11 +750,13 @@ export async function exportCampaign(job) {
       ...row,
       ...customFields,
       tags: tags.reduce((acc, cur) => {
-        if (cur.campaign_contact_id == row.id)
-          acc.push(cur.name)
-        }, []),
+        if (cur.campaign_contact_id === row.id) {
+          acc.push(cur.name);
+        }
+        return acc;
+      }, []),
       ...responses
-    }
+    };
   });
 
   const messages = await r
@@ -764,7 +769,7 @@ export async function exportCampaign(job) {
       "contact_number",
       "is_from_contact",
       "send_status",
-      { attempted_at: "message.created_at"},
+      { attempted_at: "message.created_at" },
       "text",
       "message.error_code"
     ])


### PR DESCRIPTION
## Description

This attempts to fix out-of-memory errors and timeouts when exporting larger (100-200k) campaigns. I have not tested it with really large campaigns.

What this PR does is simplify the collection of data in the export code. Previously, `exportCampaign`  looped through all assignments in the campaign and then looped through each row in the assignment — potentially resulting in hundreds of thousands of queries for one export.

This changes it so that data is pulled with a few big queries (contacts, messages, question responses, tags), and does one loop through to combine/format the results in-place.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
