### PR TITLE
Allow texters to (optionally) see MMS media content

### DIFF
--- a/migrations/20201001164842_message_media.js
+++ b/migrations/20201001164842_message_media.js
@@ -1,0 +1,11 @@
+exports.up = knex => {
+  return knex.schema.table("message", table => {
+    table.jsonb("media").defaultTo(null);
+  });
+};
+
+exports.down = knex => {
+  return knex.schema.table("message", table => {
+    table.dropColumn("media");
+  });
+};

--- a/src/api/message.js
+++ b/src/api/message.js
@@ -1,7 +1,13 @@
 export const schema = `
+  type MediaItem {
+    type: String
+    url: String
+  }
+
   type Message {
     id: ID
     text: String
+    media: [MediaItem]
     userNumber: String
     contactNumber: String
     createdAt: Date

--- a/src/components/AssignmentTexter/MessageList.jsx
+++ b/src/components/AssignmentTexter/MessageList.jsx
@@ -1,10 +1,17 @@
 import PropTypes from "prop-types";
 import React from "react";
 import { List, ListItem } from "material-ui/List";
+import { Card, CardHeader, CardMedia } from "material-ui/Card";
+import Avatar from "material-ui/Avatar";
 import moment from "moment";
+import AttachmentIcon from "material-ui/svg-icons/file/attachment";
+import AudioIcon from "material-ui/svg-icons/hardware/headset";
+import ImageIcon from "material-ui/svg-icons/image/image";
+import VideoIcon from "material-ui/svg-icons/hardware/tv";
 import ProhibitedIcon from "material-ui/svg-icons/av/not-interested";
 import Divider from "material-ui/Divider";
 import { red300 } from "material-ui/styles/colors";
+import theme from "../../styles/theme";
 
 const defaultStyles = {
   optOut: {
@@ -19,12 +26,20 @@ const defaultStyles = {
   received: {
     fontSize: "13px",
     marginRight: "24px"
+  },
+  mediaItem: {
+    marginTop: "5px",
+    backgroundColor: "rgba(255,255,255,.5)"
   }
 };
 
 const MessageList = function MessageList(props) {
   const { contact, styles } = props;
   const { optOut, messages } = contact;
+
+  messages.forEach(m => {
+    console.log(m);
+  });
 
   const received = (styles && styles.messageReceived) || defaultStyles.received;
   const sent = (styles && styles.messageSent) || defaultStyles.sent;
@@ -46,6 +61,64 @@ const MessageList = function MessageList(props) {
     ""
   );
 
+  const renderMsg = message => (
+    <div>
+      <div>{message.text}</div>
+      {message.media && message.media.map(media => {
+        let type, icon, embed, subtitle;
+        if (media.type.startsWith('image')) {
+          type = 'Image';
+          icon = <ImageIcon />;
+          embed = <img src={media.url} alt="Media" />;
+        }
+        else if (media.type.startsWith('video')) {
+          type = 'Video';
+          icon = <VideoIcon />;
+          embed = (
+            <video controls>
+              <source src={media.url} type={media.type} />
+              Your browser can't play this file
+            </video>
+          );
+        }
+        else if (media.type.startsWith('audio')) {
+          type = 'Audio';
+          icon = <AudioIcon />;
+          embed = (
+            <audio controls>
+              <source src={media.url} type={media.type} />
+              Your browser can't play this file
+            </audio>
+          );
+        }
+        else {
+          type = 'Unsupprted media';
+          icon = <AttachmentIcon />;
+          subtitle = `Type: ${media.type}`;
+        }
+        return (
+          <Card style={defaultStyles.mediaItem}>
+            <CardHeader
+              actAsExpander
+              showExpandableButton={!!embed}
+              title={`${type} attached`}
+              subtitle={subtitle || "View media at your own risk"}
+              avatar={<Avatar
+                icon={icon}
+                backgroundColor={theme.colors.darkGray}
+              />}
+            />
+            {embed && (
+              <CardMedia expandable>
+                {embed}
+              </CardMedia>
+            )}
+          </Card>
+        )
+      })}
+    </div>
+  );
+
   return (
     <List style={listStyle}>
       {messages.map(message => (
@@ -53,7 +126,7 @@ const MessageList = function MessageList(props) {
           disabled
           style={message.isFromContact ? received : sent}
           key={message.id}
-          primaryText={message.text}
+          primaryText={renderMsg(message)}
           secondaryText={
             <span
               style={{ fontSize: "90%", display: "block", paddingTop: "5px" }}

--- a/src/components/AssignmentTexter/MessageList.jsx
+++ b/src/components/AssignmentTexter/MessageList.jsx
@@ -37,10 +37,6 @@ const MessageList = function MessageList(props) {
   const { contact, styles } = props;
   const { optOut, messages } = contact;
 
-  messages.forEach(m => {
-    console.log(m);
-  });
-
   const received = (styles && styles.messageReceived) || defaultStyles.received;
   const sent = (styles && styles.messageSent) || defaultStyles.sent;
   const listStyle = (styles && styles.messageList) || {};

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -34,6 +34,10 @@ export const contactDataFragment = `
           id
           createdAt
           text
+          media {
+            type
+            url
+          }
           isFromContact
         }
         tags {

--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -155,11 +155,24 @@ async function convertMessagePartsToMessage(messageParts) {
     .map(serviceMessage => serviceMessage.Body)
     .join("")
     .replace(/\0/g, ""); // strip all UTF-8 null characters (0x00)
+  const media = serviceMessages
+    .map(serviceMessage => {
+      const mediaItems = [];
+      for (let m = 0; m < Number(serviceMessage.NumMedia); m++) {
+        mediaItems.push({
+          type: serviceMessage[`MediaContentType${m}`],
+          url: serviceMessage[`MediaUrl${m}`]
+        });
+      }
+      return mediaItems;
+    })
+    .reduce((acc, val) => acc.concat(val), []); // flatten array
   return new Message({
     contact_number: contactNumber,
     user_number: userNumber,
     is_from_contact: true,
     text,
+    media,
     error_code: null,
     service_id: firstPart.service_id,
     // will be set during cacheableData.message.save()

--- a/src/server/api/message.js
+++ b/src/server/api/message.js
@@ -7,7 +7,9 @@ export const resolvers = {
       ["text", "userNumber", "contactNumber", "createdAt", "isFromContact"],
       Message
     ),
-    media: msg => msg.media || [],
+    media: msg =>
+      // Sometimes it's array, sometimes string. Maybe db vs. cache?
+      typeof msg.media === "string" ? JSON.parse(msg.media) : msg.media || [],
     // cached messages don't have message.id -- why bother
     id: msg => msg.id || `fake${Math.random()}`
   }

--- a/src/server/api/message.js
+++ b/src/server/api/message.js
@@ -7,6 +7,7 @@ export const resolvers = {
       ["text", "userNumber", "contactNumber", "createdAt", "isFromContact"],
       Message
     ),
+    media: msg => msg.media,
     // cached messages don't have message.id -- why bother
     id: msg => msg.id || `fake${Math.random()}`
   }

--- a/src/server/api/message.js
+++ b/src/server/api/message.js
@@ -7,7 +7,7 @@ export const resolvers = {
       ["text", "userNumber", "contactNumber", "createdAt", "isFromContact"],
       Message
     ),
-    media: msg => msg.media,
+    media: msg => msg.media || [],
     // cached messages don't have message.id -- why bother
     id: msg => msg.id || `fake${Math.random()}`
   }

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -257,6 +257,10 @@ const messageCache = {
         messageInstance.campaign_contact_id ||
         (activeCellFound && activeCellFound.campaign_contact_id);
       messageToSave.campaign_contact_id = contactId;
+      messageToSave.media =
+        messageInstance.media && messageInstance.media.length
+          ? JSON.stringify(messageInstance.media)
+          : null;
     } else {
       if (
         r.redis &&

--- a/src/server/models/message.js
+++ b/src/server/models/message.js
@@ -29,6 +29,7 @@ const Message = thinky.createModel(
         .required()
         .allowNull(false),
       text: optionalString(),
+      media: type.string().default(null),
       assignment_id: optionalString(), //deprecated: use refs by campaign_contact_id or user_id
       campaign_contact_id: optionalString(),
       messageservice_sid: optionalString().stopReference(),


### PR DESCRIPTION
# Fixes #1354 

## Description

Currently, all multimedia attached to incoming messages is ignored. This gives the texter an option to see attached media by clicking to expand a card in the message list. This way, they can decide — based on the context of the conversation and their own comfort level — whether they want to see the images.

This can be great for GOTV campaigns, where people often respond with "I Voted" selfies and other fun content.

![2020-10-05 at 4 22 PM](https://user-images.githubusercontent.com/18371709/95228202-08aa4a00-07cd-11eb-90d5-70b42e5c4bc8.png)

![2020-10-05 at 4 23 PM](https://user-images.githubusercontent.com/18371709/95228511-6e96d180-07cd-11eb-9ad9-3d6bb6e071ca.png)

![2020-10-05 at 4 28 PM](https://user-images.githubusercontent.com/18371709/95228600-8cfccd00-07cd-11eb-94d7-b762001b83a0.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
