### PR TITLE
Clear user cache when creating org

### DIFF
--- a/src/containers/AdminOrganizationsDashboard.jsx
+++ b/src/containers/AdminOrganizationsDashboard.jsx
@@ -155,6 +155,7 @@ class AdminOrganizationsDashboard extends React.Component {
                 this.props.data.organizations.reverse();
               }
             }}
+            initialSort={{ column: "id", order: "desc" }}
           />
         </div>
         {this.renderActionButton()}

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1065,6 +1065,7 @@ const rootMutations = {
         user_id: userId,
         organization_id: newOrganization.id
       });
+      await cacheableData.user.clearUser(userId);
       await Invite.save(
         {
           id: inviteId,
@@ -1435,7 +1436,7 @@ const rootResolvers = {
     },
     organizations: async (_, { id }, { user }) => {
       if (user.is_superadmin) {
-        return r.table("organization");
+        return r.table("organization").orderBy("id");
       } else {
         return await cacheableData.user.userOrgs(user.id, "TEXTER");
       }


### PR DESCRIPTION
## Description

When a superadmin creates a new organization through the UI, they get added to the org as OWNER, but a cache clear is needed for them to actually be able to act as admin for the group.

Also defaults the Manage Organizations dashboard to be sorted by org id.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
