### PR TITLE
[WIP] Multi org todo screen

### DIFF
--- a/src/containers/TexterTodoList.jsx
+++ b/src/containers/TexterTodoList.jsx
@@ -17,7 +17,6 @@ class TexterTodoList extends React.Component {
   }
 
   renderTodoList(assignments) {
-    const organizationId = this.props.params.organizationId;
     return assignments
       .sort((x, y) => {
         const xToText = x.unmessagedCount + x.unrepliedCount;
@@ -34,7 +33,7 @@ class TexterTodoList extends React.Component {
         ) {
           return (
             <AssignmentSummary
-              organizationId={organizationId}
+              organizationId={assignment.campaign.organization.id}
               key={assignment.id}
               assignment={assignment}
               texter={this.props.data.user}
@@ -121,6 +120,7 @@ export const dataQuery = gql`
   query getTodos(
     $userId: Int
     $organizationId: String!
+    $todosOrg: String
     $needsMessageFilter: ContactsFilter
     $needsResponseFilter: ContactsFilter
     $badTimezoneFilter: ContactsFilter
@@ -134,7 +134,7 @@ export const dataQuery = gql`
       profileComplete(organizationId: $organizationId)
       cacheable
       roles(organizationId: $organizationId)
-      todos(organizationId: $organizationId) {
+      todos(organizationId: $todosOrg) {
         id
         hasUnassignedContactsForTexter
         campaign {
@@ -199,6 +199,11 @@ const queries = {
       variables: {
         userId: ownProps.params.userId || null,
         organizationId: ownProps.params.organizationId,
+        todosOrg:
+          ownProps.location.query["org"] == "all" ||
+          !ownProps.params.organizationId
+            ? null
+            : ownProps.params.organizationId,
         needsMessageFilter: {
           messageStatus: "needsMessage",
           isOptedOut: false,

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -259,11 +259,12 @@ export const resolvers = {
         .join("campaign", "assignment.campaign_id", "campaign.id")
         .where({
           is_started: true,
-          organization_id: organizationId,
           is_archived: false
         })
         .where("assignment.user_id", user.id);
-
+      if (organizationId) {
+        query.where("organization_id", organizationId);
+      }
       if (getConfig("FILTER_DUEBY", null, { truthy: 1 })) {
         query = query.where("campaign.due_by", ">", new Date());
       }


### PR DESCRIPTION
# Fixes #1871

## Description
This allows for appending the query param `?org=all` to the Texter Todo screen to get all texter assignments cross org. I'm posting this WIP because I wanted to check in on my proposal here to run a `filter` whenever we display the Todo screen. My understanding is that this page is not one that is particularly slow normally, and that filter will in the majority of cases be pretty fast since most texters shouldn't have a huge number of assignments. That said, I want to be mindful of adding any scaling concerns to the texter side.

This also doesn't have tests yet, but I'm working on those.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
