### PR TITLE
Add phone inventory config var to the code while keeping the experime…

### DIFF
--- a/__test__/cypress/plugins/utils.js
+++ b/__test__/cypress/plugins/utils.js
@@ -14,7 +14,7 @@ export async function getOrCreateTestOrganization() {
       .insert({
         name: DEFAULT_ORGANIZATION_NAME,
         uuid: uuid.v4(),
-        features: JSON.stringify({ EXPERIMENTAL_PHONE_INVENTORY: true })
+        features: JSON.stringify({ PHONE_INVENTORY: true })
       })
       .returning("*");
   }

--- a/__test__/server/api/campaign/campaign.test.js
+++ b/__test__/server/api/campaign/campaign.test.js
@@ -1276,7 +1276,7 @@ describe("per-campaign phone numbers", async () => {
   beforeAll(() => {
     process.env = {
       ...process.env,
-      EXPERIMENTAL_PHONE_INVENTORY: "1",
+      PHONE_INVENTORY: "1",
       EXPERIMENTAL_CAMPAIGN_PHONE_NUMBERS: "1"
     };
   });

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -359,6 +359,9 @@ export const resolvers = {
       if (
         !getConfig("EXPERIMENTAL_PHONE_INVENTORY", organization, {
           truthy: true
+        }) ||
+        !getConfig("PHONE_INVENTORY", organization, {
+          truthy: true
         })
       ) {
         return [];


### PR DESCRIPTION
…ntal var
# Description

Every few weeks someone applies the `PHONE_INVENTORY` env var as they setup a new instance cause that's what our docs say to do and then there's this one area of the code that doesn't yet have the phone inventory conditional and their phone inventory screen doesn't register their numbers even as they buy them from Twilio. This should fix that.

Admittedly I don't have a good dev env set up for testing this. I can definitely set that up. The tests do all pass with this in though.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
