### PR TITLE
Delete phone numbers from inventory and Twilio

### DIFF
--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -360,6 +360,7 @@ const rootSchema = gql`
       limit: Int!
       addToOrganizationMessagingService: Boolean
     ): JobRequest
+    deletePhoneNumbers(organizationId: ID!, areaCode: String!): JobRequest
     releaseCampaignNumbers(campaignId: ID!): Campaign!
     clearCachedOrgAndExtensionCaches(organizationId: String!): String
   }

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -120,17 +120,19 @@ class AdminPhoneNumberInventory extends React.Component {
     });
   };
 
-  handleDeleteNumbersOpen = areaCode => {
+  handleDeleteNumbersOpen = row => {
     this.setState({
       deleteNumbersDialogOpen: true,
-      deleteNumbersAreaCode: areaCode
+      deleteNumbersAreaCode: row.areaCode,
+      deleteNumbersCount: row.availableCount
     });
   };
 
   handleDeleteNumbersCancel = () => {
     this.setState({
       deleteNumbersDialogOpen: false,
-      deleteNumbersAreaCode: null
+      deleteNumbersAreaCode: null,
+      deleteNumbersCount: 0
     });
   };
 
@@ -177,7 +179,7 @@ class AdminPhoneNumberInventory extends React.Component {
           this.props.params.ownerPerms ? (
             <FlatButton
               icon={<DeleteIcon />}
-              onTouchTap={() => this.handleDeleteNumbersOpen(row.areaCode)}
+              onTouchTap={() => this.handleDeleteNumbersOpen(row)}
             />
           ) : null
       },
@@ -319,7 +321,7 @@ class AdminPhoneNumberInventory extends React.Component {
               onClick={this.handleDeleteNumbersCancel}
             />,
             <RaisedButton
-              label="Delete"
+              label={`Delete ${this.state.deleteNumbersCount} Numbers`}
               secondary
               onClick={this.handleDeletePhoneNumbersSubmit}
             />

--- a/src/server/api/lib/fakeservice.js
+++ b/src/server/api/lib/fakeservice.js
@@ -1,7 +1,6 @@
 import { getLastMessage } from "./message-sending";
 import { Message, PendingMessagePart, r, cacheableData } from "../../models";
 import uuid from "uuid";
-import { CountryInstance } from "twilio/lib/rest/pricing/v1/voice/country";
 
 // This 'fakeservice' allows for fake-sending messages
 // that end up just in the db appropriately and then using sendReply() graphql

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -48,3 +48,35 @@ export const buyPhoneNumbers = async (
     })
   });
 };
+
+export const deletePhoneNumbers = async (
+  _,
+  { organizationId, areaCode },
+  { user }
+) => {
+  await accessRequired(user, organizationId, "OWNER");
+  const org = await cacheableData.organization.load(organizationId);
+  if (
+    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true }) &&
+    !getConfig("PHONE_INVENTORY", org, { truthy: true })
+  ) {
+    throw new Error("Phone inventory management is not enabled");
+  }
+  const serviceName = getConfig("DEFAULT_SERVICE", org);
+  const service = serviceMap[serviceName];
+  if (!service || !service.hasOwnProperty("buyNumbersInAreaCode")) {
+    throw new Error(
+      `Service ${serviceName} does not support phone number buying`
+    );
+  }
+
+  return await jobRunner.dispatchJob({
+    queue_name: `${organizationId}:delete_phone_numbers`,
+    organization_id: organizationId,
+    job_type: Jobs.DELETE_PHONE_NUMBERS,
+    locks_queue: false,
+    payload: JSON.stringify({
+      areaCode
+    })
+  });
+};

--- a/src/server/api/mutations/index.js
+++ b/src/server/api/mutations/index.js
@@ -1,5 +1,5 @@
 import { bulkSendMessages } from "./bulkSendMessages";
-import { buyPhoneNumbers } from "./buyPhoneNumbers";
+import { buyPhoneNumbers, deletePhoneNumbers } from "./buyPhoneNumbers";
 import { editOrganization } from "./editOrganization";
 import { findNewCampaignContact } from "./findNewCampaignContact";
 import { joinOrganization } from "./joinOrganization";
@@ -14,6 +14,7 @@ import { clearCachedOrgAndExtensionCaches } from "./clearCachedOrgAndExtensionCa
 export {
   bulkSendMessages,
   buyPhoneNumbers,
+  deletePhoneNumbers,
   editOrganization,
   findNewCampaignContact,
   joinOrganization,

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -332,10 +332,8 @@ export const resolvers = {
       await accessRequired(user, organization.id, "OWNER", true);
       const jobs = await r
         .knex("job_request")
-        .where({
-          job_type: "buy_phone_numbers",
-          organization_id: organization.id
-        })
+        .whereIn("job_type", ["buy_phone_numbers", "delete_phone_numbers"])
+        .andWhere("organization_id", organization.id)
         .orderBy("updated_at", "desc");
       return jobs.map(j => {
         const payload = JSON.parse(j.payload);
@@ -345,7 +343,7 @@ export const resolvers = {
           status: j.status,
           resultMessage: j.result_message,
           areaCode: payload.areaCode,
-          limit: payload.limit
+          limit: payload.limit || 0
         };
       });
     },

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -55,6 +55,7 @@ import Twilio from "twilio";
 import {
   bulkSendMessages,
   buyPhoneNumbers,
+  deletePhoneNumbers,
   findNewCampaignContact,
   joinOrganization,
   editOrganization,
@@ -478,6 +479,7 @@ const rootMutations = {
   RootMutation: {
     bulkSendMessages,
     buyPhoneNumbers,
+    deletePhoneNumbers,
     editOrganization,
     findNewCampaignContact,
     joinOrganization,

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -16,6 +16,7 @@ import {
   clearOldJobs,
   importScript,
   buyPhoneNumbers,
+  deletePhoneNumbers,
   startCampaignWithPhoneNumbers
 } from "./jobs";
 import { setupUserNotificationObservers } from "../server/notifications";
@@ -39,6 +40,7 @@ export const Jobs = Object.freeze({
   ASSIGN_TEXTERS: "assign_texters",
   IMPORT_SCRIPT: "import_script",
   BUY_PHONE_NUMBERS: "buy_phone_numbers",
+  DELETE_PHONE_NUMBERS: "delete_phone_numbers",
   START_CAMPAIGN_WITH_PHONE_NUMBERS: "start_campaign_with_phone_numbers"
 });
 
@@ -47,6 +49,7 @@ const jobMap = Object.freeze({
   [Jobs.ASSIGN_TEXTERS]: assignTexters,
   [Jobs.IMPORT_SCRIPT]: importScript,
   [Jobs.BUY_PHONE_NUMBERS]: buyPhoneNumbers,
+  [Jobs.DELETE_PHONE_NUMBERS]: deletePhoneNumbers,
   [Jobs.START_CAMPAIGN_WITH_PHONE_NUMBERS]: startCampaignWithPhoneNumbers
 });
 

--- a/src/workers/jobs.js
+++ b/src/workers/jobs.js
@@ -1208,7 +1208,7 @@ export async function deletePhoneNumbers(job) {
     }
     const { areaCode } = JSON.parse(job.payload);
     if (!areaCode) {
-      throw new Error("areaCode and is required");
+      throw new Error("areaCode is required");
     }
     const organization = await cacheableData.organization.load(
       job.organization_id


### PR DESCRIPTION
## Description

Adds delete buttons to the phone number inventory page, which lets you bulk remove unallocated numbers for an area code from both the Spoke inventory and you Twilio account.

![2020-11-06 at 9 03 AM](https://user-images.githubusercontent.com/18371709/98376145-1859c000-2011-11eb-8237-73f3252626b9.png)
![2020-11-06 at 9 03 AM](https://user-images.githubusercontent.com/18371709/98376177-23145500-2011-11eb-93ca-05d3e22a2f83.png)
 

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
