### PR TITLE
Move step to run Postgres command before step to populate test db in local setup doc

### DIFF
--- a/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
+++ b/docs/HOWTO_DEVELOPMENT_LOCAL_SETUP.md
@@ -44,10 +44,11 @@ Docker is optional, but can help with a consistent development environment using
 - Docker allows you to run apps in containers and can be installed [here with Docker's instructions](https://docs.docker.com/desktop/)
 - Docker Compose is the tool used to create and run docker configurations. If you installed Docker on Mac, you already have Docker Compose, if you're using Linux or Windows you can install Docker Compose [with these instructions](https://docs.docker.com/compose/install/)
 
-2. Run `./dev-tools/create-test-database` to populate the test database
-
-3. Make sure Docker is running on your machine and then build and run Spoke with `docker-compose up -d` to run redis and postgres in the background
+2. Make sure Docker is running on your machine and then build and run Spoke with `docker-compose up -d` to run redis and postgres in the background
    - You can stop docker compose at any time with `docker-compose down`, and data will persist next time you run `docker-compose up`.
+
+3. Run `./dev-tools/create-test-database` to populate the test database
+
 4. When done testing, clean up resources with `docker-compose down`, or `docker-compose down -v` to **_completely destroy_** your Postgres database & Redis datastore volumes.
 
 ### Getting the app running


### PR DESCRIPTION
# Fixes #1892

## Description

Swap the steps for running `docker-compose up -d` and running `./dev-tools/create-test-database` in doc about running a local setup with Postgres.

We need to make sure Postgres is running before trying to populate the database.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
  - Tested manually by following the new steps in order
- [x] My PR is labeled [WIP] if it is in progress
