### PR TITLE
Message Review: Allow long TagChips to overflow and enable horizonal scrolling of IncomingMessageList table

### DIFF
--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -217,7 +217,7 @@ export class IncomingMessageList extends Component {
       label: "View Conversation",
       style: {
         textOverflow: "ellipsis",
-        overflow: "hidden",
+        overflow: "visible",
         whiteSpace: "pre-line"
       },
       render: (columnKey, row) => (

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -325,6 +325,7 @@ export class IncomingMessageList extends Component {
     const { clearSelectedMessages } = this.props;
     const displayPage = Math.floor(offset / limit) + 1;
     const tableData = prepareDataTableData(conversations);
+    const tableBodyStyle = {overflowX: "auto"}
 
     return (
       <div>
@@ -343,6 +344,7 @@ export class IncomingMessageList extends Component {
           onRowSizeChange={this.handleRowSizeChanged}
           onRowSelection={this.handleRowsSelected}
           selectedRows={clearSelectedMessages ? null : this.state.selectedRows}
+          tableBodyStyle={tableBodyStyle}
         />
         <ConversationPreviewModal
           organizationTags={this.state.tags}


### PR DESCRIPTION
# Fixes #1894

## Description

In the Message Review incoming message list, allow long TagChips to overflow their table cells and allow horizontal scrolling of the table. This ensures that users can both see the entire tag text and access the delete button when using any combination of small enough screen, long enough tag text, and large enough text size such that the TagChip does not fit entirely inside its table cell.

See screenshot of table scrolled to view a long tag:
<img width="1347" alt="Screen Shot 2020-11-28 at 11 25 31 AM" src="https://user-images.githubusercontent.com/2031490/100520626-b05c4c80-316c-11eb-8661-7f75f63e79a8.png">

# Checklist:

- [x] I have manually tested my changes on desktop and mobile (mobile via device emulation on desktop browser)
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
  - Manual testing only -- if we have a way to test purely UI changes, let me know!
- [x] My PR is labeled [WIP] if it is in progress
  - not applicable
