### PR TITLE
Allow vertical scrolling of tags sidebox independent from message list

### DIFF
--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -931,7 +931,7 @@ export class AssignmentTexterContactControls extends React.Component {
         </Popover>
       );
     }
-    // TODO: max height and scroll-y
+    // TODO: max height
     return <div className={css(flexStyles.sectionSideBox)}>{sideboxList}</div>;
   }
 

--- a/src/components/AssignmentTexter/StyleControls.js
+++ b/src/components/AssignmentTexter/StyleControls.js
@@ -89,6 +89,7 @@ export const flexStyles = StyleSheet.create({
   },
   sectionSideBox: {
     flex: "0 1 240px",
+    overflowY: "scroll",
     textAlign: "center",
     padding: "24px",
     maxWidth: "240px",


### PR DESCRIPTION
# Fixes #1896 

## Description

Add `overflow-y: scroll` to CSS for `sectionSideBox` in AssignmentTexterContactControls. This allows the tag sidebox to scroll independently from the message list in the texter conversation view, so that the texter can scroll to the bottom of long lists of tags without causing the conversation to disappear off screen. See screenshot below of a tag sidebox scrolled vertically without changing moving the conversation message list (and compare to screenshot in #1896).

I also verified that the behavior of the popup sidebox (used when the viewport is narrow) is unchanged.

<img width="1354" alt="Screen Shot 2020-11-28 at 7 06 22 PM" src="https://user-images.githubusercontent.com/2031490/100528745-07cedc80-31ae-11eb-95bf-f5dfe7297b5a.png">

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
  - On mobile I tested using device emulation in Chrome. My physical mobile device has a small enough screen that the conversation view is completely unusable in landscape mode (which is the only way to get the viewport wide enough for the sidebox to appear on the side).
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
  - If there is a way to test a purely UI/style change, let me know and I will add something.
- [x] My PR is labeled [WIP] if it is in progress
  - n/a
