### PR TITLE
Change  -1 error message to not suggest an automatic retry

### DIFF
--- a/src/server/api/lib/twilio.js
+++ b/src/server/api/lib/twilio.js
@@ -85,7 +85,7 @@ export const errorDescriptions = {
   30006: "Landline or unreachable carrier",
   30007: "Message Delivery - Carrier violation",
   30008: "Message Delivery - Unknown error",
-  "-1": "Spoke failed to send the message and will try again.",
+  "-1": "Spoke failed to send the message, usually due to a temporary issue.",
   "-2": "Spoke failed to send the message and will try again.",
   "-3": "Spoke failed to send the message and will try again.",
   "-4": "Spoke failed to send the message and will try again.",


### PR DESCRIPTION
Automatic retries are not the default behavior on a new Spoke build, so the error message when you get a -1 shouldn't suggest a retry is coming. I did not change the messages for -2 to -5, since to reach those cases your build must be employing some manner of retry logic. 

See https://progcode.slack.com/archives/C717R1DMZ/p1606154352333200 for slightly more discussion.


