### PR TITLE
for heroku + pg 8+ need ssl -> rejectunauthorized: true

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "passport-local": "^1.0.0",
     "passport-local-authenticate": "^1.2.0",
     "pg": "^8.0.3",
+    "pg-connection-string": "^2.4.0",
     "pg-query-stream": "^1.1.1",
     "prop-types": "^15.6.0",
     "query-string": "^4.1.0",

--- a/src/server/knex-connect.js
+++ b/src/server/knex-connect.js
@@ -22,6 +22,7 @@ const min = parseInt(DB_MIN_POOL, 10);
 const max = parseInt(DB_MAX_POOL, 10);
 
 const pg = require("pg");
+const { parse: pgDbUrlParser } = require("pg-connection-string");
 
 const useSSL = DB_USE_SSL === "1" || DB_USE_SSL.toLowerCase() === "true";
 if (useSSL) pg.defaults.ssl = true;
@@ -49,15 +50,30 @@ if (DB_JSON) {
   };
 } else if (DATABASE_URL) {
   const dbType = DATABASE_URL.match(/^\w+/)[0];
+  if (/postgres/.test(dbType)) {
+    const connection = pgDbUrlParser(process.env.DATABASE_URL);
+    config = {
+      client: "pg",
+      connection: {
+        ...connection,
+        ssl: useSSL ? { rejectUnauthorized: false } : false
+      }
+    };
+  } else {
+    config = {
+      client: dbType,
+      connection: DATABASE_URL,
+      ssl: useSSL
+    };
+  }
+
   config = {
-    client: /postgres/.test(dbType) ? "pg" : dbType,
-    connection: DATABASE_URL,
+    ...config,
     searchPath: DB_SCHEMA || "",
     migrations: {
       directory: process.env.KNEX_MIGRATION_DIR || "./migrations/"
     },
-    pool: { min, max },
-    ssl: useSSL
+    pool: { min, max }
   };
 } else if (NODE_ENV === "test") {
   config = {


### PR DESCRIPTION
upgrading to pg8+ breaks heroku PG deployments without the following fix

see: https://help.heroku.com/MDM23G46/why-am-i-getting-an-error-when-i-upgrade-to-pg-8

NOTE: using the simpler method of just turning `ssl: true` in the config object into `ssl: { rejectUnauthorized: false }` doesn't work – the only way i can get it working is putting the ssl key in a `connection` _object_, thus needing to use this `DATABASE_URL` parser package recommended by heroku (edited) 