### PR TITLE
ScriptEditor cursor position

### DIFF
--- a/src/components/ScriptEditor.jsx
+++ b/src/components/ScriptEditor.jsx
@@ -148,6 +148,16 @@ class ScriptEditor extends React.Component {
     return editorState;
   }
 
+  componentDidMount() {
+    const { editorState } = this.state;
+    this.setState({ editorState: this.moveFocusToEnd(editorState) });
+  }
+
+  moveFocusToEnd(editorState) {
+    editorState = EditorState.moveSelectionToEnd(editorState);
+    return EditorState.forceSelection(editorState, editorState.getSelection());
+  }
+
   getValue() {
     const { editorState } = this.state;
     return editorState.getCurrentContent().getPlainText();


### PR DESCRIPTION
## Description
When opening the ScriptEditor the cursor should be at the end of the text in the input. Starting the cursor at the beginning of the input feels awkward and makes it harder to open the editor and start typing.

OLD
![image](https://user-images.githubusercontent.com/87616/107452779-d52f5180-6b17-11eb-9158-c8969483eea1.png)

NEW
![image](https://user-images.githubusercontent.com/87616/107452824-ebd5a880-6b17-11eb-8cb4-28598a12ed01.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
