### PR TITLE
No yellow badges

### DIFF
--- a/__test__/components/AssignmentSummary.test.js
+++ b/__test__/components/AssignmentSummary.test.js
@@ -170,16 +170,20 @@ describe("AssignmentSummary actions inUSA and NOT AllowSendAll", () => {
     const actions = create(0, 0, 0, 9, 0, false);
     expect(
       actions
-        .find(Badge)
+        .find(RaisedButton)
         .at(0)
-        .prop("badgeContent")
-    ).toBe(9);
+        .prop("label")
+    ).toBe("Past 9 Messages");
+  });
+
+  it('renders "skipped messages (n)" with messaged', () => {
+    const actions = create(0, 0, 0, 0, 8, false);
     expect(
       actions
         .find(RaisedButton)
         .at(0)
         .prop("label")
-    ).toBe("Past Messages");
+    ).toBe("Skipped 8 Messages");
   });
 });
 
@@ -242,7 +246,8 @@ it('renders "Send later" when there is a badTimezoneCount', () => {
             unmessagedCount: 0,
             unrepliedCount: 0,
             badTimezoneCount: 4,
-            skippedMessagesCount: 0
+            skippedMessagesCount: 0,
+            pastMessagesCount: 0
           }
         })}
       />
@@ -251,21 +256,15 @@ it('renders "Send later" when there is a badTimezoneCount', () => {
   expect(
     actions
       .find(Badge)
-      .at(1)
+      .at(0)
       .prop("badgeContent")
   ).toBe(4);
   expect(
     actions
       .find(RaisedButton)
-      .at(0)
-      .prop("label")
-  ).toBe("Past Messages");
-  expect(
-    actions
-      .find(RaisedButton)
       .at(1)
       .prop("label")
-  ).toBe("Send messages");
+  ).toBe("Send later (outside timezone)");
 });
 
 describe("contacts filters", () => {

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -197,7 +197,9 @@ export class AssignmentSummary extends Component {
                 })}
             {this.renderBadgedButton({
               assignment,
-              title: `Past ${pastMessagesCount} Messages`,
+              title: pastMessagesCount
+                ? `Past ${pastMessagesCount} Messages`
+                : `Past Messages`,
               count: pastMessagesCount,
               primary: false,
               disabled: false,
@@ -207,7 +209,9 @@ export class AssignmentSummary extends Component {
             })}
             {this.renderBadgedButton({
               assignment,
-              title: `Skipped ${skippedMessagesCount} Messages`,
+              title: skippedMessagesCount
+                ? `Skipped ${skippedMessagesCount} Messages`
+                : `Skipped Messages`,
               count: skippedMessagesCount,
               primary: false,
               disabled: false,

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -25,17 +25,6 @@ export const inlineStyles = {
     textAlign: "center",
     verticalAlign: "middle",
     height: 20
-  },
-  pastMsgStyle: {
-    backgroundColor: "#FFD700",
-    fontSize: 12,
-    top: 20,
-    right: 20,
-    padding: "4px 2px 0px 2px",
-    width: 20,
-    textAlign: "center",
-    verticalAlign: "middle",
-    height: 20
   }
 };
 
@@ -210,7 +199,6 @@ export class AssignmentSummary extends Component {
               assignment,
               title: `Past ${pastMessagesCount} Messages`,
               count: pastMessagesCount,
-              style: inlineStyles.pastMsgStyle,
               primary: false,
               disabled: false,
               contactsFilter: "stale",
@@ -221,7 +209,6 @@ export class AssignmentSummary extends Component {
               assignment,
               title: `Skipped ${skippedMessagesCount} Messages`,
               count: skippedMessagesCount,
-              style: inlineStyles.pastMsgStyle,
               primary: false,
               disabled: false,
               contactsFilter: "skipped",

--- a/src/components/AssignmentSummary.jsx
+++ b/src/components/AssignmentSummary.jsx
@@ -77,12 +77,13 @@ export class AssignmentSummary extends Component {
     disabled,
     contactsFilter,
     hideIfZero,
+    hideBadge,
     style
   }) {
     if (count === 0 && hideIfZero) {
       return "";
     }
-    if (count === 0) {
+    if (count === 0 || hideBadge) {
       return (
         <RaisedButton
           {...dataTest(dataTestText)}
@@ -207,23 +208,25 @@ export class AssignmentSummary extends Component {
                 })}
             {this.renderBadgedButton({
               assignment,
-              title: "Past Messages",
+              title: `Past ${pastMessagesCount} Messages`,
               count: pastMessagesCount,
               style: inlineStyles.pastMsgStyle,
               primary: false,
               disabled: false,
               contactsFilter: "stale",
-              hideIfZero: true
+              hideIfZero: true,
+              hideBadge: true
             })}
             {this.renderBadgedButton({
               assignment,
-              title: "Skipped Messages",
+              title: `Skipped ${skippedMessagesCount} Messages`,
               count: skippedMessagesCount,
               style: inlineStyles.pastMsgStyle,
               primary: false,
               disabled: false,
               contactsFilter: "skipped",
-              hideIfZero: true
+              hideIfZero: true,
+              hideBadge: true
             })}
             {window.NOT_IN_USA && window.ALLOW_SEND_ALL && !hasPopupSidebox
               ? this.renderBadgedButton({


### PR DESCRIPTION
# Fixes #1874

## Description

Volunteer texters see the yellow badges on buckets of handled conversations and want to get rid of the badges so they opt people out to “clear” those conversations leading to lots of admin clean-up.

This PR removes those yellow badge icons and inlines the number. This make it so folks don't think they are a number that needs to be addressed.

![image](https://user-images.githubusercontent.com/87616/108293373-a42bce00-7162-11eb-851f-a3f836af8a10.png)


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
