### PR TITLE
Return informative errors from GraphQL endpoint

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,7 +3,7 @@ import bodyParser from "body-parser";
 import express from "express";
 import appRenderer from "./middleware/app-renderer";
 import { graphqlExpress, graphiqlExpress } from "apollo-server-express";
-import { makeExecutableSchema, addMockFunctionsToSchema } from "graphql-tools";
+import { makeExecutableSchema } from "graphql-tools";
 // ORDERING: ./models import must be imported above ./api to help circular imports
 import { createLoaders, createTablesIfNecessary, r } from "./models";
 import { resolvers } from "./api/schema";
@@ -22,6 +22,7 @@ import { setupUserNotificationObservers } from "./notifications";
 import { existsSync } from "fs";
 import { rawAllMethods } from "../extensions/contact-loaders";
 import herokuSslRedirect from "heroku-ssl-redirect";
+import { GraphQLError } from "graphql/error";
 
 process.on("uncaughtException", ex => {
   log.error(ex);
@@ -193,7 +194,7 @@ app.use(
       if (process.env.SHOW_SERVER_ERROR || process.env.DEBUG) {
         return error;
       }
-      return new Error(
+      return new GraphQLError(
         error &&
         error.originalError &&
         error.originalError.code === "UNAUTHORIZED"

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -194,13 +194,20 @@ app.use(
       if (process.env.SHOW_SERVER_ERROR || process.env.DEBUG) {
         return error;
       }
-      return new GraphQLError(
+
+      if (
         error &&
         error.originalError &&
         error.originalError.code === "UNAUTHORIZED"
-          ? "UNAUTHORIZED"
-          : "Internal server error"
-      );
+      ) {
+        return new GraphQLError("UNAUTHORIZED");
+      }
+
+      if (error instanceof GraphQLError) {
+        return error;
+      }
+
+      return new GraphQLError(error.message);
     }
   }))
 );

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -191,23 +191,21 @@ app.use(
         // drop if this fails
         .catch(() => {})
         .then(() => {});
+
       if (process.env.SHOW_SERVER_ERROR || process.env.DEBUG) {
-        return error;
+        if (error instanceof GraphQLError) {
+          return error;
+        }
+        return new GraphQLError(error.message);
       }
 
-      if (
+      return new GraphQLError(
         error &&
         error.originalError &&
         error.originalError.code === "UNAUTHORIZED"
-      ) {
-        return new GraphQLError("UNAUTHORIZED");
-      }
-
-      if (error instanceof GraphQLError) {
-        return error;
-      }
-
-      return new GraphQLError(error.message);
+          ? "UNAUTHORIZED"
+          : "Internal server error"
+      );
     }
   }))
 );


### PR DESCRIPTION
## Description

I noticed while working on a web component that all errors coming back from the graphql endpoint were empty objects. When an error was thrown in a query or mutation, [this code](https://github.com/lperson/Spoke/blob/a4cc5a19998f87e88377e48573784950f5e22a61/src/network/apollo-client-singleton.js#L17-L26) would be called with `graphQLErrors` equal to an array consisting of an empty object -- `[{}]`. The error thrown in the client would be simply `error Error: GraphQL error: undefined` which doesn't let us give the user any useful information.

This PR has two commits. The first commit could be a solution on its own depending on what we think should be disclosed in the web app.

The [first commit](https://github.com/MoveOnOrg/Spoke/pull/1932/commits/c2a5117e9ecd8a1df1cc32bf4adb9b430f999328) improves the situation a little, resulting in an error with this message: `error Error: GraphQL error: Internal server error`.

The [second commit](https://github.com/MoveOnOrg/Spoke/pull/1932/commits/a4cc5a19998f87e88377e48573784950f5e22a61) returns this (as an example) `error Error: GraphQL error: Invalid Twilio credentials`.

Also, I believe [this is dead code](https://github.com/lperson/Spoke/blob/a4cc5a19998f87e88377e48573784950f5e22a61/src/network/errors.js#L1-L35)  now.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
