### PR TITLE
Fix #1910: Bump Auth0 Lock to v11.28

### DIFF
--- a/docs/HOWTO-configure-auth0.md
+++ b/docs/HOWTO-configure-auth0.md
@@ -51,7 +51,7 @@ callback(null, user, context);
       <script src="https://cdn.auth0.com/js/base64.js"></script>
       <script src="https://cdn.auth0.com/js/es5-shim.min.js"></script>
       <![endif]-->
-      <script src="https://cdn.auth0.com/js/lock/11.11/lock.min.js"></script>
+      <script src="https://cdn.auth0.com/js/lock/11.28/lock.min.js"></script>
       <script>
         // Decode utf8 characters properly
         var config = JSON.parse(decodeURIComponent(escape(window.atob('@@config@@'))));


### PR DESCRIPTION
# Fixes # (issue)
Fixes #1910

## Description

After failing to duplicate this error in a dev environment, I noticed a production environment using Auth0 has this issue. I found the issue is with https://github.com/auth0/lock/issues/1935.

By updating the version number in the documentation file, future configurations should no longer have this issue. There is [a comment on the Auth0/lock issue](https://github.com/auth0/lock/issues/1935#issuecomment-709349436) indicating that older Android phones may still run into this bug, but most devices shouldn't have this bug.

To fix this issue in existing deployments, one should follow the docs/HOWTO-configure-auth0.md guide to customize the login page and bump the version.

# Checklist:
_I do not believe the checklist is applicable for this case._

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
