### PR TITLE
fix people search when text filter is ANY

### DIFF
--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -66,11 +66,10 @@ export function buildUsersQuery(
     .distinct();
 
   if (role !== "ANY") {
+    query = query.where({ role: role });
     if (role !== "SUSPENDED") {
       query = query.whereNot({ role: "SUSPENDED" });
     }
-  } else {
-    query = query.where({ role: role });
   }
 
   if (filterString) {

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -66,7 +66,9 @@ export function buildUsersQuery(
     .distinct();
 
   if (role !== "ANY") {
-    query = query.where({ role: role });
+    if (role) {
+      query = query.where({ role: role });
+    }
     if (role !== "SUSPENDED") {
       query = query.whereNot({ role: "SUSPENDED" });
     }


### PR DESCRIPTION
## Description

When there's a people search text filter and setting is ANY it interprets the where clause with ORs globally instead of narrowly in the first/last/email fields.  This adds parens

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [na] My PR is labeled [WIP] if it is in progress
