### PR TITLE
Update HOWTO_DEPLOYING_AWS_LAMBDA.md

### DIFF
--- a/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
+++ b/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
@@ -202,6 +202,40 @@ $ AWS_PROFILE=[your_profile_nickname] claudia create --handler lambda.handler \
     --memory 512 --timeout 300
 ```
 
+- You'll have to create the Role for `--role SpokeOnLamba` yourself. Use the wizard to give the baseline Lambda permissions and add AmazonS3FullAccess. Below is an example of how to do this in a cloudformation template.
+
+```
+ LambdaExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+                - apigateway.amazonaws.com
+                - events.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: LambdaFunctionPolicy
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - ec2:CreateNetworkInterface
+                  - ec2:DeleteNetworkInterface
+                  - ec2:DescribeNetworkInterfaces
+                  - s3:*
+                Resource: "*"
+```
+
 **Notes**:
 
 - You'll want a timeout that corresponds with the scheduled jobs -- this is 5 minutes which should be the same as below


### PR DESCRIPTION
# Fixes https://github.com/MoveOnOrg/Spoke/issues/1909

## Description

Updated documentation to regarding the `--role SpokeOnLamba` to specify that this role has to be created to give the baseline Lambda permissions and add AmazonS3FullAccess. Thanks @ffaristocrat 

# Checklist:

Not applicable.

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
