### PR TITLE
MobileCommons extrafields

### DIFF
--- a/docs/HOWTO_INTEGRATE_WITH_MOBILE_COMMONS.md
+++ b/docs/HOWTO_INTEGRATE_WITH_MOBILE_COMMONS.md
@@ -23,14 +23,17 @@ TestFirstName3,TestLastName3,4435555555,
 ## Step Two - Adding the appropriate environment variables (for developers)
 - In order to use this feature, you will have to add four more variables and update another environment variable in your environment variables file or your lambda config or your heroku variables config. The following variables you will need to add:
   - New Variables:
-      UMC_PROFILE_URL = API url for creating profiles (included in API documentation)
-      UMC_USER = user that has privileges to use the API
-      UMC_PW = password for user that has privileges to use the API
-      UMC_OPT_IN_PATH = opt in path id to default to if none is included in the CSV
+      * UMC_PROFILE_URL = API url for creating profiles (included in API documentation)
+      * UMC_USER = user that has privileges to use the API
+      * UMC_PW = password for user that has privileges to use the API
+      * UMC_OPT_IN_PATH = opt in path id to default to if none is included in the CSV
   - Updated Variable:
       ACTION_HANDLERS='mobilecommons-signup'
-      *Note - if you currently have a variable set here, i.e. 'actionkit-rsvp', then it will look like the following
+      * Note - if you currently have a variable set here, i.e. 'actionkit-rsvp', then it will look like the following
         - ACTION_HANDLERS='actionkit-rsvp,revere-signup,mobilecommons-signup'
+  - If you want to convey custom fields or the external id, then set UMC_FIELDS.
+    This is a comma-separated list of fields that should be passed through to MobileCommons and end with a `:<name of external_id>` if desired.  For instance, if you want to pass through custom fields `state` and `congressional_district` and
+    the external_id should be called `org_id`, then you would set UMC_FIELDS=`state,congressional_district:org_id`.
 
 ## Additional Steps To Add New Mobile Commons Users to Action Kit
 - If you have an account with Action Kit and want to add the new user to Mobile Commons and Action Kit (without adding them to your email subscribed list), you can add two more environment variables (in addition to variables set in step two).

--- a/src/extensions/action-handlers/mobilecommons-signup.js
+++ b/src/extensions/action-handlers/mobilecommons-signup.js
@@ -2,22 +2,12 @@ import request from "request";
 import aws from "aws-sdk";
 import { r } from "../../server/models";
 import { actionKitSignup } from "./helper-ak-sync.js";
+import { getConfig } from "../../server/api/lib/config";
 
 export const name = "mobilecommons-signup";
 
 // What the user sees as the option
 export const displayName = () => "Mobile Commons Signup";
-
-const akAddUserUrl = process.env.AK_ADD_USER_URL;
-const akAddPhoneUrl = process.env.AK_ADD_PHONE_URL;
-const createProfileUrl = process.env.UMC_PROFILE_URL;
-const defaultProfileOptInId = process.env.UMC_OPT_IN_PATH;
-const umcAuth =
-  "Basic " +
-  Buffer.from(process.env.UMC_USER + ":" + process.env.UMC_PW).toString(
-    "base64"
-  );
-const umcConfigured = defaultProfileOptInId && createProfileUrl;
 
 // The Help text for the user after selecting the action
 export const instructions = () =>
@@ -34,32 +24,37 @@ export function serverAdministratorInstructions() {
       "UMC_PROFILE_URL",
       "UMC_USER",
       "UMC_PW",
-      "UMC_OPT_IN_PATH"
+      "UMC_OPT_IN_PATH",
+      "UMC_FIELDS"
     ]
   };
 }
 
-export async function available(organizationId) {
+export async function available(organization) {
+  const getUMCconfigured =
+    getConfig("UMC_PROFILE_URL", organization) &&
+    getConfig("UMC_OPT_IN_PATH", organization);
   return {
-    result: organizationId && umcConfigured,
-    expiresSeconds: 600
+    result: organization && getUMCconfigured,
+    expiresSeconds: 0
   };
 }
 
-export async function processAction({ campaignContactId }) {
-  const contactRes = await r
-    .knex("campaign_contact")
-    .where("campaign_contact.id", campaignContactId)
-    .leftJoin("campaign", "campaign_contact.campaign_id", "campaign.id")
-    .leftJoin("organization", "campaign.organization_id", "organization.id")
-    .select(
-      "campaign_contact.cell",
-      "campaign_contact.first_name",
-      "campaign_contact.last_name",
-      "campaign_contact.custom_fields"
-    );
-
-  const contact = contactRes.length ? contactRes[0] : {};
+export async function processAction({
+  interactionStep,
+  contact,
+  organization
+}) {
+  const createProfileUrl = getConfig("UMC_PROFILE_URL", organization);
+  const defaultProfileOptInId = getConfig("UMC_OPT_IN_PATH", organization);
+  const umcAuth =
+    "Basic " +
+    Buffer.from(
+      getConfig("UMC_USER", organization) +
+        ":" +
+        getConfig("UMC_PW", organization)
+    ).toString("base64");
+  console.log("contact", contact, "qr", interactionStep, "o", organization);
   const customFields = JSON.parse(contact.custom_fields);
   const optInPathId = customFields.umc_opt_in_path
     ? customFields.umc_opt_in_path
@@ -68,6 +63,22 @@ export async function processAction({ campaignContactId }) {
 
   actionKitSignup(contact);
 
+  const extraFields = {};
+  const umcFields = getConfig("UMC_FIELDS", organization);
+  if (umcFields) {
+    const [extra, external] = umcFields.split(":");
+    if (external && contact.external_id) {
+      extraFields[external] = contact.external_id;
+    }
+    if (extra) {
+      const fields = extra.split(",");
+      for (const f of fields) {
+        if (f in customFields) {
+          extraFields[f] = String(customFields[f]);
+        }
+      }
+    }
+  }
   const options = {
     method: "POST",
     url: createProfileUrl,
@@ -80,11 +91,16 @@ export async function processAction({ campaignContactId }) {
       phone_number: cell,
       first_name: contact.first_name || "",
       last_name: contact.last_name || "",
-      opt_in_path_id: optInPathId
+      opt_in_path_id: optInPathId,
+      ...extraFields
     },
     json: true
   };
 
+  if (process.env.UMC_DEBUG) {
+    console.log("UMC_DEBUG enabled", options);
+    return;
+  }
   return request(options, (error, response) => {
     if (error) throw new Error(error);
   });

--- a/src/extensions/action-handlers/mobilecommons-signup.js
+++ b/src/extensions/action-handlers/mobilecommons-signup.js
@@ -54,7 +54,6 @@ export async function processAction({
         ":" +
         getConfig("UMC_PW", organization)
     ).toString("base64");
-  console.log("contact", contact, "qr", interactionStep, "o", organization);
   const customFields = JSON.parse(contact.custom_fields);
   const optInPathId = customFields.umc_opt_in_path
     ? customFields.umc_opt_in_path

--- a/src/extensions/contact-loaders/test-fakedata/index.js
+++ b/src/extensions/contact-loaders/test-fakedata/index.js
@@ -144,8 +144,9 @@ export async function processContactLoad(job, maxContacts, organization) {
       last_name: `Bar${i}`,
       // conform to Hollywood-reserved numbers
       // https://www.businessinsider.com/555-phone-number-tv-movies-telephone-exchange-names-ghostbusters-2018-3
-      cell: `+1${ac}555${suffix}`,
+      cell: `+1${ac}55501${suffix}`,
       zip: "10011",
+      external_id: "fake" + String(Math.random()).slice(3, 8),
       custom_fields: genCustomFields(i, campaignId),
       timezone_offset:
         timezones[parseInt(Math.random() * timezones.length, 10)],

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -55,7 +55,7 @@ export const preMessageSave = async ({ messageToSave, organization }) => {
       const re = new RegExp(matcher.regex, "i");
       return String(messageToSave.text).match(re);
     });
-    console.log("auto-optout", matches, messageToSave.text, regexList);
+    // console.log("auto-optout", matches, messageToSave.text, regexList);
     if (matches.length) {
       console.log(
         "auto-optout MATCH",


### PR DESCRIPTION
Support a UMC_FIELDS variable that passes external_id (converting it to a diff field) and other specified fields from contact.custom_fields through to mobile commons

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
