### PR TITLE
campaign after start: show contact load results

### DIFF
--- a/src/components/CampaignContactsChoiceForm.jsx
+++ b/src/components/CampaignContactsChoiceForm.jsx
@@ -82,7 +82,8 @@ export class CampaignContactsChoiceForm extends React.Component {
       maxNumbersPerCampaign,
       contactsPerPhoneNumber,
       ingestMethodChoices,
-      pastIngestMethod
+      pastIngestMethod,
+      ensureComplete
     } = this.props;
     const ingestMethod = this.getCurrentMethod();
     const ingestMethodName = ingestMethod && ingestMethod.name;
@@ -91,6 +92,49 @@ export class CampaignContactsChoiceForm extends React.Component {
         ? pastIngestMethod
         : null;
     const IngestComponent = components[ingestMethodName];
+    if (ensureComplete) {
+      // isStarted
+      return (
+        <div>
+          {this.props.contactsCount && (
+            <div>
+              <div>Ingest Method: {ingestMethod.displayName}</div>
+              <div>Loaded Contacts: {this.props.contactsCount}</div>
+              {lastResult ? (
+                <div>
+                  <div>Deleted Duplicates: {lastResult.deletedDupes}</div>
+                  <div>Deleted OptOuts: {lastResult.deletedOptouts}</div>
+                </div>
+              ) : null}
+            </div>
+          )}
+          {this.props.jobResultMessage && (
+            <div>
+              <CampaignFormSectionHeading title="Job Outcome" />
+              <div>{this.props.jobResultMessage}</div>
+            </div>
+          )}
+
+          {IngestComponent && IngestComponent.prototype.renderAfterStart ? (
+            <IngestComponent
+              onChange={chg => {
+                this.handleChange(chg);
+              }}
+              onSubmit={this.props.onSubmit}
+              campaignIsStarted={ensureComplete}
+              icons={icons}
+              saveDisabled={this.props.saveDisabled}
+              saveLabel={this.props.saveLabel}
+              clientChoiceData={ingestMethod && ingestMethod.clientChoiceData}
+              lastResult={lastResult}
+              jobResultMessage={null}
+              contactsPerPhoneNumber={contactsPerPhoneNumber}
+              maxNumbersPerCampaign={maxNumbersPerCampaign}
+            />
+          ) : null}
+        </div>
+      );
+    }
 
     return (
       <div>
@@ -173,7 +217,7 @@ export class CampaignContactsChoiceForm extends React.Component {
                 this.handleChange(chg);
               }}
               onSubmit={this.props.onSubmit}
-              campaignIsStarted={this.props.ensureComplete}
+              campaignIsStarted={ensureComplete}
               icons={icons}
               saveDisabled={this.props.saveDisabled}
               saveLabel={this.props.saveLabel}

--- a/src/containers/AdminCampaignEdit.jsx
+++ b/src/containers/AdminCampaignEdit.jsx
@@ -402,7 +402,7 @@ export class AdminCampaignEdit extends React.Component {
           this.props.campaignData.campaign.contactsCount > 0,
         checkSaved: () => !this.state.campaignFormValues.contactData,
         blocksStarting: true,
-        expandAfterCampaignStarts: false,
+        expandAfterCampaignStarts: true,
         expandableBySuperVolunteers: false,
         extraProps: {
           contactsCount: this.props.campaignData.campaign.contactsCount,

--- a/src/extensions/contact-loaders/csv-s3-upload/index.js
+++ b/src/extensions/contact-loaders/csv-s3-upload/index.js
@@ -128,15 +128,20 @@ export async function processContactLoad(job, maxContacts, organization) {
   const contactsData = (await s3.getObject(params).promise()).Body.toString(
     "utf-8"
   );
-  const contacts = JSON.parse(await gunzip(Buffer.from(contactsData, "base64")))
-    .contacts;
-
+  const parsedData = JSON.parse(
+    await gunzip(Buffer.from(contactsData, "base64"))
+  );
+  const contacts = parsedData.contacts;
   const contactsCount = contacts.length;
+
   await finalizeContactLoad(
     job,
     contacts,
     maxContacts,
     job.payload,
-    JSON.stringify({ finalCount: contactsCount })
+    JSON.stringify({
+      finalCount: contactsCount,
+      filename: parsedData.name || null
+    })
   );
 }

--- a/src/extensions/contact-loaders/csv-s3-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-s3-upload/react-component.js
@@ -91,7 +91,12 @@ export class CampaignContactsForm extends React.Component {
           } else if (contacts.length === 0) {
             this.handleUploadError("Upload at least one contact");
           } else if (contacts.length > 0) {
-            this.handleUploadSuccess(validationStats, contacts, customFields);
+            this.handleUploadSuccess(
+              validationStats,
+              contacts,
+              customFields,
+              file
+            );
           }
         },
         { headerTransformer: ensureCamelCaseRequiredHeaders }
@@ -108,7 +113,7 @@ export class CampaignContactsForm extends React.Component {
     });
   }
 
-  handleUploadSuccess(validationStats, contacts, customFields) {
+  handleUploadSuccess(validationStats, contacts, customFields, file) {
     this.setState({
       validationStats,
       customFields,
@@ -117,6 +122,7 @@ export class CampaignContactsForm extends React.Component {
       contactsCount: contacts.length
     });
     const contactCollection = {
+      name: file.name || null,
       contactsCount: contacts.length,
       customFields,
       contacts
@@ -262,6 +268,20 @@ export class CampaignContactsForm extends React.Component {
   }
 
   render() {
+    if (this.props.campaignIsStarted) {
+      let data;
+      try {
+        data = JSON.parse(
+          (this.props.lastResult && this.props.lastResult.result) || "{}"
+        );
+      } catch (err) {
+        return null;
+      }
+      return data && data.filename ? (
+        <div>Filename: {data.filename}</div>
+      ) : null;
+    }
+
     let subtitle = (
       <span>
         Your upload file should be in CSV format with column headings in the
@@ -289,6 +309,8 @@ export class CampaignContactsForm extends React.Component {
   }
 }
 
+CampaignContactsForm.prototype.renderAfterStart = true;
+
 CampaignContactsForm.propTypes = {
   onChange: type.func,
   onSubmit: type.func,
@@ -300,5 +322,6 @@ CampaignContactsForm.propTypes = {
   saveLabel: type.string,
 
   clientChoiceData: type.string,
+  lastResult: type.object,
   jobResultMessage: type.string
 };

--- a/src/extensions/contact-loaders/csv-upload/index.js
+++ b/src/extensions/contact-loaders/csv-upload/index.js
@@ -84,12 +84,17 @@ export async function processContactLoad(job, maxContacts, organization) {
   /// * Error handling
   /// * "Request of Doom" scenarios -- queries or jobs too big to complete
 
-  let contacts;
+  let payload;
   if (job.payload[0] === "{") {
-    contacts = JSON.parse(job.payload).contacts;
+    payload = JSON.parse(job.payload);
   } else {
-    contacts = (await unzipPayload(job)).contacts;
+    payload = await unzipPayload(job);
   }
-
-  await finalizeContactLoad(job, contacts, maxContacts);
+  await finalizeContactLoad(
+    job,
+    payload.contacts,
+    maxContacts,
+    null,
+    JSON.stringify({ filename: payload.name || null })
+  );
 }

--- a/src/extensions/contact-loaders/csv-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-upload/react-component.js
@@ -87,6 +87,7 @@ export class CampaignContactsForm extends React.Component {
 
     event.preventDefault();
     const file = event.target.files[0];
+    console.log("file upload", file);
     this.setState({ uploading: true }, () => {
       parseCSV(
         file,
@@ -102,7 +103,12 @@ export class CampaignContactsForm extends React.Component {
               ).toLocaleString()} contacts max – your file contains ${contacts.length.toLocaleString()}.`
             );
           } else if (contacts.length > 0) {
-            this.handleUploadSuccess(validationStats, contacts, customFields);
+            this.handleUploadSuccess(
+              validationStats,
+              contacts,
+              customFields,
+              file
+            );
           }
         },
         { headerTransformer: ensureCamelCaseRequiredHeaders }
@@ -119,7 +125,7 @@ export class CampaignContactsForm extends React.Component {
     });
   }
 
-  handleUploadSuccess(validationStats, contacts, customFields) {
+  handleUploadSuccess(validationStats, contacts, customFields, file) {
     this.setState({
       validationStats,
       customFields,
@@ -128,6 +134,7 @@ export class CampaignContactsForm extends React.Component {
       contactsCount: contacts.length
     });
     const contactCollection = {
+      name: file.name || null,
       contactsCount: contacts.length,
       customFields,
       contacts
@@ -271,6 +278,19 @@ export class CampaignContactsForm extends React.Component {
   }
 
   render() {
+    if (this.props.campaignIsStarted) {
+      let data;
+      try {
+        data = JSON.parse(
+          (this.props.lastResult && this.props.lastResult.result) || "{}"
+        );
+      } catch (err) {
+        return null;
+      }
+      return data && data.filename ? (
+        <div>Filename: {data.filename}</div>
+      ) : null;
+    }
     let subtitle = (
       <span>
         Your upload file should be in CSV format with column headings in the
@@ -298,6 +318,8 @@ export class CampaignContactsForm extends React.Component {
   }
 }
 
+CampaignContactsForm.prototype.renderAfterStart = true;
+
 CampaignContactsForm.propTypes = {
   onChange: type.func,
   onSubmit: type.func,
@@ -310,6 +332,7 @@ CampaignContactsForm.propTypes = {
 
   clientChoiceData: type.string,
   jobResultMessage: type.string,
+  lastResult: type.object,
 
   maxNumbersPerCampaign: type.number,
   contactsPerPhoneNumber: type.number

--- a/src/extensions/contact-loaders/csv-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-upload/react-component.js
@@ -134,7 +134,7 @@ export class CampaignContactsForm extends React.Component {
       contactsCount: contacts.length
     });
     const contactCollection = {
-      name: file.name || null,
+      name: (file && file.name) || null,
       contactsCount: contacts.length,
       customFields,
       contacts

--- a/src/extensions/contact-loaders/past-contacts/react-component.js
+++ b/src/extensions/contact-loaders/past-contacts/react-component.js
@@ -12,7 +12,7 @@ import WarningIcon from "material-ui/svg-icons/alert/warning";
 import ErrorIcon from "material-ui/svg-icons/alert/error";
 import { StyleSheet, css } from "aphrodite";
 import yup from "yup";
-import { withRouter } from "react-router";
+import { withRouter, Link } from "react-router";
 
 export class CampaignContactsFormInner extends React.Component {
   constructor(props) {
@@ -20,7 +20,11 @@ export class CampaignContactsFormInner extends React.Component {
     const { lastResult } = props;
     let cur = {};
     if (lastResult && lastResult.reference) {
-      cur = JSON.parse(lastResult.reference);
+      try {
+        cur = JSON.parse(lastResult.reference);
+      } catch (err) {
+        // parse error should just stay empty
+      }
     }
     console.log("pastcontacts", lastResult, props);
     this.state = {
@@ -34,7 +38,31 @@ export class CampaignContactsFormInner extends React.Component {
   }
 
   render() {
-    const { clientChoiceData, lastResult } = this.props;
+    const {
+      campaignIsStarted,
+      clientChoiceData,
+      lastResult,
+      location
+    } = this.props;
+    if (campaignIsStarted) {
+      const messageReviewLink = location.pathname.replace(
+        /campaigns.*/,
+        "incoming"
+      );
+      return (
+        <div>
+          Loaded query:{" "}
+          <Link to={`${messageReviewLink}?${this.state.pastContactsQuery}`}>
+            {this.state.pastContactsQuery}
+          </Link>
+          {this.state.questionResponseAnswer ? (
+            <div>
+              Question Response Answer: {this.state.questionResponseAnswer}
+            </div>
+          ) : null}
+        </div>
+      );
+    }
     let resultMessage = "";
     return (
       <GSForm
@@ -115,3 +143,5 @@ CampaignContactsFormInner.propTypes = {
 };
 
 export const CampaignContactsForm = withRouter(CampaignContactsFormInner);
+
+CampaignContactsForm.prototype.renderAfterStart = true;

--- a/src/extensions/contact-loaders/s3-pull/react-component.js
+++ b/src/extensions/contact-loaders/s3-pull/react-component.js
@@ -24,7 +24,10 @@ export class CampaignContactsForm extends React.Component {
   }
 
   render() {
-    const { lastResult } = this.props;
+    const { lastResult, campaignIsStarted } = this.props;
+    if (campaignIsStarted) {
+      return <div>Path: {this.state.s3Path}</div>;
+    }
     let results = {};
     if (lastResult && lastResult.result) {
       results = JSON.parse(lastResult.result);
@@ -106,6 +109,8 @@ export class CampaignContactsForm extends React.Component {
   }
 }
 
+CampaignContactsForm.prototype.renderAfterStart = true;
+
 CampaignContactsForm.propTypes = {
   onChange: type.func,
   onSubmit: type.func,
@@ -116,6 +121,7 @@ CampaignContactsForm.propTypes = {
   saveDisabled: type.bool,
   saveLabel: type.string,
 
+  lastResult: object,
   clientChoiceData: type.string,
   jobResultMessage: type.string
 };

--- a/src/extensions/contact-loaders/s3-pull/react-component.js
+++ b/src/extensions/contact-loaders/s3-pull/react-component.js
@@ -121,7 +121,7 @@ CampaignContactsForm.propTypes = {
   saveDisabled: type.bool,
   saveLabel: type.string,
 
-  lastResult: object,
+  lastResult: type.object,
   clientChoiceData: type.string,
   jobResultMessage: type.string
 };


### PR DESCRIPTION
Show results from contact load after a campaign is started.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
