### PR TITLE
Message review table overflow visible for long tags & truncate long tag text

### DIFF
--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -231,7 +231,7 @@ export class IncomingMessageList extends Component {
       label: "View Conversation",
       style: {
         textOverflow: "ellipsis",
-        overflow: "hidden",
+        overflow: "visible",
         whiteSpace: "pre-line"
       },
       render: (columnKey, row) => (
@@ -389,6 +389,7 @@ export class IncomingMessageList extends Component {
           onRowSizeChange={this.handleRowSizeChanged}
           onRowSelection={this.handleRowsSelected}
           selectedRows={clearSelectedMessages ? null : this.state.selectedRows}
+          tableBodyStyle={{ overflowX: "auto" }}
         />
         <ConversationPreviewModal
           organizationTags={this.state.tags}

--- a/src/components/TagChip.jsx
+++ b/src/components/TagChip.jsx
@@ -4,7 +4,6 @@ import type from "prop-types";
 import Avatar from "material-ui/Avatar";
 import FlagIcon from "material-ui/svg-icons/content/flag";
 import theme from "../styles/theme";
-import { gray900 } from "material-ui/styles/colors";
 
 const inlineStyles = {
   chip: {
@@ -20,7 +19,11 @@ const inlineStyles = {
   text: {
     fontSize: "12px",
     fontWeight: "900",
-    color: gray900
+    color: "#111",
+    maxWidth: 200,
+    whiteSpace: "nowrap",
+    overflow: "hidden",
+    textOverflow: "ellipsis"
   },
   icon: {
     width: "16px",


### PR DESCRIPTION
## Fixes https://github.com/MoveOnOrg/Spoke/issues/1894

## Description
@navinsivakumar: In the Message Review incoming message list, allow long TagChips to overflow their table cells and allow horizontal scrolling of the table. This ensures that users can both see the entire tag text and access the delete button when using any combination of small enough screen, long enough tag text, and large enough text size such that the TagChip does not fit entirely inside its table cell.

@codygordon: I also set a max-width for tag text so they can't be infinitely long  (we should probably have a character limit on tag names anyhow). 

Also darkened the tag text to make them pop a bit more.

Resulting in:

![Screen Shot 2021-03-23 at 8 31 26 AM](https://user-images.githubusercontent.com/13374656/112172738-34ba5b80-8bb2-11eb-9100-4d12e96c0437.png)
