### PR TITLE
Feedback config

### DIFF
--- a/src/extensions/texter-sideboxes/texter-feedback/AssignmentTexterFeedback.jsx
+++ b/src/extensions/texter-sideboxes/texter-feedback/AssignmentTexterFeedback.jsx
@@ -119,7 +119,7 @@ export class AssignmentTexterFeedback extends Component {
 
     const issueItems = Object.entries(issueCounts)
       .map(([key, count]) => {
-        const item = defaults.issues.find(issue => issue.key === key);
+        const item = config.issues.find(issue => issue.key === key);
         if (count && !isNaN(count) && item) return item;
         return null;
       })
@@ -129,14 +129,14 @@ export class AssignmentTexterFeedback extends Component {
       // issueItems with successMessage and no count
       ...Object.entries(issueCounts)
         .map(([key, count]) => {
-          const item = defaults.issues.find(issue => issue.key === key);
+          const item = config.issues.find(issue => issue.key === key);
           if (count === 0 && item && item.successMessage) return item;
           return null;
         })
         .filter(Boolean),
       // skillCounts items
       ...Object.entries(skillCounts).map(([key, count]) => {
-        const item = defaults.skills.find(skill => skill.key === key);
+        const item = config.skills.find(skill => skill.key === key);
         if (count && !isNaN(count) && item) return item;
         return null;
       })

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -523,10 +523,34 @@ export const resolvers = {
 
       let options =
         getConfig("TEXTER_UI_SETTINGS", campaign, { onlyLocal: true }) || "";
+
       if (!options) {
         // fallback on organization defaults
         options = getConfig("TEXTER_UI_SETTINGS", organization) || "";
       }
+
+      if (options.includes("texter-feedback")) {
+        try {
+          const parsedOptions = JSON.parse(options);
+
+          if (parsedOptions["texter-feedback"]) {
+            if (!parsedOptions.texterFeedbackJSON) {
+              const orgOptions =
+                JSON.parse(getConfig("TEXTER_UI_SETTINGS", organization)) || {};
+
+              if (orgOptions.texterFeedbackJSON) {
+                parsedOptions.texterFeedbackJSON =
+                  orgOptions.texterFeedbackJSON;
+
+                options = JSON.stringify(parsedOptions);
+              }
+            }
+          }
+        } catch (err) {
+          console.log("Corrupted TexterFeedback JSON", err);
+        }
+      }
+
       const sideboxChoices = getSideboxChoices(organization);
       return {
         options,


### PR DESCRIPTION
## Description

1. The texter feedback custom config issue and skills items weren't actually being used, fixed that.
2. We want the org-level custom feedback config to be used when the campaign has feedback turned on but no custom config entered.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
