### PR TITLE
Change s3cmd to aws cli

### DIFF
--- a/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
+++ b/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
@@ -130,16 +130,9 @@ Create an RDS instance running Postgres 10.4 with the following settings:
    aws_access_key_id = XXXXXXXXXXXXXXXXXXX
    aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
    ```
-4. Configure [s3cmd](https://github.com/s3tools/s3cmd)
-   1. Create an AWS user called `spoke_upload`. Create a new group for it with the `AmazonS3FullAccess` policy
-   2. Copy the credentials of the `spoke_upload` user to `~/.s3cfg`:
-      ```
-      [default]
-      access_key = XXXXXXXXXXXXXXXXXX
-      secret_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
-      ```
-      > _TODO_: figure out how to switch away from default profile in `package.json`'s `prod-static-upload` script using ENV vars
-   3. [Install s3cmd](https://s3tools.org/download)
+4. Install the AWS CLI
+  - See instructions at [AWS Command Line Interface Version 2](https://docs.aws.amazon.com/cli/latest/userguide/install-cliv2.html)
+  - On a mac, you can also use [homebrew](https://brew.sh/) command `brew install aws-cli`
 
 ### Create Production Environment File
 
@@ -170,7 +163,7 @@ Do **NOT** set:
 - `"JOB_RUNNER": "lambda-async",`: This dispatches asynchronous tasks that occur after a web response to another Lambda invocation which improves performance and completion.
 - `"AWS_ACCESS_AVAILABLE": "1",`: This replaces the AWS\_ key variables for S3 bucket support
 - `STATIC_BASE_URL`: You will need to upload your ASSETS_DIR to an S3 bucket (or other static file site) and then set this to something like: `"https://s3.amazonaws.com/YOUR_BUCKET_AND_PATH/"` (don't forget the trailing '/')
-- `S3_STATIC_PATH`: This will be the s3cmd upload path that corresponds to STATIC_BASE_URL. So if `STATIC_BASE_URL=https://s3.amazon.com/spoke.example.com/static/` then `S3_STATIC_PATH=s3://spoke.example.com/static/` You will also need a ~/.s3cfg file that has the s3 upload credentials. See `package.json`'s postinstall script and more specifically `prod-static-upload`.
+- `S3_STATIC_PATH`: This will be the aws s3 upload path that corresponds to STATIC_BASE_URL. So if `STATIC_BASE_URL=https://s3.amazon.com/spoke.example.com/static/` then `S3_STATIC_PATH=s3://spoke.example.com/static/` You will also need a ~/.s3cfg file that has the s3 upload credentials. See `package.json`'s postinstall script and more specifically `prod-static-upload`.
 - `"LAMBDA_DEBUG_LOG": "1",`: (ONLY FOR DEBUGGING) This will send more details of requests to the CloudWatch log. However, it will include the full request details, e.g. so do not use this in production.
 
 For large production environments, it might also be a good idea to add `"SUPPRESS_MIGRATIONS": "1"` so that any time you update the schema with a version upgrade,

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "prod-build-client": "webpack --config ./webpack/config.js",
     "prod-build-server": "babel ./src  -d ./build/server --source-maps --copy-files; babel ./migrations -d ./build/server/migrations/ --source-maps --copy-files",
     "prod-build": "npm run clean && npm run prod-build-client && npm run prod-build-server",
-    "prod-static-upload": "if [ \"$S3_STATIC_PATH\" != \"\" ] ; then s3cmd sync --acl-public --guess-mime-type ./build/client/assets/ $S3_STATIC_PATH ; fi",
+    "prod-static-upload": "if [ \"$S3_STATIC_PATH\" != \"\" ] ; then aws s3 sync --acl public-read ./build/client/assets/ $S3_STATIC_PATH ; fi",
     "postinstall": "if [ \"$NODE_ENV\" = production ] ; then npm run prod-build && npm run prod-static-upload && npm run install-config-file && npm run notify-slack; fi",
     "notify-slack": "if [ \"$SLACK_NOTIFY_URL\" != \"\" ] ; then echo notifying slack && curl -XPOST -d '{\"channel\": \"#spoke\", \"text\":\"'\"$(whoami) building spoke $(git log -1 --pretty=%h) for $AWS_S3_BUCKET_NAME\"'\"}' $SLACK_NOTIFY_URL; fi",
     "install-config-file": "if [ \"$CONFIG_FILE\" != \"\" ] ; then cp $CONFIG_FILE ./CONFIG_FILE.json; fi",


### PR DESCRIPTION
## Description

Updates `package.json` to run aws s3 instead of s3cmd. 
Updates `HOWTO_deploying_aws_lamda.md` including instructions on how to download AWS CLI

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
