### PR TITLE
Add admin organization settings JSON editor UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
   "dependencies": {
     "@aoberoi/passport-slack": "^1.0.5",
     "@trt2/gsm-charset-utils": "^1.0.13",
+    "ace-builds": "^1.4.12",
     "aphrodite": "^2.3.1",
     "apollo-cache-inmemory": "^1.6.6",
     "apollo-client": "^2.6.10",
@@ -147,6 +148,7 @@
     "prop-types": "^15.6.0",
     "query-string": "^4.1.0",
     "react": "^15.6.1",
+    "react-ace": "^9.4.0",
     "react-addons-css-transition-group": "^15.2.1",
     "react-apollo": "2.5.7",
     "react-async-script": "^0.6.0",

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -248,6 +248,7 @@ const rootSchema = gql`
     editOrganization(
       id: String!
       organization: OrganizationInput!
+      updateRawSettings: Boolean
     ): Organization
     deleteJob(campaignId: String!, id: String!): JobRequest
     copyCampaign(id: String!): Campaign

--- a/src/server/api/organization.js
+++ b/src/server/api/organization.js
@@ -172,6 +172,7 @@ export const resolvers = {
       } catch (err) {
         return null;
       }
+
       let messageHandlers = [];
       let actionHandlers = [];
       const features = getFeatures(organization);
@@ -201,7 +202,7 @@ export const resolvers = {
         messageHandlers,
         actionHandlers,
         unsetFeatures,
-        featuresJSON: JSON.stringify(visibleFeatures)
+        featuresJSON: JSON.stringify(features)
       };
     },
     textingHoursEnforced: organization => organization.texting_hours_enforced,
@@ -229,7 +230,7 @@ export const resolvers = {
       };
     },
     cacheable: (org, _, { user }) =>
-      //quanery logic.  levels are 0, 1, 2
+      // quanery logic.  levels are 0, 1, 2
       r.redis ? (getConfig("REDIS_CONTACT_CACHE", org) ? 2 : 1) : 0,
     twilioAccountSid: async (organization, _, { user }) => {
       try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1593,6 +1593,11 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+ace-builds@^1.4.12:
+  version "1.4.12"
+  resolved "https://registry.yarnpkg.com/ace-builds/-/ace-builds-1.4.12.tgz#888efa386e36f4345f40b5233fcc4fe4c588fae7"
+  integrity sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg==
+
 acorn-dynamic-import@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz#c752bd210bef679501b6c6cb7fc84f8f47158cc4"
@@ -5183,6 +5188,11 @@ detect-port-alt@1.1.6:
   dependencies:
     address "^1.0.1"
     debug "^2.6.0"
+
+diff-match-patch@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
 
 diff@^3.2.0:
   version "3.5.0"
@@ -9884,7 +9894,7 @@ lodash.flattendeep@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
 
-lodash.get@^4.4.0:
+lodash.get@^4.4.0, lodash.get@^4.4.2:
   version "4.4.2"
   resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
   integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
@@ -12998,6 +13008,17 @@ rc@^1.2.7, rc@^1.2.8:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-ace@^9.4.0:
+  version "9.4.0"
+  resolved "https://registry.yarnpkg.com/react-ace/-/react-ace-9.4.0.tgz#5c68423b5c7d4bc9332fc8b651187799c0bc97f6"
+  integrity sha512-fpY3AGViE1OglXThgn3wZWcPoAxr0bqRYqeG3jY3m1L7OIHo0GfZ3bJI0grhrADDy2i9jQoip9xZfpOFupQCsw==
+  dependencies:
+    ace-builds "^1.4.12"
+    diff-match-patch "^1.0.4"
+    lodash.get "^4.4.2"
+    lodash.isequal "^4.5.0"
+    prop-types "^15.7.2"
 
 react-addons-create-fragment@^15.4.0:
   version "15.6.2"


### PR DESCRIPTION
## Description

I've been editing org-level `features` directly on the db quite often, which is kind of annoying, and this was a fun little implementation that might help others out who do this too.

![Screen Shot 2021-03-28 at 12 08 20 PM](https://user-images.githubusercontent.com/13374656/112764626-548cbd80-8fbe-11eb-8883-09581682fd96.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
