### PR TITLE
Replacing SHOW/CLOSE Menu elements with IconButtons

### DIFF
--- a/src/components/Navigation.jsx
+++ b/src/components/Navigation.jsx
@@ -6,17 +6,18 @@ import Divider from "material-ui/Divider";
 import { withRouter } from "react-router";
 import _ from "lodash";
 import { dataTest, camelCase } from "../lib/attributes";
-import { FlatButton } from "material-ui";
+import MenuIcon from "material-ui/svg-icons/navigation/menu";
+import CloseIcon from "material-ui/svg-icons/navigation/close";
+import IconButton from "material-ui/IconButton/IconButton";
+
 import { StyleSheet, css } from "aphrodite";
 
 const styles = StyleSheet.create({
   sideBarWithMenu: {
     width: 256,
-    height: "100%",
-    writingMode: "hoizontal-lr"
+    height: "100%"
   },
   sideBarWithoutMenu: {
-    writingMode: "vertical-rl",
     padding: "5px",
     paddingTop: "20px"
   }
@@ -36,7 +37,9 @@ const Navigation = function Navigation(props) {
           }}
         >
           <div style={{ display: "flex", justifyContent: "flex-end" }}>
-            <FlatButton label={"Close Menu"} onClick={props.onToggleMenu} />
+            <IconButton onClick={props.onToggleMenu}>
+              <CloseIcon />
+            </IconButton>
           </div>
 
           <List>
@@ -56,12 +59,9 @@ const Navigation = function Navigation(props) {
     );
   } else {
     return (
-      <div
-        className={css(styles.sideBarWithoutMenu)}
-        onClick={props.onToggleMenu}
-      >
-        <span style={{ cursor: "pointer" }}>SHOW MENU</span>
-      </div>
+      <IconButton onClick={props.onToggleMenu}>
+        <MenuIcon />
+      </IconButton>
     );
   }
 };


### PR DESCRIPTION
# Fixes # (issue)
https://github.com/MoveOnOrg/Spoke/issues/1928
## Description

Swapping out FlatButtons with IconButtons so that we do not need to hack together a button with vertical text, because doing so eliminated tabbed navigation (as span's are not by default focusable).

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress

New Menu Open:
![image](https://user-images.githubusercontent.com/1431739/113605945-321d2480-95fc-11eb-8d0e-5a3552af6f2a.png)

New Menu Closed:
![image](https://user-images.githubusercontent.com/1431739/113605973-3cd7b980-95fc-11eb-9cd9-8e33e7f67bd2.png)
