### PR TITLE
Memoize timezonedst

### DIFF
--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -120,13 +120,10 @@ export const getSendBeforeTimeUtc = (
 };
 
 export const getLocalTime = (offset, hasDST, dstReferenceTimezone) => {
+  const isDateDST = DstHelper.isDateDst(new Date(), dstReferenceTimezone);
   return moment()
     .utc()
-    .utcOffset(
-      DstHelper.isDateDst(new Date(), dstReferenceTimezone) && hasDST
-        ? offset + 1
-        : offset
-    );
+    .utcOffset(hasDST && isDateDST ? offset + 1 : offset);
 };
 
 const isOffsetBetweenTextingHours = (
@@ -195,7 +192,6 @@ export const isBetweenTextingHours = (offsetData, config) => {
       .add(config.textingHoursEnd, "hours");
     return moment.tz(localTimezone).isBetween(start, stop, null, "[]");
   }
-
   return isOffsetBetweenTextingHours(
     offsetData,
     config.textingHoursStart,
@@ -205,23 +201,20 @@ export const isBetweenTextingHours = (offsetData, config) => {
   );
 };
 
-// Currently USA (-4 through -11) and Australia (10)
+// Currently USA (-4 through -11), but campaign timezones will supplant this list
 const ALL_OFFSETS = [-4, -5, -6, -7, -8, -9, -10, -11, 10];
 
 export const defaultTimezoneIsBetweenTextingHours = config =>
   isBetweenTextingHours(null, config);
 
 export function convertOffsetsToStrings(offsetArray) {
-  const result = [];
-  offsetArray.forEach(offset => {
-    result.push(offset[0].toString() + "_" + (offset[1] === true ? "1" : "0"));
-  });
-  return result;
+  return offsetArray.map(
+    offset => offset[0].toString() + "_" + (offset[1] === true ? "1" : "0")
+  );
 }
 
-export const getOffsets = config => {
-  const offsets = ALL_OFFSETS.slice(0);
-
+export const getOffsets = (config, campaignOffsets) => {
+  const offsets = campaignOffsets || ALL_OFFSETS;
   const valid = [];
   const invalid = [];
 

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -214,17 +214,21 @@ export function convertOffsetsToStrings(offsetArray) {
 }
 
 export const getOffsets = (config, campaignOffsets) => {
-  const offsets = campaignOffsets || ALL_OFFSETS;
+  // TODO: campaignOffsetes will sometimes have an array of e.g. ['-5_1', ...]
+  // future we should split that out and then only process the dst/offset cases passed in
+  const offsets = /*campaignOffsets || */ ALL_OFFSETS;
   const valid = [];
   const invalid = [];
 
   const dst = [true, false];
   dst.forEach(hasDST =>
     offsets.forEach(offset => {
-      if (isBetweenTextingHours({ offset, hasDST }, config)) {
-        valid.push([offset, hasDST]);
-      } else {
-        invalid.push([offset, hasDST]);
+      if (offset) {
+        if (isBetweenTextingHours({ offset, hasDST }, config)) {
+          valid.push([offset, hasDST]);
+        } else {
+          invalid.push([offset, hasDST]);
+        }
       }
     })
   );

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -64,7 +64,10 @@ export function getCampaignOffsets(campaign, organization, timezoneFilter) {
       timezone
     };
   }
-  const [validOffsets, invalidOffsets] = getOffsets(config);
+  const [validOffsets, invalidOffsets] = getOffsets(
+    config,
+    campaign.contactTimezones
+  );
   const defaultIsValid = defaultTimezoneIsBetweenTextingHours(config);
   if (timezoneFilter === true && defaultIsValid) {
     // missing timezone ok


### PR DESCRIPTION
## Description

One timezone call that is leveraged very heavily in Texter Todos api call and takes ~20ms which adds up to 10s of seconds esp. if a texter has many open assignments.  This memoizes this call so the past result can be used each time again.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
