### PR TITLE
texter todos: gather unassigned checks into a single query instead of per-assignment

### DIFF
--- a/src/extensions/dynamicassignment-batches/all-texters/index.js
+++ b/src/extensions/dynamicassignment-batches/all-texters/index.js
@@ -11,7 +11,8 @@ export const requestNewBatchCount = async ({
   texter,
   r,
   cacheableData,
-  loaders
+  loaders,
+  hasAny
 }) => {
   // START WITH SOME BASE-LINE THINGS EVERY POLICY SHOULD HAVE
   if (!campaign.use_dynamic_assignment || campaign.is_archived) {
@@ -21,15 +22,24 @@ export const requestNewBatchCount = async ({
     return 0;
   }
 
-  const availableCount = await r.getCount(
-    r
-      .knex("campaign_contact")
-      .where({
-        campaign_id: campaign.id,
-        is_opted_out: false,
-        message_status: "needsMessage"
-      })
-      .whereNull("assignment_id")
-  );
+  const countQuery = r
+    .knex("campaign_contact")
+    .where({
+      campaign_id: campaign.id,
+      is_opted_out: false,
+      message_status: "needsMessage"
+    })
+    .whereNull("assignment_id");
+
+  let availableCount = 0;
+  if (hasAny) {
+    availableCount = assignment.hasOwnProperty("hasUnassigned")
+      ? assignment.hasUnassigned
+      : (await countQuery.select("id").first())
+      ? 1
+      : 0;
+  } else {
+    availableCount = await r.getCount(countQuery);
+  }
   return availableCount;
 };

--- a/src/extensions/dynamicassignment-batches/vetted-takeconversations/index.js
+++ b/src/extensions/dynamicassignment-batches/vetted-takeconversations/index.js
@@ -12,7 +12,8 @@ export const requestNewBatchCount = async ({
   texter,
   r,
   cacheableData,
-  loaders
+  loaders,
+  hasAny
 }) => {
   // START WITH SOME BASE-LINE THINGS EVERY POLICY SHOULD HAVE
   if (campaign.is_archived) {
@@ -30,7 +31,6 @@ export const requestNewBatchCount = async ({
   if (!isVetted) {
     return 0;
   }
-
   const availableCount = await r.getCount(
     r
       .knex("campaign_contact")

--- a/src/server/api/assignment.js
+++ b/src/server/api/assignment.js
@@ -161,6 +161,21 @@ export function getContacts(
   return query;
 }
 
+// Used for Assignment.contactsCount to get a cross-section of timezone/status counts
+const filterCount = (assignment, statusFilter, offsetFilter) =>
+  Object.keys(assignment.tzStatusCounts) // .entries post-node10.x
+    .map(m => ({ status: m, offsets: assignment.tzStatusCounts[m] }))
+    .filter(statusFilter)
+    .map(({ offsets }) =>
+      offsets
+        .filter(offsetFilter)
+        .map(x => Number(x.count))
+        .reduce((a, b) => {
+          return a + b;
+        }, 0)
+    )
+    .reduce((a, b) => a + b, 0);
+
 export const resolvers = {
   Assignment: {
     ...mapFieldsToModel(["id", "maxContacts"], Assignment),
@@ -194,6 +209,7 @@ export const resolvers = {
       const organization = await loaders.organization.load(
         campaign.organization_id
       );
+
       const policies = getDynamicAssignmentBatchPolicies({
         organization,
         campaign
@@ -209,7 +225,8 @@ export const resolvers = {
         organization,
         campaign,
         assignment,
-        texter: user
+        texter: user,
+        hasAny: true
       });
       const suggestedCount = Math.min(
         assignment.max_contacts || campaign.batch_size,
@@ -261,22 +278,10 @@ export const resolvers = {
           organization,
           contactsFilter && contactsFilter.validTimezone
         );
-        const filterCount = (statusFilter, offsetFilter) =>
-          Object.keys(assignment.tzStatusCounts) // .entries post-node10.x
-            .map(m => ({ status: m, offsets: assignment.tzStatusCounts[m] }))
-            .filter(statusFilter)
-            .map(({ offsets }) =>
-              offsets
-                .filter(offsetFilter)
-                .map(x => Number(x.count))
-                .reduce((a, b) => {
-                  return a + b;
-                }, 0)
-            )
-            .reduce((a, b) => a + b, 0);
         if (contactsFilter && !contactsFilter.messageStatus) {
           // ASSUME: invalidTimezones
           const invalidTzCount = filterCount(
+            assignment,
             ({ status }) =>
               status === "needsMessage" || status === "needsResponse",
             offset => invalidOffsets.indexOf(offset.tz) !== -1
@@ -290,12 +295,14 @@ export const resolvers = {
           contactsFilter.validTimezone
         ) {
           const validStatusCount = filterCount(
+            assignment,
             ({ status }) => status === contactsFilter.messageStatus,
             offset => validOffsets.indexOf(offset.tz) !== -1
           );
           return validStatusCount;
         } else if (!contactsFilter) {
           return filterCount(
+            assignment,
             status => true,
             offset => true
           );

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -255,7 +255,8 @@ export const resolvers = {
         "assignment.created_at",
         "assignment_feedback.feedback",
         "assignment_feedback.is_acknowledged",
-        "assignment_feedback.creator_id"
+        "assignment_feedback.creator_id",
+        "campaign.use_dynamic_assignment"
       ];
       let query = r
         .knexReadOnly("assignment")
@@ -315,11 +316,38 @@ export const resolvers = {
             )
           );
         const result = await query;
-
+        const campaignIds = result
+          .filter(a => a.use_dynamic_assignment)
+          .map(a => a.campaign_id);
+        const campaignsWithUnassigned = {};
+        let hasUnassigned = [];
+        if (campaignIds.length) {
+          hasUnassigned = await r
+            .knex("campaign_contact")
+            .where({
+              is_opted_out: false,
+              message_status: "needsMessage"
+            })
+            .whereNull("assignment_id")
+            .whereIn("campaign_id", campaignIds)
+            .select("campaign_id")
+            .groupBy("campaign_id")
+            .havingRaw("count(1) > 0");
+          hasUnassigned.forEach(c => {
+            campaignsWithUnassigned[c.campaign_id] = 1;
+          });
+        }
         const assignments = {};
         for (const assn of result) {
           if (!assignments[assn.id]) {
-            assignments[assn.id] = { ...assn, tzStatusCounts: {} };
+            assignments[assn.id] = {
+              ...assn,
+              tzStatusCounts: {}
+            };
+            if (assn.use_dynamic_assignment && campaignIds.length) {
+              assignments[assn.id].hasUnassigned =
+                campaignsWithUnassigned[assn.campaign_id] || 0;
+            }
           }
           if (!assignments[assn.id].tzStatusCounts[assn.message_status]) {
             assignments[assn.id].tzStatusCounts[assn.message_status] = [];


### PR DESCRIPTION
## Description

Makes queries for dynamic assignment info more efficient -- instead of a sql query for each assignment, it does them all at once

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
