### PR TITLE
Separated Privacy Policy and TOS links and added a point to remind th…

### DIFF
--- a/docs/HOWTO-configure-auth0.md
+++ b/docs/HOWTO-configure-auth0.md
@@ -88,7 +88,7 @@ callback(null, user, context);
           language: language,
           languageDictionary: {
             title: 'Spoke',
-            signUpTerms: 'I agree to the <a href="YOUR_LINK HERE" target="_new">terms of service and privacy policy</a>.'
+            signUpTerms: 'I agree to the <a href="YOUR_TOS_LINK_HERE" target="_new">terms of service</a> and <a href="YOUR_PRIVACY_POLICY_LINK_HERE" target="_new">privacy policy</a>.'
           },
           mustAcceptTerms: true,
           theme: {
@@ -125,4 +125,4 @@ callback(null, user, context);
     ```
 
     </details>
-
+8. Replace `YOUR_TOS_LINK_HERE` with the link to your Terms of Service and replace `YOUR_PRIVACY_POLICY_LINK_HERE` with the link to your Privacy Policy


### PR DESCRIPTION
…e user to replace the placeholders with their actual TOS and Privacy Policy

# Fixes #1392

## Description

_Separated Privacy Policy and TOS links and added a point to remind the user to replace the placeholders with their actual TOS and Privacy Policy_

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
