### PR TITLE
Add contact.external_id to TexterTodo container for sidebox use

### DIFF
--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -13,6 +13,7 @@ export const contactDataFragment = `
         lastName
         cell
         zip
+        external_id
         customFields
         optOut {
           id


### PR DESCRIPTION
# Fixes #
This fixes issue #1992 and exposes a contact's `external_id` property for use within Texter Sideboxes.

## Description

I've added external_id to the `contactDataFragment` defined in the TexterTodo container. This makes it visible to Texter Sideboxes that may wish to use it for third party system integrations/actions.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
