### PR TITLE
NGPVAN action phone context

### DIFF
--- a/__test__/extensions/action-handlers/ngpvan-action.test.js
+++ b/__test__/extensions/action-handlers/ngpvan-action.test.js
@@ -1125,6 +1125,7 @@ describe("ngpvn-action", () => {
     describe("when the contact has a VanPhoneId", () => {
       beforeEach(async () => {
         contact = {
+          cell: '+15555550990',
           custom_fields: JSON.stringify({
             VanID: "8675309",
             VanPhoneId: "789"
@@ -1133,13 +1134,17 @@ describe("ngpvn-action", () => {
 
         body = {
           canvassContext: {
-            phoneId: "789"
+            phoneId: "789",
+            phone: {
+              dialingPrefix: '1',
+              phoneNumber: '555-555-0990'
+            }
           },
           willVote: true
         };
       });
 
-      it("calls the people endpoint and includes VanPhoneId in the canvass context", async () => {
+      it("calls the people endpoint and includes VanPhoneId and phone in the canvass context", async () => {
         const postPeopleCanvassResponsesNock = nock(
           "https://api.securevan.com:443",
           {

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -1,6 +1,6 @@
 import { getConfig } from "../../server/api/lib/config";
 import Van from "../contact-loaders/ngpvan/util";
-
+import { getCountryCode, getDashedPhoneNumberDisplay } from "../../lib/phone-format";
 import httpRequest from "../../server/lib/http-request.js";
 
 export const name = "ngpvan-action";
@@ -64,9 +64,19 @@ export const postCanvassResponse = async (contact, organization, bodyInput) => {
     ...bodyInput
   };
 
+  if (contact.cell) {
+    const phoneCountry = process.env.PHONE_NUMBER_COUNTRY || "US";
+
+    body.canvassContext.phone = {
+      dialingPrefix: getCountryCode(contact.cell, phoneCountry).toString(),
+      phoneNumber: getDashedPhoneNumberDisplay(contact.cell, phoneCountry)
+    };
+  }
+
   if (vanPhoneId) {
     body.canvassContext.phoneId = vanPhoneId;
   }
+
   const url = Van.makeUrl(`v4/people/${vanId}/canvassResponses`, organization);
 
   // eslint-disable-next-line no-console

--- a/src/lib/phone-format.js
+++ b/src/lib/phone-format.js
@@ -19,8 +19,24 @@ export const getFormattedPhoneNumber = (cell, country = "US") => {
   }
 };
 
-export const getDisplayPhoneNumber = (e164Number, country = "US") => {
+const parsePhoneNumber = (e164Number, country = "US") => {
   const phoneUtil = PhoneNumberUtil.getInstance();
   const parsed = phoneUtil.parse(e164Number, country);
+  return parsed;
+};
+
+export const getDisplayPhoneNumber = (e164Number, country = "US") => {
+  const parsed = parsePhoneNumber(e164Number, country);
   return phoneUtil.format(parsed, PhoneNumberFormat.NATIONAL);
+};
+
+export const getDashedPhoneNumberDisplay = (e164Number, country = "US") => {
+  const parsed = parsePhoneNumber(e164Number, country);
+  return parsed.getNationalNumber().toString()
+    .replace(/(\d{3})(\d{3})(\d{4})/, '$1-$2-$3');
+};
+
+export const getCountryCode = (e164Number, country = "US") => {
+  const parsed = parsePhoneNumber(e164Number, country);
+  return parsed.getCountryCode();
 };


### PR DESCRIPTION
## Description

Adds the cell number to NGPVAN API calls. This is a new feature in their API, which should help with making accurate suppressions. Uses phone number library to get country code.

Docs: https://docs.ngpvan.com/reference/people#peoplepersonidtypepersonidcanvassresponses

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
