### PR TITLE
conditionally signup actionkit during mobile-commons signup -- based on whether an external_id is present

### DIFF
--- a/src/extensions/action-handlers/mobilecommons-signup.js
+++ b/src/extensions/action-handlers/mobilecommons-signup.js
@@ -60,7 +60,10 @@ export async function processAction({
     : defaultProfileOptInId;
   const cell = contact.cell.substring(1);
 
-  actionKitSignup(contact);
+  if (!contact.external_id) {
+    // if there is already an external_id, then we have an existing user
+    actionKitSignup(contact);
+  }
 
   const extraFields = {};
   const umcFields = getConfig("UMC_FIELDS", organization);


### PR DESCRIPTION
When there is a mobile-commons signup action handler triggered and ActionKit signup is configured, then regardless of an existing AK account, the signup is created.  This makes it so if the external_id record is set, then we do not attempt to create an extra AK account, since one presumably already exists (and will even be set in UMC_FIELDS, hopefully).