### PR TITLE
error handling van contact loader

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -1372,6 +1372,18 @@ describe("ngpvan", () => {
       expect(autocomplete.props().hintText).toEqual("Select a list to import");
     });
 
+    it("populates as empty when client choice data errors", async () => {
+      const props = {
+        ...commonProps,
+        clientChoiceData: JSON.stringify({ error: 'error occurred' })
+      };
+
+      wrapper = shallow(<CampaignContactsForm {...props} />);
+      component = wrapper.instance();
+      const autocomplete = wrapper.find("AutoComplete");
+      expect(autocomplete.props().dataSource).toEqual([]);
+    });
+
     describe("when lastResult indicates a success", () => {
       beforeEach(async () => {
         StyleSheetTestUtils.suppressStyleInjection();

--- a/src/extensions/contact-loaders/ngpvan/react-component.js
+++ b/src/extensions/contact-loaders/ngpvan/react-component.js
@@ -32,7 +32,13 @@ export class CampaignContactsForm extends React.Component {
 
   buildSelectData = () => {
     const { clientChoiceData } = this.props;
+
     const clientChoiceDataObject = JSON.parse(clientChoiceData);
+
+    if (!clientChoiceDataObject || !clientChoiceDataObject.items) {
+      return [];
+    }
+
     return clientChoiceDataObject.items.map(item =>
       dataSourceItem(item.name, item.savedListId)
     );


### PR DESCRIPTION
# Description

If an error occurs, just show no options, rather than breaking the whole page. This should point to a VAN auth issue for the user, who probably will be one step removed from making changes to the auth settings.

This is just the easier option to showing an error message directly, but I'm open to building that instead. This at least saves us from the page breaking.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
