### PR TITLE
Fixing the path in 'Developing Action Handlers'

### DIFF
--- a/docs/HOWTO-use-action-handlers.md
+++ b/docs/HOWTO-use-action-handlers.md
@@ -65,7 +65,7 @@ inside the function `serverAdministratorInstructions`
 The best way to make a new action handler is something like this in the codebase:
 
 ```
-cd src/extensions/contact-loaders
+cd src/extensions/action-handlers
 cp -rp test-action.js <NEW_CONTACT_LOADER_NAME>.js
 ```
 


### PR DESCRIPTION
# Fixes # (issue)

## Description

The path specified in Developing Action Handlers should be src/extensions/action-handlers instead of  src/extensions/contact-loaders

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
