### PR TITLE
Get proper input value for Script Import url

### DIFF
--- a/src/containers/AdminScriptImport.jsx
+++ b/src/containers/AdminScriptImport.jsx
@@ -43,7 +43,7 @@ export default class AdminScriptImport extends Component {
     this.props.onSubmit();
   };
 
-  handleUrlChange = (_eventId, newValue) => this.setState({ url: newValue });
+  handleUrlChange = ({ target }) => this.setState({ url: target.value });
 
   renderErrors = () =>
     this.state.error && (


### PR DESCRIPTION
The new Material inputs apparently provide event.target.value in the "old fashioned" way, this handler hadn't been updated. Are there others we may not yet be aware of?