### PR TITLE
get last 100 saved lists

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -164,6 +164,42 @@ describe("ngpvan", () => {
       getSavedListsNock.done();
     });
 
+    it("gets extra when more than 100 count", async () => {
+      const savedListsNock = nock(`${fakeNgpVanBaseApiUrl}:443`, {
+        encodedQueryParams: true,
+        reqheaders: {
+          authorization: "Basic c3Bva2U6dG9wc2VjcmV0fDA="
+        }
+      });
+
+      const getSavedListsNock = savedListsNock
+        .get(
+          `/v4/savedLists?$top=100&maxPeopleCount=${process.env.NGP_VAN_MAXIMUM_LIST_SIZE}`
+        )
+        .reply(200, {
+          items: listItems.slice(0, 4),
+          nextPageLink: null,
+          count: 101
+        });
+
+      const getExtraSavedListsNock = savedListsNock
+        .get(
+          `/v4/savedLists?$top=100&maxPeopleCount=${process.env.NGP_VAN_MAXIMUM_LIST_SIZE}&$skip=1`
+        )
+        .reply(200, {
+          items: listItems.slice(4),
+          nextPageLink: null,
+          count: 1
+        });
+
+      const savedListsResponse = await getClientChoiceData();
+
+      expect(JSON.parse(savedListsResponse.data).items).toEqual(listItems);
+      expect(savedListsResponse.expiresSeconds).toEqual(30);
+      getSavedListsNock.done();
+      getExtraSavedListsNock.done();
+    });
+
     describe("when there is an error retrieving the list", () => {
       it("returns what we expect", async () => {
         const getSavedListsNock = nock(`${fakeNgpVanBaseApiUrl}:443`, {

--- a/src/extensions/contact-loaders/ngpvan/index.js
+++ b/src/extensions/contact-loaders/ngpvan/index.js
@@ -99,30 +99,43 @@ export function clientChoiceDataCacheKey(campaign, user) {
   return "";
 }
 
+async function requestVanSavedLists(organization, skip) {
+  const maxPeopleCount =
+    Number(getConfig("NGP_VAN_MAXIMUM_LIST_SIZE", organization)) ||
+    DEFAULT_NGP_VAN_MAXIMUM_LIST_SIZE;
+
+  const url = Van.makeUrl(
+    `v4/savedLists?$top=100&maxPeopleCount=${maxPeopleCount}${skip ? "&$skip=" + skip : ""}`,
+    organization
+  );
+
+  // The savedLists endpoint supports pagination; we are ignoring pagination now
+  const response = await HttpRequest(url, {
+    method: "GET",
+    headers: {
+      Authorization: Van.getAuth(organization)
+    },
+    retries: 0,
+    timeout: Van.getNgpVanTimeout(organization)
+  });
+
+  return await response.json();
+}
+
 export async function getClientChoiceData(organization, campaign, user) {
   let responseJson;
 
   try {
-    const maxPeopleCount =
-      Number(getConfig("NGP_VAN_MAXIMUM_LIST_SIZE", organization)) ||
-      DEFAULT_NGP_VAN_MAXIMUM_LIST_SIZE;
+    responseJson = await requestVanSavedLists(organization);
 
-    const url = Van.makeUrl(
-      `v4/savedLists?$top=100&maxPeopleCount=${maxPeopleCount}`,
-      organization
-    );
+    if (responseJson.count > 100) {
+      // Hack to get most recently created 100 saved lists
+      const mostRecentListsJson = await requestVanSavedLists(organization, responseJson.count - 100);
 
-    // The savedLists endpoint supports pagination; we are ignoring pagination now
-    const response = await HttpRequest(url, {
-      method: "GET",
-      headers: {
-        Authorization: Van.getAuth(organization)
-      },
-      retries: 0,
-      timeout: Van.getNgpVanTimeout(organization)
-    });
-
-    responseJson = await response.json();
+      if (mostRecentListsJson.items && mostRecentListsJson.items.length) {
+        responseJson.items = responseJson.items.concat(mostRecentListsJson.items);
+      }
+    }
   } catch (error) {
     const message = `Error retrieving saved list metadata from VAN ${error}`;
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Description

Per [this post](https://docs.ngpvan.com/changelog/fixed-pagination-for-get-v4savedlists), the order of this endpoint is now by savedListId asc (practically date created). This grabs the most recent 100 from the API and includes them in our saved list options for the ngpvan contact loader.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
