### PR TITLE
remove some UI logging

### DIFF
--- a/src/components/AdminCampaignList/CampaignTable.jsx
+++ b/src/components/AdminCampaignList/CampaignTable.jsx
@@ -404,7 +404,7 @@ export class CampaignTable extends React.Component {
           case "propsUpdate":
             break;
           default:
-            console.log(`action not handled: ${action}`);
+            break;
         }
       }
     };

--- a/src/components/IncomingMessageList/index.jsx
+++ b/src/components/IncomingMessageList/index.jsx
@@ -393,7 +393,6 @@ export class IncomingMessageList extends Component {
             this.handleRowsSelected(ids);
             break;
           default:
-            console.log(`action not handled: ${action}`);
             break;
         }
       }

--- a/src/components/TagsSelector.jsx
+++ b/src/components/TagsSelector.jsx
@@ -87,7 +87,6 @@ export class TagsSelector extends React.Component {
   };
 
   handleClick = itemClicked => {
-    console.log("handleClick", itemClicked);
     let tagFilter = this.state.tagFilter;
     switch (itemClicked.id) {
       case IGNORE_TAGS.id:
@@ -116,13 +115,11 @@ export class TagsSelector extends React.Component {
           delete tagFilter.suppressedTags[`s_${itemClicked.id}`];
         }
     }
-    console.log("SET STATE", tagFilter);
     this.setState({ tagFilter });
     this.props.onChange(tagFilter);
   };
 
   createMenuItem = tagFilter => {
-    console.log("createMenuItem", tagFilter.id);
     return (
       <MenuItem
         key={tagFilter.id}

--- a/src/containers/PeopleList.jsx
+++ b/src/containers/PeopleList.jsx
@@ -338,7 +338,7 @@ export class PeopleList extends Component {
           case "propsUpdate":
             break;
           default:
-            console.log(`action not handled: ${action}`);
+            break;
         }
       }
     };


### PR DESCRIPTION
is there a good reason to leave UI logging in commits? i think it's probably a bad habit, but generally it's pretty harmless. however, one of these in particular (`createMenuItem`) i believe was causing some performance issues as it was spamming logs anytime anything was changed