### PR TITLE
fix CampaignTextersForm: onFocus/onBlur events were lost

### DIFF
--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -25,6 +25,8 @@ export default class GSTextField extends GSFormField {
       multiline,
       name,
       onChange,
+      onFocus,
+      onBlur,
       placeholder,
       required,
       rows,
@@ -56,6 +58,7 @@ export default class GSTextField extends GSFormField {
       margin,
       multiline,
       name,
+      onBlur,
       placeholder,
       required,
       rows,
@@ -83,7 +86,12 @@ export default class GSTextField extends GSFormField {
       <TextField
         {...dataTest}
         label={this.floatingLabelText()}
-        onFocus={event => event.target.select()}
+        onFocus={event => {
+          event.target.select();
+          if (onFocus) {
+            onFocus(event);
+          }
+        }}
         {...textFieldProps}
         onChange={event => {
           onChange(event.target.value);


### PR DESCRIPTION
# Fixes 11.0 release issue: texter reassignment kills edit page
also fixes #2045 

## Description
When removing assigned contacts from campaign edit texters section and then adding a number that exceeds the total available, the page will 'white-screen of death' with an error message in the dev console 'focusedTexter is undefined'

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [na] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress

Let's add this to stage-main-11-1