### PR TITLE
fix organization message service assignment on buyNumbers

### DIFF
--- a/__test__/extensions/service-vendors/twilio.test.js
+++ b/__test__/extensions/service-vendors/twilio.test.js
@@ -475,7 +475,9 @@ describe("twilio", () => {
   describe("Number buying", () => {
     it("buys numbers in batches from twilio", async () => {
       const org2 = await cacheableData.organization.load(organizationId2);
-      await twilio.buyNumbersInAreaCode(org2, "212", 35);
+      await twilio.buyNumbersInAreaCode(org2, "212", 35, {
+        skipOrgMessageService: true
+      });
       const inventoryCount = await r.getCount(
         r.knex("owned_phone_number").where({
           area_code: "212",

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -384,7 +384,6 @@ const rootSchema = gql`
       organizationId: ID!
       areaCode: String!
       limit: Int!
-      addToOrganizationMessagingService: Boolean
     ): JobRequest
     deletePhoneNumbers(organizationId: ID!, areaCode: String!): JobRequest
     releaseCampaignNumbers(campaignId: ID!): Campaign!

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -63,9 +63,7 @@ class AdminPhoneNumberInventory extends React.Component {
 
     this.state = {
       buyNumbersDialogOpen: false,
-      buyNumbersFormValues: {
-        addToOrganizationMessagingService: false
-      },
+      buyNumbersFormValues: {},
       sortCol: "state",
       sortOrder: "asc",
       filters: {},
@@ -84,8 +82,7 @@ class AdminPhoneNumberInventory extends React.Component {
         .number()
         .required()
         .max(window.MAX_NUMBERS_PER_BUY_JOB)
-        .min(1),
-      addToOrganizationMessagingService: yup.bool()
+        .min(1)
     });
   }
 
@@ -117,23 +114,14 @@ class AdminPhoneNumberInventory extends React.Component {
   };
 
   handleBuyNumbersSubmit = async () => {
-    const {
-      areaCode,
-      limit,
-      addToOrganizationMessagingService
-    } = this.state.buyNumbersFormValues;
-    await this.props.mutations.buyPhoneNumbers(
-      areaCode,
-      limit,
-      addToOrganizationMessagingService
-    );
+    const { areaCode, limit } = this.state.buyNumbersFormValues;
+    await this.props.mutations.buyPhoneNumbers(areaCode, limit);
 
     this.setState({
       buyNumbersDialogOpen: false,
       buyNumbersFormValues: {
         areaCode: null,
-        limit: null,
-        addToOrganizationMessagingService: false
+        limit: null
       }
     });
   };
@@ -299,30 +287,6 @@ class AdminPhoneNumberInventory extends React.Component {
             name="limit"
             {...dataTest("limit")}
           />
-          {serviceName === "twilio" &&
-            serviceConfig.TWILIO_MESSAGE_SERVICE_SID &&
-            serviceConfig.TWILIO_MESSAGE_SERVICE_SID.length > 0 &&
-            !this.props.data.organization.campaignPhoneNumbersEnabled && (
-              <Form.Field
-                name="addToOrganizationMessagingService"
-                as={props => (
-                  <FormControlLabel
-                    {...props}
-                    checked={props.value}
-                    label="Add to this organization's Messaging Service"
-                    control={<Switch color="primary" />}
-                  />
-                )}
-                style={{
-                  marginTop: 30
-                }}
-                onToggle={(_, toggled) => {
-                  this.handleFormChange({
-                    addToOrganizationMessagingService: toggled
-                  });
-                }}
-              />
-            )}
         </div>
         <div style={inlineStyles.dialogActions}>
           <Button
@@ -507,23 +471,17 @@ const queries = {
 };
 
 const mutations = {
-  buyPhoneNumbers: ownProps => (
-    areaCode,
-    limit,
-    addToOrganizationMessagingService
-  ) => ({
+  buyPhoneNumbers: ownProps => (areaCode, limit) => ({
     mutation: gql`
       mutation buyPhoneNumbers(
         $organizationId: ID!
         $areaCode: String!
         $limit: Int!
-        $addToOrganizationMessagingService: Boolean
       ) {
         buyPhoneNumbers(
           organizationId: $organizationId
           areaCode: $areaCode
           limit: $limit
-          addToOrganizationMessagingService: $addToOrganizationMessagingService
         ) {
           id
         }
@@ -532,8 +490,7 @@ const mutations = {
     variables: {
       organizationId: ownProps.params.organizationId,
       areaCode,
-      limit,
-      addToOrganizationMessagingService
+      limit
     },
     refetchQueries: () => ["getOrganizationData"]
   }),

--- a/src/extensions/service-managers/per-campaign-messageservices/index.js
+++ b/src/extensions/service-managers/per-campaign-messageservices/index.js
@@ -237,6 +237,14 @@ export async function onCampaignUpdateSignal({
   return await _editCampaignData(organization, campaign);
 }
 
+export async function onBuyPhoneNumbers({ organization, serviceName, opts }) {
+  return {
+    opts: {
+      skipOrgMessageService: true
+    }
+  };
+}
+
 export async function onVendorServiceFullyConfigured({
   organization,
   serviceName

--- a/src/extensions/service-managers/test-fake-example/index.js
+++ b/src/extensions/service-managers/test-fake-example/index.js
@@ -121,6 +121,15 @@ export async function getOrganizationData({ organization, user, loaders }) {
   };
 }
 
+export async function onBuyPhoneNumbers({
+  organization,
+  user,
+  serviceName,
+  areaCode,
+  limit,
+  opts
+}) {}
+
 export async function onOrganizationServiceVendorSetup({
   organization,
   user,

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -697,7 +697,13 @@ async function addNumberToMessagingService(
 /**
  * Buy a phone number and add it to the owned_phone_number table
  */
-async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
+async function buyNumber(
+  organization,
+  twilioInstance,
+  phoneNumber,
+  opts = {},
+  messageServiceSid
+) {
   const response = await twilioInstance.incomingPhoneNumbers.create({
     phoneNumber,
     friendlyName: `Managed by Spoke [${process.env.BASE_URL}]: ${phoneNumber}`,
@@ -711,10 +717,7 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   log.debug(`Bought number ${phoneNumber} [${response.sid}]`);
 
   let allocationFields = {};
-  let messagingServiceSid = getConfig(
-    "TWILIO_MESSAGE_SERVICE_SID",
-    organization
-  );
+  let messagingServiceSid = messageServiceSid;
   if (opts) {
     if (opts.messagingServiceSid) {
       messagingServiceSid = opts.messagingServiceSid;
@@ -768,6 +771,7 @@ export async function buyNumbersInAreaCode(
 ) {
   const twilioInstance = await exports.getTwilio(organization);
   const countryCode = getConfig("PHONE_NUMBER_COUNTRY ", organization) || "US";
+  const messageServiceSid = await getMessageServiceSid(organization);
   async function buyBatch(size) {
     let successCount = 0;
     log.debug(`Attempting to buy batch of ${size} numbers`);
@@ -780,7 +784,13 @@ export async function buyNumbersInAreaCode(
     );
 
     await bulkRequest(response, async item => {
-      await buyNumber(organization, twilioInstance, item.phoneNumber, opts);
+      await buyNumber(
+        organization,
+        twilioInstance,
+        item.phoneNumber,
+        opts,
+        messageServiceSid
+      );
       successCount++;
     });
 

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -711,7 +711,18 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   log.debug(`Bought number ${phoneNumber} [${response.sid}]`);
 
   let allocationFields = {};
-  const messagingServiceSid = opts && opts.messagingServiceSid;
+  let messagingServiceSid = getConfig(
+    "TWILIO_MESSAGE_SERVICE_SID",
+    organization
+  );
+  if (opts) {
+    if (opts.messagingServiceSid) {
+      messagingServiceSid = opts.messagingServiceSid;
+    } else if (opts.skipOrgMessageService) {
+      messagingServiceSid = null;
+    }
+  }
+
   if (messagingServiceSid) {
     await addNumberToMessagingService(
       twilioInstance,
@@ -727,7 +738,6 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   // Note: relies on the fact that twilio returns E. 164 formatted numbers
   //  and only works in the US
   const areaCode = phoneNumber.slice(2, 5);
-
   return await r.knex("owned_phone_number").insert({
     organization_id: organization.id,
     area_code: areaCode,

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -852,8 +852,13 @@ export async function deleteNumbersInAreaCode(organization, areaCode) {
     .where({
       organization_id: organization.id,
       area_code: areaCode,
-      service: "twilio",
-      allocated_to: null
+      service: "twilio"
+    })
+    .where(function() {
+      this.whereNull("allocated_to").orWhere(
+        "allocated_to",
+        "messaging_service"
+      );
     });
   let successCount = 0;
   for (const n of numbersToDelete) {

--- a/src/server/api/lib/owned-phone-number.js
+++ b/src/server/api/lib/owned-phone-number.js
@@ -67,7 +67,7 @@ async function listOrganizationCounts(organization) {
       "area_code",
       r.knex.raw("COUNT(allocated_to) as allocated_count"),
       r.knex.raw(
-        "SUM(CASE WHEN allocated_to IS NULL THEN 1 END) as available_count"
+        "SUM(CASE WHEN allocated_to IS NULL OR allocated_to = 'messaging_service' THEN 1 END) as available_count"
       )
     )
     .where({

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -2,49 +2,58 @@ import serviceMap from "../../../extensions/service-vendors";
 import { accessRequired } from "../errors";
 import { getConfig } from "../lib/config";
 import { cacheableData } from "../../models";
+import { processServiceManagers } from "../../../extensions/service-managers";
+import {
+  getServiceFromOrganization,
+  getServiceNameFromOrganization
+} from "../../../extensions/service-vendors";
 import { jobRunner } from "../../../extensions/job-runners";
 import { Jobs } from "../../../workers/job-processes";
 
 export const buyPhoneNumbers = async (
   _,
-  { organizationId, areaCode, limit, addToOrganizationMessagingService },
+  { organizationId, areaCode, limit },
   { user }
 ) => {
   await accessRequired(user, organizationId, "ADMIN");
-  const org = await cacheableData.organization.load(organizationId);
+  const organization = await cacheableData.organization.load(organizationId);
   if (
-    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true }) &&
-    !getConfig("PHONE_INVENTORY", org, { truthy: true })
+    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", organization, {
+      truthy: true
+    }) &&
+    !getConfig("PHONE_INVENTORY", organization, { truthy: true })
   ) {
     throw new Error("Phone inventory management is not enabled");
   }
-  const serviceName = getConfig("DEFAULT_SERVICE", org);
-  const service = serviceMap[serviceName];
+  const serviceName = getServiceNameFromOrganization(organization);
+  const service = getServiceFromOrganization(organization);
   if (!service || !service.hasOwnProperty("buyNumbersInAreaCode")) {
     throw new Error(
       `Service ${serviceName} does not support phone number buying`
     );
   }
-
-  let messagingServiceSid;
-  if (addToOrganizationMessagingService) {
-    const msgSrv = JSON.parse(org.features || "{}").TWILIO_MESSAGE_SERVICE_SID;
-    if (serviceName !== "twilio" || !msgSrv) {
-      throw new Error(
-        "This organization is not configured to use its own Twilio Messaging Service"
-      );
+  const opts = {};
+  const serviceManagerResult = await processServiceManagers(
+    "onBuyPhoneNumbers",
+    organization,
+    {
+      user,
+      serviceName,
+      areaCode,
+      limit,
+      opts
     }
-    messagingServiceSid = msgSrv;
-  }
+  );
+
   return await jobRunner.dispatchJob({
     queue_name: `${organizationId}:buy_phone_numbers`,
     organization_id: organizationId,
     job_type: Jobs.BUY_PHONE_NUMBERS,
     locks_queue: false,
     payload: JSON.stringify({
-      areaCode,
-      limit,
-      messagingServiceSid
+      areaCode: serviceManagerResult.areaCode || areaCode,
+      limit: serviceManagerResult.limit || limit,
+      opts: serviceManagerResult.opts || opts
     })
   });
 };
@@ -55,15 +64,17 @@ export const deletePhoneNumbers = async (
   { user }
 ) => {
   await accessRequired(user, organizationId, "OWNER");
-  const org = await cacheableData.organization.load(organizationId);
+  const organization = await cacheableData.organization.load(organizationId);
   if (
-    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true }) &&
-    !getConfig("PHONE_INVENTORY", org, { truthy: true })
+    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", organization, {
+      truthy: true
+    }) &&
+    !getConfig("PHONE_INVENTORY", organization, { truthy: true })
   ) {
     throw new Error("Phone inventory management is not enabled");
   }
-  const serviceName = getConfig("DEFAULT_SERVICE", org);
-  const service = serviceMap[serviceName];
+  const serviceName = getServiceNameFromOrganization(organization);
+  const service = getServiceFromOrganization(organization);
   if (!service || !service.hasOwnProperty("buyNumbersInAreaCode")) {
     throw new Error(
       `Service ${serviceName} does not support phone number buying`


### PR DESCRIPTION

# Fixes #2044

## Description

remove addToOrganizationMessageService as a UI option and instead make it a config based on setup

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
