### PR TITLE
fix reopen button in texter controls: change the state to see Skip after reopening

### DIFF
--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -74,7 +74,7 @@ export class ContactController extends React.Component {
     // In fact, without the code below, we will 'double-jump' each message
     // we send or change the status in some way.
     // Below, we update our index with the contact that matches our current index.
-
+    console.log("ContactController", nextProps, nextState);
     if (nextState.currentContactIndex != this.state.currentContactIndex) {
       console.log(
         "updateindex <cur> <next>",

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -530,36 +530,49 @@ export class AssignmentTexterContactControls extends React.Component {
   renderNeedsResponseToggleButton(contact) {
     const { messageStatus } = contact;
     let button = null;
-    if (messageStatus === "needsMessage") {
-      return null;
-    } else if (messageStatus === "closed") {
-      // todo: add flex: style.
-      button = (
-        <Button
-          onClick={() => this.props.onEditStatus("needsResponse")}
-          className={css(flexStyles.button)}
-          style={{ flex: "1 1 auto" }}
-          disabled={!!this.props.contact.optOut}
-          color="default"
-          variant="outlined"
-        >
-          Reopen
-        </Button>
-      );
-    } else {
-      button = (
-        <Button
-          onClick={() => this.props.onEditStatus("closed", true)}
-          className={css(flexStyles.button)}
-          disabled={!!this.props.contact.optOut}
-          color="default"
-          variant="outlined"
-        >
-          Skip
-        </Button>
-      );
+    if (messageStatus !== "needsMessage") {
+      const status = this.state.messageStatus || messageStatus;
+      const onClick = (newStatus, finishContact) => async () => {
+        const res = await this.props.onEditStatus(newStatus, finishContact);
+        if (
+          res &&
+          res.data &&
+          res.data.editCampaignContactMessageStatus &&
+          res.data.editCampaignContactMessageStatus.messageStatus
+        ) {
+          this.setState({
+            messageStatus:
+              res.data.editCampaignContactMessageStatus.messageStatus
+          });
+        }
+      };
+      if (status === "closed") {
+        button = (
+          <Button
+            onClick={onClick("needsResponse")}
+            className={css(flexStyles.button)}
+            style={{ flex: "1 1 auto" }}
+            disabled={!!this.props.contact.optOut}
+            color="default"
+            variant="outlined"
+          >
+            Reopen
+          </Button>
+        );
+      } else {
+        button = (
+          <Button
+            onClick={onClick("closed", true)}
+            className={css(flexStyles.button)}
+            disabled={!!this.props.contact.optOut}
+            color="default"
+            variant="outlined"
+          >
+            Skip
+          </Button>
+        );
+      }
     }
-
     return button;
   }
 

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -286,7 +286,7 @@ export class AssignmentTexterContact extends React.Component {
 
   handleEditStatus = async (messageStatus, finishContact) => {
     const { contact } = this.props;
-    await this.props.mutations.editCampaignContactMessageStatus(
+    const res = await this.props.mutations.editCampaignContactMessageStatus(
       messageStatus,
       contact.id
     );
@@ -294,6 +294,7 @@ export class AssignmentTexterContact extends React.Component {
       await this.handleSubmitSurveys();
       this.props.onFinishContact();
     }
+    return res;
   };
 
   handleOptOut = async ({ optOutMessageText }) => {


### PR DESCRIPTION
## Description

When clicking the Reopen button from a skipped message, there's no UI indication that it was reopened.  This fix will change the state so it will flip the button to say Skip once it is successfully reopened.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
