### PR TITLE
SCRUB_MOBILE_OPTIONAL: allow scrubbing optionally rather than required

### DIFF
--- a/src/extensions/service-managers/scrub-bad-mobilenums/index.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/index.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { r, cacheableData } from "../../../server/models";
-import { getFeatures } from "../../../server/api/lib/config";
+import { getConfig, getFeatures } from "../../../server/api/lib/config";
 import { Jobs } from "../../../workers/job-processes";
 import { jobRunner } from "../../job-runners";
 import { getServiceFromOrganization } from "../../service-vendors";
@@ -80,7 +80,6 @@ export async function getCampaignData({
   // MUST NOT RETURN SECRETS!
   // called both from edit and stats contexts: editMode==true for edit page
   if (!fromCampaignStatsPage) {
-    // TODO: get campaignFeatures current
     const features = getFeatures(campaign);
     const {
       scrubBadMobileNumsFreshStart = false,
@@ -90,6 +89,10 @@ export async function getCampaignData({
       scrubBadMobileNumsDeletedOnUpload = null
     } = features;
 
+    const scrubMobileOptional = getConfig(
+      "SCRUB_MOBILE_OPTIONAL",
+      organization
+    );
     const serviceClient = getServiceFromOrganization(organization);
     const scrubBadMobileNumsGettable =
       typeof serviceClient.getContactInfo === "function";
@@ -111,10 +114,13 @@ export async function getCampaignData({
         scrubBadMobileNumsGettable,
         scrubBadMobileNumsCount,
         scrubBadMobileNumsFinishedDeleteCount,
-        scrubBadMobileNumsDeletedOnUpload
+        scrubBadMobileNumsDeletedOnUpload,
+        scrubMobileOptional
       },
       fullyConfigured:
-        scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0
+        scrubBadMobileNumsFinished ||
+        scrubBadMobileNumsCount === 0 ||
+        scrubMobileOptional
     };
   }
 }

--- a/src/extensions/service-managers/scrub-bad-mobilenums/react-component.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/react-component.js
@@ -33,7 +33,8 @@ export class CampaignConfig extends React.Component {
       scrubBadMobileNumsGettable,
       scrubBadMobileNumsCount,
       scrubBadMobileNumsFinishedDeleteCount,
-      scrubBadMobileNumsDeletedOnUpload
+      scrubBadMobileNumsDeletedOnUpload,
+      scrubMobileOptional
     } = this.props.serviceManagerInfo.data;
     const { isStarted, contactsCount, pendingJobs } = this.props.campaign;
     const scrubJobs = pendingJobs.filter(
@@ -66,7 +67,10 @@ export class CampaignConfig extends React.Component {
     let scrubState = null;
     if (isStarted) {
       scrubState = states.F_CAMPAIGN_STARTED;
-    } else if (scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0) {
+    } else if (
+      contactsCount &&
+      (scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0)
+    ) {
       scrubState = states.E_PROCESS_COMPLETE;
     } else if (scrubJobs.length) {
       scrubState = states.D_PROCESSING;
@@ -96,7 +100,9 @@ export class CampaignConfig extends React.Component {
         )}
         {scrubState === states.B_NEEDS_UPLOAD && (
           <p>
-            This is a required step to lookup numbers you&rsquo;ve uploaded, but
+            {scrubMobileOptional
+              ? ""
+              : "This is a required step to lookup numbers you&rsquo;ve uploaded, but"}
             FIRST you need to upload your contacts -- go to the Contacts section
             and upload your list -- then check back here to look them up.
           </p>
@@ -104,10 +110,13 @@ export class CampaignConfig extends React.Component {
         {scrubState === states.C_NEEDS_RUN && (
           <div>
             <p>
-              This is a required step to lookup numbers you&rsquo;ve uploaded,
-              however, looking them up costs money, so only trigger this lookup
-              before starting the campaign. If you upload a new set of numbers,
-              we&rsquo;ll have to look them up again?!
+              {scrubMobileOptional
+                ? "This is a tool "
+                : "This is a required step "}
+              to lookup numbers you&rsquo;ve uploaded, however, looking them up
+              costs money, so only trigger this lookup before starting the
+              campaign. If you upload a new set of numbers, we&rsquo;ll have to
+              look them up again?!
             </p>
             {scrubBadMobileNumsCount ? (
               <p>


### PR DESCRIPTION
## Description

scrub-bad-mobilenums service-manager defaults to forcing it to be run before the campaign is started.  This adds an env var/org option to be able to enable it and use it optionally on specific campaigns rather than all of them.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
