### PR TITLE
Stage main 11.1 release candidate

### DIFF
--- a/__test__/extensions/service-vendors/twilio.test.js
+++ b/__test__/extensions/service-vendors/twilio.test.js
@@ -475,7 +475,9 @@ describe("twilio", () => {
   describe("Number buying", () => {
     it("buys numbers in batches from twilio", async () => {
       const org2 = await cacheableData.organization.load(organizationId2);
-      await twilio.buyNumbersInAreaCode(org2, "212", 35);
+      await twilio.buyNumbersInAreaCode(org2, "212", 35, {
+        skipOrgMessageService: true
+      });
       const inventoryCount = await r.getCount(
         r.knex("owned_phone_number").where({
           area_code: "212",

--- a/src/api/schema.js
+++ b/src/api/schema.js
@@ -384,7 +384,6 @@ const rootSchema = gql`
       organizationId: ID!
       areaCode: String!
       limit: Int!
-      addToOrganizationMessagingService: Boolean
     ): JobRequest
     deletePhoneNumbers(organizationId: ID!, areaCode: String!): JobRequest
     releaseCampaignNumbers(campaignId: ID!): Campaign!

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -74,7 +74,7 @@ export class ContactController extends React.Component {
     // In fact, without the code below, we will 'double-jump' each message
     // we send or change the status in some way.
     // Below, we update our index with the contact that matches our current index.
-
+    console.log("ContactController", nextProps, nextState);
     if (nextState.currentContactIndex != this.state.currentContactIndex) {
       console.log(
         "updateindex <cur> <next>",

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -74,7 +74,6 @@ export class ContactController extends React.Component {
     // In fact, without the code below, we will 'double-jump' each message
     // we send or change the status in some way.
     // Below, we update our index with the contact that matches our current index.
-    console.log("ContactController", nextProps, nextState);
     if (nextState.currentContactIndex != this.state.currentContactIndex) {
       console.log(
         "updateindex <cur> <next>",

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -530,36 +530,49 @@ export class AssignmentTexterContactControls extends React.Component {
   renderNeedsResponseToggleButton(contact) {
     const { messageStatus } = contact;
     let button = null;
-    if (messageStatus === "needsMessage") {
-      return null;
-    } else if (messageStatus === "closed") {
-      // todo: add flex: style.
-      button = (
-        <Button
-          onClick={() => this.props.onEditStatus("needsResponse")}
-          className={css(flexStyles.button)}
-          style={{ flex: "1 1 auto" }}
-          disabled={!!this.props.contact.optOut}
-          color="default"
-          variant="outlined"
-        >
-          Reopen
-        </Button>
-      );
-    } else {
-      button = (
-        <Button
-          onClick={() => this.props.onEditStatus("closed", true)}
-          className={css(flexStyles.button)}
-          disabled={!!this.props.contact.optOut}
-          color="default"
-          variant="outlined"
-        >
-          Skip
-        </Button>
-      );
+    if (messageStatus !== "needsMessage") {
+      const status = this.state.messageStatus || messageStatus;
+      const onClick = (newStatus, finishContact) => async () => {
+        const res = await this.props.onEditStatus(newStatus, finishContact);
+        if (
+          res &&
+          res.data &&
+          res.data.editCampaignContactMessageStatus &&
+          res.data.editCampaignContactMessageStatus.messageStatus
+        ) {
+          this.setState({
+            messageStatus:
+              res.data.editCampaignContactMessageStatus.messageStatus
+          });
+        }
+      };
+      if (status === "closed") {
+        button = (
+          <Button
+            onClick={onClick("needsResponse")}
+            className={css(flexStyles.button)}
+            style={{ flex: "1 1 auto" }}
+            disabled={!!this.props.contact.optOut}
+            color="default"
+            variant="outlined"
+          >
+            Reopen
+          </Button>
+        );
+      } else {
+        button = (
+          <Button
+            onClick={onClick("closed", true)}
+            className={css(flexStyles.button)}
+            disabled={!!this.props.contact.optOut}
+            color="default"
+            variant="outlined"
+          >
+            Skip
+          </Button>
+        );
+      }
     }
-
     return button;
   }
 

--- a/src/components/forms/GSTextField.jsx
+++ b/src/components/forms/GSTextField.jsx
@@ -25,6 +25,8 @@ export default class GSTextField extends GSFormField {
       multiline,
       name,
       onChange,
+      onFocus,
+      onBlur,
       placeholder,
       required,
       rows,
@@ -56,6 +58,7 @@ export default class GSTextField extends GSFormField {
       margin,
       multiline,
       name,
+      onBlur,
       placeholder,
       required,
       rows,
@@ -83,7 +86,12 @@ export default class GSTextField extends GSFormField {
       <TextField
         {...dataTest}
         label={this.floatingLabelText()}
-        onFocus={event => event.target.select()}
+        onFocus={event => {
+          event.target.select();
+          if (onFocus) {
+            onFocus(event);
+          }
+        }}
         {...textFieldProps}
         onChange={event => {
           onChange(event.target.value);

--- a/src/containers/AdminPhoneNumberInventory.js
+++ b/src/containers/AdminPhoneNumberInventory.js
@@ -63,9 +63,7 @@ class AdminPhoneNumberInventory extends React.Component {
 
     this.state = {
       buyNumbersDialogOpen: false,
-      buyNumbersFormValues: {
-        addToOrganizationMessagingService: false
-      },
+      buyNumbersFormValues: {},
       sortCol: "state",
       sortOrder: "asc",
       filters: {},
@@ -84,8 +82,7 @@ class AdminPhoneNumberInventory extends React.Component {
         .number()
         .required()
         .max(window.MAX_NUMBERS_PER_BUY_JOB)
-        .min(1),
-      addToOrganizationMessagingService: yup.bool()
+        .min(1)
     });
   }
 
@@ -117,23 +114,14 @@ class AdminPhoneNumberInventory extends React.Component {
   };
 
   handleBuyNumbersSubmit = async () => {
-    const {
-      areaCode,
-      limit,
-      addToOrganizationMessagingService
-    } = this.state.buyNumbersFormValues;
-    await this.props.mutations.buyPhoneNumbers(
-      areaCode,
-      limit,
-      addToOrganizationMessagingService
-    );
+    const { areaCode, limit } = this.state.buyNumbersFormValues;
+    await this.props.mutations.buyPhoneNumbers(areaCode, limit);
 
     this.setState({
       buyNumbersDialogOpen: false,
       buyNumbersFormValues: {
         areaCode: null,
-        limit: null,
-        addToOrganizationMessagingService: false
+        limit: null
       }
     });
   };
@@ -299,30 +287,6 @@ class AdminPhoneNumberInventory extends React.Component {
             name="limit"
             {...dataTest("limit")}
           />
-          {serviceName === "twilio" &&
-            serviceConfig.TWILIO_MESSAGE_SERVICE_SID &&
-            serviceConfig.TWILIO_MESSAGE_SERVICE_SID.length > 0 &&
-            !this.props.data.organization.campaignPhoneNumbersEnabled && (
-              <Form.Field
-                name="addToOrganizationMessagingService"
-                as={props => (
-                  <FormControlLabel
-                    {...props}
-                    checked={props.value}
-                    label="Add to this organization's Messaging Service"
-                    control={<Switch color="primary" />}
-                  />
-                )}
-                style={{
-                  marginTop: 30
-                }}
-                onToggle={(_, toggled) => {
-                  this.handleFormChange({
-                    addToOrganizationMessagingService: toggled
-                  });
-                }}
-              />
-            )}
         </div>
         <div style={inlineStyles.dialogActions}>
           <Button
@@ -507,23 +471,17 @@ const queries = {
 };
 
 const mutations = {
-  buyPhoneNumbers: ownProps => (
-    areaCode,
-    limit,
-    addToOrganizationMessagingService
-  ) => ({
+  buyPhoneNumbers: ownProps => (areaCode, limit) => ({
     mutation: gql`
       mutation buyPhoneNumbers(
         $organizationId: ID!
         $areaCode: String!
         $limit: Int!
-        $addToOrganizationMessagingService: Boolean
       ) {
         buyPhoneNumbers(
           organizationId: $organizationId
           areaCode: $areaCode
           limit: $limit
-          addToOrganizationMessagingService: $addToOrganizationMessagingService
         ) {
           id
         }
@@ -532,8 +490,7 @@ const mutations = {
     variables: {
       organizationId: ownProps.params.organizationId,
       areaCode,
-      limit,
-      addToOrganizationMessagingService
+      limit
     },
     refetchQueries: () => ["getOrganizationData"]
   }),

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -286,7 +286,7 @@ export class AssignmentTexterContact extends React.Component {
 
   handleEditStatus = async (messageStatus, finishContact) => {
     const { contact } = this.props;
-    await this.props.mutations.editCampaignContactMessageStatus(
+    const res = await this.props.mutations.editCampaignContactMessageStatus(
       messageStatus,
       contact.id
     );
@@ -294,6 +294,7 @@ export class AssignmentTexterContact extends React.Component {
       await this.handleSubmitSurveys();
       this.props.onFinishContact();
     }
+    return res;
   };
 
   handleOptOut = async ({ optOutMessageText }) => {

--- a/src/extensions/contact-loaders/redash/index.js
+++ b/src/extensions/contact-loaders/redash/index.js
@@ -215,7 +215,7 @@ export async function processContactLoad(job, maxContacts, organization) {
   }
   // 1. start query
   const startQueryUrl = `${baseUrl}/api/queries/${queryId}/refresh${params}`;
-  console.log("REDASH 1");
+  console.log("redash 1");
   let refreshRedashResult;
   try {
     refreshRedashResult = await httpRequest(startQueryUrl, {
@@ -249,12 +249,12 @@ export async function processContactLoad(job, maxContacts, organization) {
   // 2. poll job status
   const jobQueryId = redashJobData.job.id;
   const redashPollStatusUrl = `${baseUrl}/api/jobs/${jobQueryId}`;
-  console.log("REDASH 2", redashJobData);
+  console.log("redash 2", redashJobData);
   const redashQueryCompleted = await httpRequest(redashPollStatusUrl, {
     method: "get",
     bodyRetryFunction: async res => {
       const json = await res.json();
-      console.log("statusValidation", json);
+      console.log("redash statusValidation", json);
       const jobStatus = json && json.job && json.job.status;
       return jobStatus === 3 || jobStatus === 4 ? json : { RETRY: 1 };
     },
@@ -263,7 +263,7 @@ export async function processContactLoad(job, maxContacts, organization) {
     retryDelayMs: 3000, // 3 seconds
     ...httpsArgs(organization)
   });
-  console.log("refreshDataResult", redashQueryCompleted);
+  console.log("redash refreshDataResult", redashQueryCompleted);
   if (redashQueryCompleted.job.status === 4) {
     await failedContactLoad(
       job,

--- a/src/extensions/contact-loaders/redash/index.js
+++ b/src/extensions/contact-loaders/redash/index.js
@@ -215,7 +215,6 @@ export async function processContactLoad(job, maxContacts, organization) {
   }
   // 1. start query
   const startQueryUrl = `${baseUrl}/api/queries/${queryId}/refresh${params}`;
-  console.log("redash 1");
   let refreshRedashResult;
   try {
     refreshRedashResult = await httpRequest(startQueryUrl, {
@@ -249,12 +248,10 @@ export async function processContactLoad(job, maxContacts, organization) {
   // 2. poll job status
   const jobQueryId = redashJobData.job.id;
   const redashPollStatusUrl = `${baseUrl}/api/jobs/${jobQueryId}`;
-  console.log("redash 2", redashJobData);
   const redashQueryCompleted = await httpRequest(redashPollStatusUrl, {
     method: "get",
     bodyRetryFunction: async res => {
       const json = await res.json();
-      console.log("redash statusValidation", json);
       const jobStatus = json && json.job && json.job.status;
       return jobStatus === 3 || jobStatus === 4 ? json : { RETRY: 1 };
     },
@@ -263,7 +260,6 @@ export async function processContactLoad(job, maxContacts, organization) {
     retryDelayMs: 3000, // 3 seconds
     ...httpsArgs(organization)
   });
-  console.log("redash refreshDataResult", redashQueryCompleted);
   if (redashQueryCompleted.job.status === 4) {
     await failedContactLoad(
       job,

--- a/src/extensions/service-managers/per-campaign-messageservices/index.js
+++ b/src/extensions/service-managers/per-campaign-messageservices/index.js
@@ -237,6 +237,14 @@ export async function onCampaignUpdateSignal({
   return await _editCampaignData(organization, campaign);
 }
 
+export async function onBuyPhoneNumbers({ organization, serviceName, opts }) {
+  return {
+    opts: {
+      skipOrgMessageService: true
+    }
+  };
+}
+
 export async function onVendorServiceFullyConfigured({
   organization,
   serviceName

--- a/src/extensions/service-managers/scrub-bad-mobilenums/index.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/index.js
@@ -1,6 +1,6 @@
 import _ from "lodash";
 import { r, cacheableData } from "../../../server/models";
-import { getFeatures } from "../../../server/api/lib/config";
+import { getConfig, getFeatures } from "../../../server/api/lib/config";
 import { Jobs } from "../../../workers/job-processes";
 import { jobRunner } from "../../job-runners";
 import { getServiceFromOrganization } from "../../service-vendors";
@@ -80,7 +80,6 @@ export async function getCampaignData({
   // MUST NOT RETURN SECRETS!
   // called both from edit and stats contexts: editMode==true for edit page
   if (!fromCampaignStatsPage) {
-    // TODO: get campaignFeatures current
     const features = getFeatures(campaign);
     const {
       scrubBadMobileNumsFreshStart = false,
@@ -90,6 +89,10 @@ export async function getCampaignData({
       scrubBadMobileNumsDeletedOnUpload = null
     } = features;
 
+    const scrubMobileOptional = getConfig(
+      "SCRUB_MOBILE_OPTIONAL",
+      organization
+    );
     const serviceClient = getServiceFromOrganization(organization);
     const scrubBadMobileNumsGettable =
       typeof serviceClient.getContactInfo === "function";
@@ -111,10 +114,13 @@ export async function getCampaignData({
         scrubBadMobileNumsGettable,
         scrubBadMobileNumsCount,
         scrubBadMobileNumsFinishedDeleteCount,
-        scrubBadMobileNumsDeletedOnUpload
+        scrubBadMobileNumsDeletedOnUpload,
+        scrubMobileOptional
       },
       fullyConfigured:
-        scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0
+        scrubBadMobileNumsFinished ||
+        scrubBadMobileNumsCount === 0 ||
+        scrubMobileOptional
     };
   }
 }

--- a/src/extensions/service-managers/scrub-bad-mobilenums/react-component.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/react-component.js
@@ -33,7 +33,8 @@ export class CampaignConfig extends React.Component {
       scrubBadMobileNumsGettable,
       scrubBadMobileNumsCount,
       scrubBadMobileNumsFinishedDeleteCount,
-      scrubBadMobileNumsDeletedOnUpload
+      scrubBadMobileNumsDeletedOnUpload,
+      scrubMobileOptional
     } = this.props.serviceManagerInfo.data;
     const { isStarted, contactsCount, pendingJobs } = this.props.campaign;
     const scrubJobs = pendingJobs.filter(
@@ -66,7 +67,10 @@ export class CampaignConfig extends React.Component {
     let scrubState = null;
     if (isStarted) {
       scrubState = states.F_CAMPAIGN_STARTED;
-    } else if (scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0) {
+    } else if (
+      contactsCount &&
+      (scrubBadMobileNumsFinished || scrubBadMobileNumsCount === 0)
+    ) {
       scrubState = states.E_PROCESS_COMPLETE;
     } else if (scrubJobs.length) {
       scrubState = states.D_PROCESSING;
@@ -96,7 +100,9 @@ export class CampaignConfig extends React.Component {
         )}
         {scrubState === states.B_NEEDS_UPLOAD && (
           <p>
-            This is a required step to lookup numbers you&rsquo;ve uploaded, but
+            {scrubMobileOptional
+              ? ""
+              : "This is a required step to lookup numbers you&rsquo;ve uploaded, but"}
             FIRST you need to upload your contacts -- go to the Contacts section
             and upload your list -- then check back here to look them up.
           </p>
@@ -104,10 +110,13 @@ export class CampaignConfig extends React.Component {
         {scrubState === states.C_NEEDS_RUN && (
           <div>
             <p>
-              This is a required step to lookup numbers you&rsquo;ve uploaded,
-              however, looking them up costs money, so only trigger this lookup
-              before starting the campaign. If you upload a new set of numbers,
-              we&rsquo;ll have to look them up again?!
+              {scrubMobileOptional
+                ? "This is a tool "
+                : "This is a required step "}
+              to lookup numbers you&rsquo;ve uploaded, however, looking them up
+              costs money, so only trigger this lookup before starting the
+              campaign. If you upload a new set of numbers, we&rsquo;ll have to
+              look them up again?!
             </p>
             {scrubBadMobileNumsCount ? (
               <p>

--- a/src/extensions/service-managers/test-fake-example/index.js
+++ b/src/extensions/service-managers/test-fake-example/index.js
@@ -121,6 +121,15 @@ export async function getOrganizationData({ organization, user, loaders }) {
   };
 }
 
+export async function onBuyPhoneNumbers({
+  organization,
+  user,
+  serviceName,
+  areaCode,
+  limit,
+  opts
+}) {}
+
 export async function onOrganizationServiceVendorSetup({
   organization,
   user,

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -697,7 +697,13 @@ async function addNumberToMessagingService(
 /**
  * Buy a phone number and add it to the owned_phone_number table
  */
-async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
+async function buyNumber(
+  organization,
+  twilioInstance,
+  phoneNumber,
+  opts = {},
+  messageServiceSid
+) {
   const response = await twilioInstance.incomingPhoneNumbers.create({
     phoneNumber,
     friendlyName: `Managed by Spoke [${process.env.BASE_URL}]: ${phoneNumber}`,
@@ -711,10 +717,7 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   log.debug(`Bought number ${phoneNumber} [${response.sid}]`);
 
   let allocationFields = {};
-  let messagingServiceSid = getConfig(
-    "TWILIO_MESSAGE_SERVICE_SID",
-    organization
-  );
+  let messagingServiceSid = messageServiceSid;
   if (opts) {
     if (opts.messagingServiceSid) {
       messagingServiceSid = opts.messagingServiceSid;
@@ -768,6 +771,7 @@ export async function buyNumbersInAreaCode(
 ) {
   const twilioInstance = await exports.getTwilio(organization);
   const countryCode = getConfig("PHONE_NUMBER_COUNTRY ", organization) || "US";
+  const messageServiceSid = await getMessageServiceSid(organization);
   async function buyBatch(size) {
     let successCount = 0;
     log.debug(`Attempting to buy batch of ${size} numbers`);
@@ -780,7 +784,13 @@ export async function buyNumbersInAreaCode(
     );
 
     await bulkRequest(response, async item => {
-      await buyNumber(organization, twilioInstance, item.phoneNumber, opts);
+      await buyNumber(
+        organization,
+        twilioInstance,
+        item.phoneNumber,
+        opts,
+        messageServiceSid
+      );
       successCount++;
     });
 

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -711,7 +711,18 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   log.debug(`Bought number ${phoneNumber} [${response.sid}]`);
 
   let allocationFields = {};
-  const messagingServiceSid = opts && opts.messagingServiceSid;
+  let messagingServiceSid = getConfig(
+    "TWILIO_MESSAGE_SERVICE_SID",
+    organization
+  );
+  if (opts) {
+    if (opts.messagingServiceSid) {
+      messagingServiceSid = opts.messagingServiceSid;
+    } else if (opts.skipOrgMessageService) {
+      messagingServiceSid = null;
+    }
+  }
+
   if (messagingServiceSid) {
     await addNumberToMessagingService(
       twilioInstance,
@@ -727,7 +738,6 @@ async function buyNumber(organization, twilioInstance, phoneNumber, opts = {}) {
   // Note: relies on the fact that twilio returns E. 164 formatted numbers
   //  and only works in the US
   const areaCode = phoneNumber.slice(2, 5);
-
   return await r.knex("owned_phone_number").insert({
     organization_id: organization.id,
     area_code: areaCode,

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -852,8 +852,13 @@ export async function deleteNumbersInAreaCode(organization, areaCode) {
     .where({
       organization_id: organization.id,
       area_code: areaCode,
-      service: "twilio",
-      allocated_to: null
+      service: "twilio"
+    })
+    .where(function() {
+      this.whereNull("allocated_to").orWhere(
+        "allocated_to",
+        "messaging_service"
+      );
     });
   let successCount = 0;
   for (const n of numbersToDelete) {

--- a/src/extensions/service-vendors/twilio/react-component.js
+++ b/src/extensions/service-vendors/twilio/react-component.js
@@ -20,7 +20,6 @@ import DialogContentText from "@material-ui/core/DialogContentText";
 import DisplayLink from "../../../components/DisplayLink";
 import GSForm from "../../../components/forms/GSForm";
 import GSTextField from "../../../components/forms/GSTextField";
-import GSSubmitButton from "../../../components/forms/GSSubmitButton";
 
 export class OrgConfig extends React.Component {
   constructor(props) {
@@ -178,11 +177,13 @@ export class OrgConfig extends React.Component {
                 fullWidth
               />
 
-              <Form.Submit
-                as={GSSubmitButton}
-                label={this.props.saveLabel || "Save Twilio Credentials"}
+              <Button
+                color="primary"
+                variant="contained"
                 onClick={this.handleOpenTwilioDialog}
-              />
+              >
+                {this.props.saveLabel || "Save Twilio Credentials"}
+              </Button>
               <Dialog open={this.state.twilioDialogOpen}>
                 <DialogContent>
                   <DialogContentText>
@@ -198,13 +199,13 @@ export class OrgConfig extends React.Component {
                   >
                     Cancel
                   </Button>
-                  <Form.Submit
-                    as={GSSubmitButton}
-                    label="Save"
-                    style={inlineStyles.dialogButton}
-                    component={GSSubmitButton}
+                  <Button
+                    color="primary"
+                    variant="contained"
                     onClick={this.handleSubmitTwilioAuthForm}
-                  />
+                  >
+                    Save
+                  </Button>
                 </DialogActions>
               </Dialog>
             </GSForm>

--- a/src/server/api/lib/owned-phone-number.js
+++ b/src/server/api/lib/owned-phone-number.js
@@ -67,7 +67,7 @@ async function listOrganizationCounts(organization) {
       "area_code",
       r.knex.raw("COUNT(allocated_to) as allocated_count"),
       r.knex.raw(
-        "SUM(CASE WHEN allocated_to IS NULL THEN 1 END) as available_count"
+        "SUM(CASE WHEN allocated_to IS NULL OR allocated_to = 'messaging_service' THEN 1 END) as available_count"
       )
     )
     .where({

--- a/src/server/api/mutations/buyPhoneNumbers.js
+++ b/src/server/api/mutations/buyPhoneNumbers.js
@@ -2,49 +2,58 @@ import serviceMap from "../../../extensions/service-vendors";
 import { accessRequired } from "../errors";
 import { getConfig } from "../lib/config";
 import { cacheableData } from "../../models";
+import { processServiceManagers } from "../../../extensions/service-managers";
+import {
+  getServiceFromOrganization,
+  getServiceNameFromOrganization
+} from "../../../extensions/service-vendors";
 import { jobRunner } from "../../../extensions/job-runners";
 import { Jobs } from "../../../workers/job-processes";
 
 export const buyPhoneNumbers = async (
   _,
-  { organizationId, areaCode, limit, addToOrganizationMessagingService },
+  { organizationId, areaCode, limit },
   { user }
 ) => {
   await accessRequired(user, organizationId, "ADMIN");
-  const org = await cacheableData.organization.load(organizationId);
+  const organization = await cacheableData.organization.load(organizationId);
   if (
-    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true }) &&
-    !getConfig("PHONE_INVENTORY", org, { truthy: true })
+    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", organization, {
+      truthy: true
+    }) &&
+    !getConfig("PHONE_INVENTORY", organization, { truthy: true })
   ) {
     throw new Error("Phone inventory management is not enabled");
   }
-  const serviceName = getConfig("DEFAULT_SERVICE", org);
-  const service = serviceMap[serviceName];
+  const serviceName = getServiceNameFromOrganization(organization);
+  const service = getServiceFromOrganization(organization);
   if (!service || !service.hasOwnProperty("buyNumbersInAreaCode")) {
     throw new Error(
       `Service ${serviceName} does not support phone number buying`
     );
   }
-
-  let messagingServiceSid;
-  if (addToOrganizationMessagingService) {
-    const msgSrv = JSON.parse(org.features || "{}").TWILIO_MESSAGE_SERVICE_SID;
-    if (serviceName !== "twilio" || !msgSrv) {
-      throw new Error(
-        "This organization is not configured to use its own Twilio Messaging Service"
-      );
+  const opts = {};
+  const serviceManagerResult = await processServiceManagers(
+    "onBuyPhoneNumbers",
+    organization,
+    {
+      user,
+      serviceName,
+      areaCode,
+      limit,
+      opts
     }
-    messagingServiceSid = msgSrv;
-  }
+  );
+
   return await jobRunner.dispatchJob({
     queue_name: `${organizationId}:buy_phone_numbers`,
     organization_id: organizationId,
     job_type: Jobs.BUY_PHONE_NUMBERS,
     locks_queue: false,
     payload: JSON.stringify({
-      areaCode,
-      limit,
-      messagingServiceSid
+      areaCode: serviceManagerResult.areaCode || areaCode,
+      limit: serviceManagerResult.limit || limit,
+      opts: serviceManagerResult.opts || opts
     })
   });
 };
@@ -55,15 +64,17 @@ export const deletePhoneNumbers = async (
   { user }
 ) => {
   await accessRequired(user, organizationId, "OWNER");
-  const org = await cacheableData.organization.load(organizationId);
+  const organization = await cacheableData.organization.load(organizationId);
   if (
-    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", org, { truthy: true }) &&
-    !getConfig("PHONE_INVENTORY", org, { truthy: true })
+    !getConfig("EXPERIMENTAL_PHONE_INVENTORY", organization, {
+      truthy: true
+    }) &&
+    !getConfig("PHONE_INVENTORY", organization, { truthy: true })
   ) {
     throw new Error("Phone inventory management is not enabled");
   }
-  const serviceName = getConfig("DEFAULT_SERVICE", org);
-  const service = serviceMap[serviceName];
+  const serviceName = getServiceNameFromOrganization(organization);
+  const service = getServiceFromOrganization(organization);
   if (!service || !service.hasOwnProperty("buyNumbersInAreaCode")) {
     throw new Error(
       `Service ${serviceName} does not support phone number buying`

--- a/src/server/lib/http-request.js
+++ b/src/server/lib/http-request.js
@@ -1,6 +1,7 @@
 import originalFetch from "node-fetch";
 import AbortController from "node-abort-controller";
 import { log } from "../../lib";
+import { sleep } from "../../workers/lib";
 import { v4 as uuid } from "uuid";
 
 // An HTTP client that supports timeout, retries and flexible status validation
@@ -126,7 +127,7 @@ const requestWithRetry = async (
       }
     }
     if (retryReturnError === RetryReturnError.RETRY) {
-      await setTimeout(() => {}, retryDelay());
+      await sleep(retryDelay());
       continue;
     } else if (retryReturnError === RetryReturnError.ERROR) {
       if (attempt >= retries && retries > 0) {


### PR DESCRIPTION
The goals of 11.1 are first to fix any bugs that surface from 11.0;

# Included
* [Redash](https://redash.io/) contact-loader to pull in contacts from a saved Redash query.
* #2041 bugfix: CampaignTextersForm
* #2040 bugfix: twilio config buttons
* #2052 add twilio hook to support service-manager changes to account
* #2051 allow scrub-mobile-badnums to have an optional mode
* #2049 fix re-open button to show state change in texter view
* #2046 fix buyNumbers for twilio organization-level message services

# Draft Release Notes

## v11.1

_October 2021:_ Version 11.1

11.1 is a bug-fix release.  After many changes, there were a few problems that surfaced and with the help of reporting from the community (special shoutout to Karla Bradley at NYCET and Brendan, Daniel, and Amy at State Voices).

### Bug-fixes
* Campaign Admin: Texter manual changing/adding of assigned triggered app failure
* Setting/Updating Twilio credentials in admin Settings failed
* Buying numbers for an organization's message service failed
* Clicking Re-open
* minor additions/fixes to service-managers api

### Appreciations

* [Larry Person](https://github.com/lperson), [Kathy Nguyen](https://github.com/crayolakat), [Schuyler Duveen](https://github.com/schuyler1d), Mark Houghton, everyone at NYCET and State Voices for bug reporting and testing.