### PR TITLE
scrub-mobile-badnums: fix bug always filtering out countryCode

### DIFF
--- a/src/extensions/contact-loaders/test-fakedata/index.js
+++ b/src/extensions/contact-loaders/test-fakedata/index.js
@@ -113,6 +113,10 @@ export async function processContactLoad(job, maxContacts, organization) {
     return; // bail early
   }
   const areaCodes = ["213", "323", "212", "718", "646", "661"];
+  // add a bunch more area codes
+  for (let ac = 200; ac < 1000; ac++) {
+    areaCodes.push(String(ac));
+  }
   // FUTURE -- maybe based on campaign default use 'surrounding' offsets
   const timezones = [
     "-12_1",

--- a/src/extensions/service-managers/index.js
+++ b/src/extensions/service-managers/index.js
@@ -90,5 +90,8 @@ export async function getServiceManagerData(
       ...(await sm[funcName]({ organization, ...funcArgs }))
     }))
   );
-  return resultArray;
+  return resultArray.map(r => ({
+    ...r,
+    fullyConfigured: r.fullyConfigured === undefined ? null : r.fullyConfigured
+  }));
 }

--- a/src/extensions/service-managers/scrub-bad-mobilenums/index.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/index.js
@@ -5,10 +5,10 @@ import { Jobs } from "../../../workers/job-processes";
 import { Tasks } from "../../../workers/tasks";
 import { jobRunner } from "../../job-runners";
 import { getServiceFromOrganization } from "../../service-vendors";
-/// All functions are OPTIONAL EXCEPT metadata() and const name=.
-/// DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
+// / All functions are OPTIONAL EXCEPT metadata() and const name=.
+// / DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
 
-/// TODO
+// / TODO
 // 1. contactsCount=0 should also block clicking on the lookup
 // 2. react component
 
@@ -217,79 +217,100 @@ export async function nextBatchJobLookups({
     return; // END FINSIHED
   }
 
-  // Do 100 at a time, so we don't lose our work if it dies early
-  const chunkSize = 200;
-  const chunks = _.chunk(contacts, chunkSize);
-  // maxes out in 15min for around 20K contacts, we we recycle tasks from that time.
-  const maxChunksToProcessThisTime = Math.min(
-    chunks.length,
-    Math.ceil(batchMax / chunkSize)
-  );
-  for (let i = 0; i < maxChunksToProcessThisTime; i++) {
-    const chunk = chunks[i];
-    const lookupChunk = await Promise.all(
-      chunk.map(async contact => {
-        // console.log("scrub.lookupChunk", contact);
-        const info = await serviceClient.getContactInfo({
-          organization,
-          contactNumber: contact.cell
-        });
-        // console.log('scrub-bad-mobilenums lookup result', info);
-        return {
-          ...contact,
-          ...info
-        };
-      })
+  try {
+    // Do 200 at a time, so we don't lose our work if it dies early
+    const chunkSize = 200;
+    const chunks = _.chunk(contacts, chunkSize);
+    // maxes out in 15min for around 20K contacts, we we recycle tasks from that time.
+    const maxChunksToProcessThisTime = Math.min(
+      chunks.length,
+      Math.ceil(batchMax / chunkSize)
     );
-    const orgContacts = lookupChunk.map(
-      ({ id, cell, status_code, carrier, lookup_name, last_error_code }) => ({
-        id,
-        organization_id: job.organization_id,
-        contact_number: cell,
-        status_code,
-        last_error_code,
-        lookup_name,
-        carrier,
-        last_lookup: new Date()
-      })
-    );
-    const newLookups = orgContacts.filter(data => !data.id && data.status_code);
-    // only send service for new lookups since old ones might have services connected to user_numbers
-    const service = serviceClient.getMetadata().name;
-    if (newLookups.length) {
-      await r.knex("organization_contact").insert(
-        newLookups.map(d => ({
-          ...d,
-          service,
-          id: undefined
-        }))
+    for (let i = 0; i < maxChunksToProcessThisTime; i++) {
+      const chunk = chunks[i];
+      const lookupChunk = await Promise.all(
+        chunk.map(async contact => {
+          // console.log("scrub.lookupChunk", contact);
+          const info = await serviceClient.getContactInfo({
+            organization,
+            contactNumber: contact.cell
+          });
+          // console.log('scrub-bad-mobilenums lookup result', info);
+          return {
+            ...contact,
+            ...info
+          };
+        })
       );
+      const orgContacts = lookupChunk.map(
+        ({ id, cell, status_code, carrier, lookup_name, last_error_code }) => ({
+          id,
+          organization_id: job.organization_id,
+          contact_number: cell,
+          status_code,
+          last_error_code,
+          lookup_name,
+          carrier,
+          last_lookup: new Date()
+        })
+      );
+      const newLookups = orgContacts.filter(
+        data => !data.id && data.status_code
+      );
+      // only send service for new lookups since old ones might have services connected to user_numbers
+      const service = serviceClient.getMetadata().name;
+      if (newLookups.length) {
+        await r.knex("organization_contact").insert(
+          newLookups.map(d => ({
+            ...d,
+            service,
+            id: undefined
+          }))
+        );
+      }
+
+      const orgContactUpdates = orgContacts.filter(
+        data => data.id && data.status_code
+      );
+      if (orgContactUpdates.length) {
+        await r
+          .knex("organization_contact")
+          .insert(orgContactUpdates)
+          .onConflict("organization_id", "contact_number")
+          .merge();
+      }
+      await r
+        .knex("job_request")
+        .where("id", job.id)
+        .update({
+          status: Math.ceil((100 * (i * chunkSize + 1)) / lookupCount)
+        });
     }
 
-    const orgContactUpdates = orgContacts.filter(
-      data => data.id && data.status_code
+    await jobRunner.dispatchTask(Tasks.EXTENSION_TASK, {
+      method: "nextBatchJobLookups",
+      path: "extensions/service-managers/scrub-bad-mobilenums",
+      job,
+      lookupCount,
+      steps: steps + 1,
+      lastCount: contacts.length
+    });
+  } catch (err) {
+    // this at least clears the job from the client and gives us a clue in logs
+    // TODO: how to send error message to client?
+    console.log(
+      "scrub-bad-mobilenums job FAILED",
+      job.id,
+      job.organization_id,
+      contacts.length,
+      lastCount,
+      steps
     );
-    if (orgContactUpdates.length) {
-      await r
-        .knex("organization_contact")
-        .insert(orgContactUpdates)
-        .onConflict("organization_id", "contact_number")
-        .merge();
-    }
     await r
       .knex("job_request")
       .where("id", job.id)
-      .update({ status: Math.ceil((100 * (i * chunkSize + 1)) / lookupCount) });
+      .delete();
   }
-
-  await jobRunner.dispatchTask(Tasks.EXTENSION_TASK, {
-    method: "nextBatchJobLookups",
-    path: "extensions/service-managers/scrub-bad-mobilenums",
-    job,
-    lookupCount,
-    steps: steps + 1,
-    lastCount: contacts.length
-  });
 }
 
 export async function onCampaignUpdateSignal({

--- a/src/extensions/service-managers/scrub-bad-mobilenums/index.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/index.js
@@ -25,8 +25,8 @@ export const metadata = () => ({
   supportsCampaignConfig: true
 });
 
-const lookupQuery = (campaignId, organizationId) =>
-  r
+const lookupQuery = (campaignId, organizationId) => {
+  let query = r
     .knex("campaign_contact")
     .leftJoin(
       "organization_contact",
@@ -40,8 +40,9 @@ const lookupQuery = (campaignId, organizationId) =>
     .where(function() {
       this.whereNull("status_code") // no entry
         .orWhere("status_code", 0); // unknown status
-    })
-    .where(function() {
+    });
+  if (!getConfig("OPTOUTS_SHARE_ALL_ORGS")) {
+    query = query.where(function() {
       // FUTURE: consider leveraging other organizations
       // challenge 1: might get contact_number dupes w/o it
       // challenge 2: need to insert instead of update
@@ -50,6 +51,9 @@ const lookupQuery = (campaignId, organizationId) =>
         organizationId
       );
     });
+  }
+  return query;
+};
 
 const deleteLandlineContacts = campaignId =>
   r

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -627,6 +627,19 @@ export async function getContactInfo({
     // console.log('twilio.getContactInfo', contactInfo, phoneNumber);
     return contactInfo;
   } catch (err) {
+    /* oddly, very rarely Twilio returns a 404 error message
+       when looking up what appears to be a valid number
+       https://www.twilio.com/docs/api/errors/20404
+
+       the message appears like:
+      "The requested resource /PhoneNumbers/{cell} was not found"
+
+      the assumption is that this must not be a real number if it can't
+      even be validated, so we should just delete it
+
+      try it with this number:
+      https://lookups.twilio.com/v1/PhoneNumbers/+15056405970?Type=carrier
+    */
     if (err.message.includes("was not found")) {
       return {
         ...contactInfo,


### PR DESCRIPTION
## Description

Current code never matched countryCode because contactInfo never had it -- it should have been compared on phoneNumber! yikes

Also shares across orgs when OPTOUTS_SHARE_ALL_ORGS is set.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
