### PR TITLE
Default twilioDialogOpen value for Dialog open prop

### DIFF
--- a/src/extensions/service-vendors/twilio/react-component.js
+++ b/src/extensions/service-vendors/twilio/react-component.js
@@ -26,7 +26,7 @@ export class OrgConfig extends React.Component {
     super(props);
     const { accountSid, authToken, messageServiceSid } = this.props.config;
     const allSet = accountSid && authToken && messageServiceSid;
-    this.state = { allSet, ...this.props.config };
+    this.state = { allSet, ...this.props.config, twilioDialogOpen: false };
     this.props.onAllSetChanged(allSet);
   }
 


### PR DESCRIPTION
# Fixes #2060

## Description

An error was showing because `import Dialog from "@material-ui/core/Dialog";` requires a default open state and throws an error when given undefined. This just sets a default value in the constructor of the component.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
