### PR TITLE
document --no-optional-dependencies for aws lambda

### DIFF
--- a/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
+++ b/docs/HOWTO_DEPLOYING_AWS_LAMBDA.md
@@ -165,7 +165,7 @@ Do **NOT** set:
 - `STATIC_BASE_URL`: You will need to upload your ASSETS_DIR to an S3 bucket (or other static file site) and then set this to something like: `"https://s3.amazonaws.com/YOUR_BUCKET_AND_PATH/"` (don't forget the trailing '/')
 - `S3_STATIC_PATH`: This will be the aws s3 upload path that corresponds to STATIC_BASE_URL. So if `STATIC_BASE_URL=https://s3.amazon.com/spoke.example.com/static/` then `S3_STATIC_PATH=s3://spoke.example.com/static/` You will also need a ~/.s3cfg file that has the s3 upload credentials. See `package.json`'s postinstall script and more specifically `prod-static-upload`.
 - `"LAMBDA_DEBUG_LOG": "1",`: (ONLY FOR DEBUGGING) This will send more details of requests to the CloudWatch log. However, it will include the full request details, e.g. so do not use this in production.
-- `"ASSETS_DIR_PREBUILT"`: should be the absolute path (run `pwd` from command line) of your spoke deploy directory suffixed by `/build/client`
+- `"ASSETS_DIR_PREBUILT"`: should be the absolute path (run `pwd` from command line) of your spoke deploy directory suffixed by `/build/client`. This complements `--no-optional-dependencies` claudia deploy arguments (below) so that the client-only libraries are not included in the packaged server file (which would be too big for a Lambda upload)
 
 For large production environments, it might also be a good idea to add `"SUPPRESS_MIGRATIONS": "1"` so that any time you update the schema with a version upgrade,
 you can manually run the migration (see below) rather than it accidentally trigger on multiple lambdas at once.
@@ -177,7 +177,7 @@ However, some environment variables like GOOGLE_SECRET for script import can be 
 another file (does not have to be located in your Spoke project directory) in the same format as production-env.json
 with GOOGLE_SECRET as a top-level JSON key (currently, no other variables are supported from this file).
 
-Then set the variable in production-env.json CONFIG_FILE: "/absolute/path/to/configfile.json" -- during deployment (below),
+Then set the variable in production-env.json `CONFIG_FILE`: "/absolute/path/to/configfile.json" -- during deployment (below),
 this file will be copied into the lambda function zip file and get deployed with the rest of the code.
 
 ## Deploy
@@ -195,6 +195,7 @@ $ AWS_PROFILE=[your_profile_nickname] claudia create --handler lambda.handler \
     --role SpokeOnLambda \
     --use-s3-bucket [YOUR_S3_BUCKET] \
     --memory 512 --timeout 300
+    --no-optional-dependencies
 ```
 
 **Notes**:
@@ -261,4 +262,5 @@ $ ASSETS_DIR=./build/client/assets ASSETS_MAP_FILE=assets.json NODE_ENV=producti
 $ AWS_PROFILE=[your_profile_nickname] claudia update \
     --use-s3-bucket [YOUR_S3_BUCKET] \
     --set-env-from-json ./production-env.json
+    --no-optional-dependencies
 ```

--- a/webpack/config.js
+++ b/webpack/config.js
@@ -21,8 +21,8 @@ const plugins = [
   )
 ];
 const jsxLoaders = [{ loader: "babel-loader" }];
-const assetsDir = process.env.ASSETS_DIR;
-const assetMapFile = process.env.ASSETS_MAP_FILE;
+const assetsDir = process.env.ASSETS_DIR || "./build/client/assets";
+const assetMapFile = process.env.ASSETS_MAP_FILE || "assets.json";
 const outputFile = DEBUG ? "[name].js" : "[name].[hash].js";
 console.log("Configuring Webpack with", {
   assetsDir,


### PR DESCRIPTION
which was in release notes to 11.0 but not carried over to docs
