### PR TITLE
Additional scrub / service manager fixes 

### DIFF
--- a/src/extensions/service-managers/index.js
+++ b/src/extensions/service-managers/index.js
@@ -90,5 +90,8 @@ export async function getServiceManagerData(
       ...(await sm[funcName]({ organization, ...funcArgs }))
     }))
   );
-  return resultArray;
+  return resultArray.map(r => ({
+    ...r,
+    fullyConfigured: r.fullyConfigured === undefined ? null : r.fullyConfigured
+  }));
 }

--- a/src/extensions/service-managers/scrub-bad-mobilenums/index.js
+++ b/src/extensions/service-managers/scrub-bad-mobilenums/index.js
@@ -5,10 +5,10 @@ import { Jobs } from "../../../workers/job-processes";
 import { Tasks } from "../../../workers/tasks";
 import { jobRunner } from "../../job-runners";
 import { getServiceFromOrganization } from "../../service-vendors";
-/// All functions are OPTIONAL EXCEPT metadata() and const name=.
-/// DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
+// / All functions are OPTIONAL EXCEPT metadata() and const name=.
+// / DO NOT IMPLEMENT ANYTHING YOU WILL NOT USE -- the existence of a function adds behavior/UI (sometimes costly)
 
-/// TODO
+// / TODO
 // 1. contactsCount=0 should also block clicking on the lookup
 // 2. react component
 
@@ -217,79 +217,100 @@ export async function nextBatchJobLookups({
     return; // END FINSIHED
   }
 
-  // Do 100 at a time, so we don't lose our work if it dies early
-  const chunkSize = 200;
-  const chunks = _.chunk(contacts, chunkSize);
-  // maxes out in 15min for around 20K contacts, we we recycle tasks from that time.
-  const maxChunksToProcessThisTime = Math.min(
-    chunks.length,
-    Math.ceil(batchMax / chunkSize)
-  );
-  for (let i = 0; i < maxChunksToProcessThisTime; i++) {
-    const chunk = chunks[i];
-    const lookupChunk = await Promise.all(
-      chunk.map(async contact => {
-        // console.log("scrub.lookupChunk", contact);
-        const info = await serviceClient.getContactInfo({
-          organization,
-          contactNumber: contact.cell
-        });
-        // console.log('scrub-bad-mobilenums lookup result', info);
-        return {
-          ...contact,
-          ...info
-        };
-      })
+  try {
+    // Do 200 at a time, so we don't lose our work if it dies early
+    const chunkSize = 200;
+    const chunks = _.chunk(contacts, chunkSize);
+    // maxes out in 15min for around 20K contacts, we we recycle tasks from that time.
+    const maxChunksToProcessThisTime = Math.min(
+      chunks.length,
+      Math.ceil(batchMax / chunkSize)
     );
-    const orgContacts = lookupChunk.map(
-      ({ id, cell, status_code, carrier, lookup_name, last_error_code }) => ({
-        id,
-        organization_id: job.organization_id,
-        contact_number: cell,
-        status_code,
-        last_error_code,
-        lookup_name,
-        carrier,
-        last_lookup: new Date()
-      })
-    );
-    const newLookups = orgContacts.filter(data => !data.id && data.status_code);
-    // only send service for new lookups since old ones might have services connected to user_numbers
-    const service = serviceClient.getMetadata().name;
-    if (newLookups.length) {
-      await r.knex("organization_contact").insert(
-        newLookups.map(d => ({
-          ...d,
-          service,
-          id: undefined
-        }))
+    for (let i = 0; i < maxChunksToProcessThisTime; i++) {
+      const chunk = chunks[i];
+      const lookupChunk = await Promise.all(
+        chunk.map(async contact => {
+          // console.log("scrub.lookupChunk", contact);
+          const info = await serviceClient.getContactInfo({
+            organization,
+            contactNumber: contact.cell
+          });
+          // console.log('scrub-bad-mobilenums lookup result', info);
+          return {
+            ...contact,
+            ...info
+          };
+        })
       );
+      const orgContacts = lookupChunk.map(
+        ({ id, cell, status_code, carrier, lookup_name, last_error_code }) => ({
+          id,
+          organization_id: job.organization_id,
+          contact_number: cell,
+          status_code,
+          last_error_code,
+          lookup_name,
+          carrier,
+          last_lookup: new Date()
+        })
+      );
+      const newLookups = orgContacts.filter(
+        data => !data.id && data.status_code
+      );
+      // only send service for new lookups since old ones might have services connected to user_numbers
+      const service = serviceClient.getMetadata().name;
+      if (newLookups.length) {
+        await r.knex("organization_contact").insert(
+          newLookups.map(d => ({
+            ...d,
+            service,
+            id: undefined
+          }))
+        );
+      }
+
+      const orgContactUpdates = orgContacts.filter(
+        data => data.id && data.status_code
+      );
+      if (orgContactUpdates.length) {
+        await r
+          .knex("organization_contact")
+          .insert(orgContactUpdates)
+          .onConflict("organization_id", "contact_number")
+          .merge();
+      }
+      await r
+        .knex("job_request")
+        .where("id", job.id)
+        .update({
+          status: Math.ceil((100 * (i * chunkSize + 1)) / lookupCount)
+        });
     }
 
-    const orgContactUpdates = orgContacts.filter(
-      data => data.id && data.status_code
+    await jobRunner.dispatchTask(Tasks.EXTENSION_TASK, {
+      method: "nextBatchJobLookups",
+      path: "extensions/service-managers/scrub-bad-mobilenums",
+      job,
+      lookupCount,
+      steps: steps + 1,
+      lastCount: contacts.length
+    });
+  } catch (err) {
+    // this at least clears the job from the client and gives us a clue in logs
+    // TODO: how to send error message to client?
+    console.log(
+      "scrub-bad-mobilenums job FAILED",
+      job.id,
+      job.organization_id,
+      contacts.length,
+      lastCount,
+      steps
     );
-    if (orgContactUpdates.length) {
-      await r
-        .knex("organization_contact")
-        .insert(orgContactUpdates)
-        .onConflict("organization_id", "contact_number")
-        .merge();
-    }
     await r
       .knex("job_request")
       .where("id", job.id)
-      .update({ status: Math.ceil((100 * (i * chunkSize + 1)) / lookupCount) });
+      .delete();
   }
-
-  await jobRunner.dispatchTask(Tasks.EXTENSION_TASK, {
-    method: "nextBatchJobLookups",
-    path: "extensions/service-managers/scrub-bad-mobilenums",
-    job,
-    lookupCount,
-    steps: steps + 1,
-    lastCount: contacts.length
-  });
 }
 
 export async function onCampaignUpdateSignal({

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -627,6 +627,19 @@ export async function getContactInfo({
     // console.log('twilio.getContactInfo', contactInfo, phoneNumber);
     return contactInfo;
   } catch (err) {
+    /* oddly, very rarely Twilio returns a 404 error message
+       when looking up what appears to be a valid number
+       https://www.twilio.com/docs/api/errors/20404
+
+       the message appears like:
+      "The requested resource /PhoneNumbers/{cell} was not found"
+
+      the assumption is that this must not be a real number if it can't
+      even be validated, so we should just delete it
+
+      try it with this number:
+      https://lookups.twilio.com/v1/PhoneNumbers/+15056405970?Type=carrier
+    */
     if (err.message.includes("was not found")) {
       return {
         ...contactInfo,


### PR DESCRIPTION
# Fixes

1. Turns out I had to roll back the recent deployment of 11.1 this patch because some campaigns were being sent `fullyConfigured: undefined` from the server causing an error. Our GraphQL settings prevent undefined values being sent to the client so I transformed `undefined` to `null` and this resolved this issue. Maybe there's a deeper reason this was happening specific to WFP's configuration, but I wasn't able to find it.

2. If the scrub job fails delete the job. Still not great user feedback but at least it doesn't appear to be hanging/working, and there's a failure log on the server.

3. I discovered a _very_ edge-case situation where a specific phone number returned a 404 "not found" error from the Twilio API. Left unhandled, the campaign could not proceed without deleting that campaign contact from the db. In this case it makes sense to just delete the phone number because if there's something about it that causes Twilio to choke on it even just attempting validation, I figure it's probably not textable.