### PR TITLE
Parse campaign timezone offsets

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -734,19 +734,21 @@ describe("ngpvan", () => {
     });
 
     it("calls failedContactLoad", async () => {
-      handleFailedContactLoad(job, payload, "fake_message");
-
-      expect(jobs.failedContactLoad.mock.calls).toEqual([
-        [
-          job,
-          null,
-          job.payload,
-          {
-            errors: ["fake_message"],
-            ...payload
-          }
-        ]
-      ]);
+      try {
+        await handleFailedContactLoad(job, payload, "fake_message");
+      } catch (err) {
+        expect(jobs.failedContactLoad.mock.calls).toEqual([
+          [
+            job,
+            null,
+            job.payload,
+            {
+              errors: ["fake_message"],
+              ...payload
+            }
+          ]
+        ]);
+      }
     });
   });
 

--- a/__test__/lambda.test.js
+++ b/__test__/lambda.test.js
@@ -1,5 +1,5 @@
 import { handler } from "../lambda.js";
-import { setupTest, cleanupTest } from "./test_helpers";
+import { cleanupTest } from "./test_helpers";
 
 beforeAll(async () => {
   await cleanupTest();
@@ -9,8 +9,8 @@ afterAll(
   global.DATABASE_SETUP_TEARDOWN_TIMEOUT
 );
 
-describe("AWS Lambda", async () => {
-  test("completes request to lambda", () => {
+describe("AWS Lambda", () => {
+  test("completes request to lambda", async () => {
     const fakeEvent = {
       resource: "/{proxy+}",
       path: "/",
@@ -51,21 +51,26 @@ describe("AWS Lambda", async () => {
       },
       isBase64Encoded: false
     };
-    handler(
-      fakeEvent,
-      {
-        succeed: response => {
-          expect(response.statusCode).toBe(200);
-          expect(response.headers["content-type"]).toBe(
-            "text/html; charset=utf-8"
-          );
-          // console.log('context.succeed response', response)
+
+    try {
+      await handler(
+        fakeEvent,
+        {
+          succeed: response => {
+            expect(response.statusCode).toBe(200);
+            expect(response.headers["content-type"]).toBe(
+              "text/html; charset=utf-8"
+            );
+            // console.log('context.succeed response', response)
+          }
+        },
+        (err, res) => {
+          console.log("result returned through callback", err, res);
         }
-      },
-      (err, res) => {
-        console.log("result returned through callback", err, res);
-      }
-    );
+      );
+    } catch (err) {
+      console.error(err);
+    }
     // console.log('lambda server', result)
   });
 });

--- a/__test__/lambda.test.js
+++ b/__test__/lambda.test.js
@@ -1,13 +1,4 @@
 import { handler } from "../lambda.js";
-import { cleanupTest } from "./test_helpers";
-
-beforeAll(async () => {
-  await cleanupTest();
-}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
-afterAll(
-  async () => await cleanupTest(),
-  global.DATABASE_SETUP_TEARDOWN_TIMEOUT
-);
 
 describe("AWS Lambda", () => {
   test("completes request to lambda", async () => {

--- a/__test__/lib/timezones.test.js
+++ b/__test__/lib/timezones.test.js
@@ -966,6 +966,41 @@ describe("test getOffsets", () => {
     expect(invalid_offsets_returned[12]).toBe("-11_0");
     expect(invalid_offsets_returned[13]).toBe("10_0");
   });
+
+  it("works for campaign offsets", () => {
+    MockDate.set("2018-02-01T17:00:00.000Z");
+    let offsets_returned = getOffsets(makeConfig(10, 12, true), [
+      "-12_1",
+      "-11_0",
+      "-5_1",
+      "-4_1",
+      "0_0",
+      "5_0",
+      "10_0",
+      ""
+    ]);
+    expect(offsets_returned).toHaveLength(2);
+
+    let valid_offsets_returned = offsets_returned[0];
+    expect(valid_offsets_returned).toHaveLength(2);
+    expect(valid_offsets_returned[0]).toBe("0_1");
+    expect(valid_offsets_returned[1]).toBe("0_0");
+
+    let invalid_offsets_returned = offsets_returned[1];
+    expect(invalid_offsets_returned).toHaveLength(12);
+    expect(invalid_offsets_returned[0]).toBe("-12_1");
+    expect(invalid_offsets_returned[1]).toBe("-11_1");
+    expect(invalid_offsets_returned[2]).toBe("-5_1");
+    expect(invalid_offsets_returned[3]).toBe("-4_1");
+    expect(invalid_offsets_returned[4]).toBe("5_1");
+    expect(invalid_offsets_returned[5]).toBe("10_1");
+    expect(invalid_offsets_returned[6]).toBe("-12_0");
+    expect(invalid_offsets_returned[7]).toBe("-11_0");
+    expect(invalid_offsets_returned[8]).toBe("-5_0");
+    expect(invalid_offsets_returned[9]).toBe("-4_0");
+    expect(invalid_offsets_returned[10]).toBe("5_0");
+    expect(invalid_offsets_returned[11]).toBe("10_0");
+  });
 });
 
 describe("test getContactTimezone", () => {

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -187,9 +187,11 @@ export class ContactController extends React.Component {
       // console.log('getContactData length', newIndex, getIds.length)
       this.setState({ loading: true });
       const contactData = await this.props.loadContacts(getIds);
-      const {
-        data: { getAssignmentContacts }
-      } = contactData;
+      let getAssignmentContacts;
+      if (contactData && contactData.data) {
+        getAssignmentContacts = contactData.data.getAssignmentContacts;
+      }
+
       if (getAssignmentContacts) {
         const newContactData = {};
         getAssignmentContacts.forEach((c, i) => {

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -217,9 +217,13 @@ export const getOffsets = (config, campaignOffsets) => {
   // campaignOffsets is an array of strings. E.g.: ['-5_1', ...]. Convert this
   // to an array of ints to make it consistent with ALL_OFFSETS
   const offsets = campaignOffsets
-    ? campaignOffsets.map(offset => {
-        return parseInt(offset.split("_", 1)[0]);
-      })
+    ? [
+        ...new Set(
+          campaignOffsets.map(offset => {
+            return parseInt(offset.split("_", 1)[0]);
+          })
+        )
+      ]
     : ALL_OFFSETS;
   const valid = [];
   const invalid = [];

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -214,16 +214,19 @@ export function convertOffsetsToStrings(offsetArray) {
 }
 
 export const getOffsets = (config, campaignOffsets) => {
-  // TODO: campaignOffsetes will sometimes have an array of e.g. ['-5_1', ...]
-  // future we should split that out and then only process the dst/offset cases passed in
-  const offsets = /*campaignOffsets || */ ALL_OFFSETS;
+  // campaignOffsets is an array of strings. E.g.: ['-5_1', ...]. Convert this
+  // to an array of ints to make it consistent with ALL_OFFSETS
+  const offsets =
+    campaignOffsets.map(offset => {
+      return parseInt(offset.split("_", 1)[0]);
+    }) || ALL_OFFSETS;
   const valid = [];
   const invalid = [];
 
   const dst = [true, false];
   dst.forEach(hasDST =>
     offsets.forEach(offset => {
-      if (offset) {
+      if (offset === 0 || offset) {
         if (isBetweenTextingHours({ offset, hasDST }, config)) {
           valid.push([offset, hasDST]);
         } else {

--- a/src/lib/timezones.js
+++ b/src/lib/timezones.js
@@ -216,10 +216,11 @@ export function convertOffsetsToStrings(offsetArray) {
 export const getOffsets = (config, campaignOffsets) => {
   // campaignOffsets is an array of strings. E.g.: ['-5_1', ...]. Convert this
   // to an array of ints to make it consistent with ALL_OFFSETS
-  const offsets =
-    campaignOffsets.map(offset => {
-      return parseInt(offset.split("_", 1)[0]);
-    }) || ALL_OFFSETS;
+  const offsets = campaignOffsets
+    ? campaignOffsets.map(offset => {
+        return parseInt(offset.split("_", 1)[0]);
+      })
+    : ALL_OFFSETS;
   const valid = [];
   const invalid = [];
 

--- a/src/server/seeds/seed-zip-codes.js
+++ b/src/server/seeds/seed-zip-codes.js
@@ -5,7 +5,12 @@ import fs from "fs";
 
 export async function seedZipCodes() {
   log.info("Checking if zip code is needed");
-  const hasZip = await r.getCount(r.knex("zip_code").limit(1));
+  let hasZip;
+  try {
+    hasZip = await r.getCount(r.knex("zip_code").limit(1));
+  } catch (err) {
+    return log.warn("zip_code table doesn't exist!");
+  }
 
   if (!hasZip) {
     log.info("Starting to seed zip codes");


### PR DESCRIPTION
## Description

If there are campaign timezone offsets (e.g.: in the test-fakedata contact loader), process these offsets and determine whether the offsets are valid or invalid timezones. Without this code, contacts with a timezone offset that isn't defined in the `ALL_OFFSETS` constant aren't processed and won't be textable.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
