### PR TITLE
Fixes for #2069

### DIFF
--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -103,7 +103,8 @@ export const postMessageSave = async ({
       // but this can relieve a lot of database pressure
       noContactUpdate: true,
       contact,
-      organization
+      organization,
+      user: null // If this is auto-optout, there is no user happening.
     });
   }
 };

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -1191,6 +1191,7 @@ const rootMutations = {
         contact.campaign_id
       );
       const { assignmentId, reason } = optOut;
+      const organization = await Organization.get(campaign.organization_id);
       await cacheableData.optOut.save({
         cell: contact.cell,
         campaignContactId,
@@ -1198,7 +1199,9 @@ const rootMutations = {
         assignmentId,
         campaign,
         noReply,
-        contact
+        contact,
+        user,
+        organization
       });
       console.log(
         "createOptOut post save",

--- a/src/server/models/cacheable_queries/opt-out.js
+++ b/src/server/models/cacheable_queries/opt-out.js
@@ -140,6 +140,7 @@ const optOutCache = {
     noContactUpdate,
     noReply,
     contact,
+    user,
     organization // not always present
   }) => {
     const organizationId = campaign.organization_id;
@@ -184,7 +185,7 @@ const optOutCache = {
       const org =
         organization || organizationCache.load(campaign.organization_id);
       await processServiceManagers("onOptOut", org, {
-        contact: newContact,
+        contact,
         campaign,
         user,
         noReply,


### PR DESCRIPTION
# Fixes #2069 

## Description

This fixes the issues with `cacheableData.optOut.save`. The undefined variable `newContact` has been removed, and the value for `user` in `onOptOut` (part of Spoke's service managers) is now given a meaningful value. One side effect is that the argument for `cacheableData.optOut.save` expands from:

```
  save: async ({
    cell,
    campaignContactId,
    campaign, // not necessarily a full campaign object
    assignmentId,
    reason,
    noContactUpdate,
    noReply,
    contact,
    organization // not always present
  })
```

To:

```
  save: async ({
    cell,
    campaignContactId,
    campaign, // not necessarily a full campaign object
    assignmentId,
    reason,
    noContactUpdate,
    noReply,
    contact,
    user,
    organization // not always present
  })
```

But that seems to be necessary by the logic of the method.


# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
