### PR TITLE
Twilio Account Switching

### DIFF
--- a/src/extensions/service-managers/index.js
+++ b/src/extensions/service-managers/index.js
@@ -5,6 +5,10 @@ export function getServiceManagers(organization) {
   const configuredHandlers = getConfig(handlerKey, organization);
   const enabledHandlers =
     (configuredHandlers && configuredHandlers.split(",")) || [];
+  const orgService = getConfig("service", organization);
+  const twilioAccountSwitchingIdx = enabledHandlers.indexOf(
+    "twilio-account-switching"
+  );
 
   if (
     typeof configuredHandlers === "undefined" &&
@@ -15,6 +19,15 @@ export function getServiceManagers(organization) {
     )
   ) {
     enabledHandlers.push("per-campaign-messageservices");
+  }
+
+  // Disable Twilio Account Switching if organization service is defined as something else besides "twilio"
+  if (
+    twilioAccountSwitchingIdx > -1 &&
+    orgService !== undefined &&
+    orgService != "twilio"
+  ) {
+    enabledHandlers.splice(twilioAccountSwitchingIdx, 1);
   }
 
   const handlers = [];

--- a/src/extensions/service-managers/twilio-account-switching/index.js
+++ b/src/extensions/service-managers/twilio-account-switching/index.js
@@ -12,7 +12,7 @@ export const metadata = () => ({
   displayName: "Twilio Accounts",
   description: "Add, delete, and edit Twilio accounts",
   canSpendMoney: false,
-  moneySpendingOperations: ["onCampaignStart"],
+  moneySpendingOperations: [],
   supportsOrgConfig: true,
   supportsCampaignConfig: true
 });

--- a/src/extensions/service-managers/twilio-account-switching/index.js
+++ b/src/extensions/service-managers/twilio-account-switching/index.js
@@ -126,7 +126,7 @@ export async function onOrganizationUpdateSignal({
     await accessRequired(user, organization.id, "OWNER", true);
     for (let i = 0; i < orgChanges.features.MULTI_TWILIO.length; i++) {
       orgChanges.features.MULTI_TWILIO[i].authToken = await convertSecret(
-        "MULTI_TWILIO_AUTH_" + orgChanges.features.MULTI_TWILIO[i].accounSid,
+        "MULTI_TWILIO_AUTH_" + orgChanges.features.MULTI_TWILIO[i].accountSid,
         organization,
         orgChanges.features.MULTI_TWILIO[i].authToken
       );

--- a/src/extensions/service-managers/twilio-account-switching/index.js
+++ b/src/extensions/service-managers/twilio-account-switching/index.js
@@ -1,0 +1,233 @@
+import { accessRequired } from "../../../server/api/errors";
+import { getFeatures } from "../../../server/api/lib/config";
+import { r } from "../../../server/models";
+import { getSecret, convertSecret } from "../../secret-manager";
+
+let orgChanges, orgFeatures;
+let version = 1;
+
+export const name = "twilio-account-switching";
+
+export const metadata = () => ({
+  displayName: "Twilio Accounts",
+  description: "Add, delete, and edit Twilio accounts",
+  canSpendMoney: false,
+  moneySpendingOperations: ["onCampaignStart"],
+  supportsOrgConfig: true,
+  supportsCampaignConfig: true
+});
+
+export async function onMessageSend({
+  message,
+  contact,
+  organization,
+  campaign
+}) {
+  const campaignTwilioAccount = _getCampaignTwilioAccount(
+    campaign,
+    ({ accountSid, authToken, id, messageServiceSids }) => ({
+      accountSid,
+      authToken,
+      id,
+      messageServiceSids
+    }),
+    organization
+  );
+
+  if (Number.isInteger(campaignTwilioAccount.id)) {
+    // Split message service SIDs into array
+    const messageServiceSids = campaignTwilioAccount.messageServiceSids
+      .replace(/\s/g, "")
+      .split(",");
+
+    return {
+      twilioAccountSwitching: {
+        twilioAccountSwitchingCreds: {
+          accountSid: campaignTwilioAccount.accountSid,
+          authToken: await getSecret(
+            `MULTI_TWILIO_AUTH_${campaignTwilioAccount.accountSid}`,
+            campaignTwilioAccount.authToken,
+            organization
+          )
+        }
+      },
+      messageservice_sid:
+        messageServiceSids[
+          Math.floor(Math.random() * messageServiceSids.length)
+        ] // Get random message service SId
+    };
+  }
+}
+
+export async function getCampaignData({
+  organization,
+  campaign,
+  user,
+  loaders,
+  fromCampaignStatsPage
+}) {
+  // MUST NOT RETURN SECRETS!
+  // called both from edit and stats contexts: editMode==true for edit page
+  if (!fromCampaignStatsPage) {
+    const campaignTwilioAccount = _getCampaignTwilioAccount(
+      campaign,
+      ({ friendlyName, id }) => ({ friendlyName, id }),
+      organization
+    );
+
+    return {
+      data: {
+        campaignTwilioAccount: campaignTwilioAccount,
+        multiTwilio: _getCampaignAccounts(organization)
+      },
+      fullyConfigured: Number.isInteger(campaignTwilioAccount.id) ? true : false
+    };
+  }
+}
+
+export async function onCampaignUpdateSignal({
+  organization,
+  campaign,
+  updateData
+}) {
+  const changes = {
+    features: getFeatures(campaign)
+  };
+
+  changes.features.multiTwilioId = updateData;
+  await r
+    .knex("campaign")
+    .where("id", campaign.id)
+    .update(changes);
+
+  return {
+    data: {
+      multiTwilio: _getCampaignAccounts(organization)
+    },
+    fullyConfigured: true,
+    unArchiveable: false
+  };
+}
+
+export async function getOrganizationData({ organization }) {
+  const accounts = getFeatures(organization).MULTI_TWILIO;
+
+  return {
+    data: {
+      multiTwilio: accounts ? _obscureSensitiveInformation(accounts) : []
+    },
+    fullyConfigured: null
+  };
+}
+
+export async function onOrganizationUpdateSignal({
+  organization,
+  user,
+  updateData
+}) {
+  let saveDisabled = false;
+
+  if (updateData == "save") {
+    // Save changes to organization features
+    await accessRequired(user, organization.id, "OWNER", true);
+    for (let i = 0; i < orgChanges.features.MULTI_TWILIO.length; i++) {
+      orgChanges.features.MULTI_TWILIO[i].authToken = await convertSecret(
+        "MULTI_TWILIO_AUTH_" + orgChanges.features.MULTI_TWILIO[i].accounSid,
+        organization,
+        orgChanges.features.MULTI_TWILIO[i].authToken
+      );
+    }
+    await r
+      .knex("organization")
+      .where("id", organization.id)
+      .update(orgChanges);
+    orgFeatures = JSON.stringify(getFeatures(organization).MULTI_TWILIO);
+    saveDisabled = true;
+  } else {
+    // Make changes to organization features
+    if (!orgChanges) {
+      orgChanges = {
+        features: getFeatures(organization)
+      };
+      orgFeatures = JSON.stringify(getFeatures(organization).MULTI_TWILIO);
+    }
+
+    orgChanges.features.MULTI_TWILIO = updateData.map(account => {
+      const existingAccount = orgChanges.features.MULTI_TWILIO
+        ? orgChanges.features.MULTI_TWILIO.find(e => {
+            return e.id == account.id;
+          })
+        : null;
+
+      if (existingAccount && existingAccount.authToken != "<Encrypted>") {
+        account.authToken = existingAccount.authToken;
+      }
+
+      return account;
+    });
+
+    if (orgFeatures == JSON.stringify(updateData)) {
+      saveDisabled = true;
+    }
+  }
+  version++;
+
+  return {
+    data: {
+      multiTwilio: _obscureSensitiveInformation(
+        orgChanges.features.MULTI_TWILIO
+      ),
+      saveDisabled: saveDisabled,
+      version: version
+    },
+    fullyConfigured: true
+  };
+}
+
+/**
+ * @param {Object} organization
+ * @returns Array of Twilio account friendlyId and id subsets
+ */
+function _getCampaignAccounts(organization) {
+  const accounts = getFeatures(organization).MULTI_TWILIO;
+
+  return accounts
+    ? accounts.map(account => {
+        return (({ friendlyName, id }) => ({ friendlyName, id }))(account);
+      })
+    : [];
+}
+
+/**
+ * @param {Object} campaign
+ * @param {function} keys Defines keys to return in account obj
+ * @param {Object} organization
+ * @returns Twilio account currently select for the campaign
+ */
+function _getCampaignTwilioAccount(campaign, keys, organization) {
+  let campaignTwilioAccount;
+  const multiTwilioId = getFeatures(campaign).multiTwilioId;
+
+  if (multiTwilioId) {
+    const account = getFeatures(organization).MULTI_TWILIO.find(
+      account => account.id == multiTwilioId
+    );
+
+    campaignTwilioAccount = account ? keys(account) : {};
+  } else {
+    campaignTwilioAccount = {};
+  }
+
+  return campaignTwilioAccount;
+}
+
+/**
+ * @param {Array} accounts
+ * @returns Obscured auth tokens
+ */
+function _obscureSensitiveInformation(accounts) {
+  return JSON.parse(JSON.stringify(accounts)).map(account => {
+    account.authToken = "<Encrypted>";
+    return account;
+  });
+}

--- a/src/extensions/service-managers/twilio-account-switching/react-component.js
+++ b/src/extensions/service-managers/twilio-account-switching/react-component.js
@@ -1,0 +1,356 @@
+/* eslint no-console: 0 */
+import PropTypes from "prop-types";
+import React from "react";
+import Form from "react-formal";
+import * as yup from "yup";
+import GSForm from "../../../components/forms/GSForm";
+import GSTextField from "../../../components/forms/GSTextField";
+import GSSubmitButton from "../../../components/forms/GSSubmitButton";
+
+import Button from "@material-ui/core/Button";
+import List from "@material-ui/core/List";
+import ListItem from "@material-ui/core/ListItem";
+import ListItemSecondaryAction from "@material-ui/core/ListItemSecondaryAction";
+import ListItemText from "@material-ui/core/ListItemText";
+import Divider from "@material-ui/core/Divider";
+import DeleteIcon from "@material-ui/icons/Delete";
+import CreateIcon from "@material-ui/icons/Create";
+import IconButton from "@material-ui/core/IconButton";
+
+import FormHelperText from "@material-ui/core/FormHelperText";
+import Select from "@material-ui/core/Select";
+import MenuItem from "@material-ui/core/MenuItem";
+
+import { css } from "aphrodite";
+
+export class OrgConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      acountId: "",
+      formButtonText: "",
+      saveDisabled: true,
+      showForm: false
+    };
+  }
+
+  componentDidUpdate(previousProps) {
+    // Allow user to save after making account changes
+    if (
+      previousProps.serviceManagerInfo.data.version !=
+      this.props.serviceManagerInfo.data.version
+    ) {
+      this.setState({
+        saveDisabled: this.props.serviceManagerInfo.data.saveDisabled,
+        showForm: false
+      });
+    }
+  }
+
+  showAddButton() {
+    if (!this.state.showForm) {
+      return (
+        <div>
+          <Button
+            color="secondary"
+            startIcon={<CreateIcon color="secondary" />}
+            onClick={() =>
+              this.setState({
+                accountId: null,
+                showForm: true,
+                formButtonText: "Add account"
+              })
+            }
+          >
+            Add new account
+          </Button>
+        </div>
+      );
+    }
+  }
+
+  showAddForm() {
+    const handleCloseAddForm = () => {
+      this.setState({
+        showForm: false
+      });
+    };
+
+    if (this.state.showForm) {
+      const modelSchema = yup.object({
+        friendlyName: yup.string().required(),
+        accountSid: yup.string().required(),
+        authToken: yup.string().required(),
+        messageServiceSids: yup.string().required()
+      });
+
+      return (
+        <div
+          className={css(this.props.styles.formContainer)}
+          style={{
+            marginTop: 15
+          }}
+        >
+          <div className={css(this.props.styles.form)}>
+            <GSForm
+              ref={this.form}
+              schema={modelSchema}
+              onSubmit={x => {
+                let newVals;
+                if (this.state.accountId) {
+                  // Edit account
+                  x.id = this.state.accountId;
+                  newVals = this.props.serviceManagerInfo.data.multiTwilio.map(
+                    accountToEdit => {
+                      if (accountToEdit.id == this.state.accountId) {
+                        return x;
+                      }
+                      return accountToEdit;
+                    }
+                  );
+                } else {
+                  // New account
+                  if (
+                    this.props.serviceManagerInfo.data.multiTwilio &&
+                    this.props.serviceManagerInfo.data.multiTwilio.length
+                  ) {
+                    x.id =
+                      this.props.serviceManagerInfo.data.multiTwilio.at(-1).id +
+                      1;
+                  } else {
+                    x.id = 1;
+                  }
+
+                  if (this.props.serviceManagerInfo.data.multiTwilio) {
+                    newVals = this.props.serviceManagerInfo.data.multiTwilio.concat(
+                      x
+                    );
+                  } else {
+                    newVals = [x];
+                  }
+                }
+                this.props.onSubmit(newVals);
+              }}
+              defaultValue={
+                (this.props.serviceManagerInfo.data.multiTwilio &&
+                  this.props.serviceManagerInfo.data.multiTwilio.find(
+                    res => res.id === this.state.accountId
+                  )) || {
+                  accountSid: "",
+                  authToken: "",
+                  friendlyName: "",
+                  messageServiceSids: ""
+                }
+              }
+            >
+              <Form.Field
+                as={GSTextField}
+                label="Friendly Name"
+                name="friendlyName"
+                fullWidth
+              />
+              <Form.Field
+                as={GSTextField}
+                label="Account SID"
+                name="accountSid"
+                fullWidth
+              />
+              <Form.Field
+                as={GSTextField}
+                label="Auth Token"
+                name="authToken"
+                fullWidth
+              />
+              <Form.Field
+                as={GSTextField}
+                label="Message Service SID(s)"
+                name="messageServiceSids"
+                fullWidth
+              />
+              <div className={css(this.props.styles.buttonRow)}>
+                <Form.Submit
+                  as={GSSubmitButton}
+                  label={this.state.formButtonText}
+                  className={css(this.props.styles.button)}
+                />
+                <Button variant="contained" onClick={handleCloseAddForm}>
+                  Cancel
+                </Button>
+              </div>
+            </GSForm>
+          </div>
+        </div>
+      );
+    }
+  }
+
+  listItems(accounts) {
+    const listItems = accounts.map(account => (
+      <ListItem key={account.id}>
+        <ListItemText>
+          <div className={css(this.props.styles.title)}>
+            {account.friendlyName}
+          </div>
+        </ListItemText>
+        <ListItemSecondaryAction>
+          <IconButton
+            onClick={() =>
+              this.setState({
+                accountId: account.id,
+                showForm: true,
+                formButtonText: "Edit Account"
+              })
+            }
+          >
+            <CreateIcon />
+          </IconButton>
+          <IconButton
+            onClick={() => {
+              this.props.onSubmit(
+                this.props.serviceManagerInfo.data.multiTwilio
+                  .map(accountToDelete => {
+                    if (accountToDelete.id === account.id) {
+                      return null;
+                    }
+                    return accountToDelete;
+                  })
+                  .filter(ele => ele !== null)
+              );
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </ListItemSecondaryAction>
+      </ListItem>
+    ));
+    return listItems;
+  }
+
+  render() {
+    const accounts = this.props.serviceManagerInfo.data.multiTwilio;
+    const list =
+      !accounts || accounts.length === 0 ? null : (
+        <List>
+          {this.listItems(accounts)}
+          <Divider />
+        </List>
+      );
+
+    return (
+      <div>
+        <GSForm
+          onSubmit={() => {
+            this.props.onSubmit("save");
+          }}
+        >
+          {list}
+          {this.showAddButton()}
+          <Form.Submit
+            as={GSSubmitButton}
+            disabled={this.state.saveDisabled}
+            label="Save"
+            style={this.props.inlineStyles.dialogButton}
+          />
+        </GSForm>
+        {this.showAddForm()}
+      </div>
+    );
+  }
+}
+
+OrgConfig.propTypes = {
+  serviceManagerInfo: PropTypes.object,
+  inlineStyles: PropTypes.object,
+  styles: PropTypes.object,
+  onSubmit: PropTypes.func
+};
+
+export class CampaignConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      campaignTwilioAccountId:
+        this.props.serviceManagerInfo.data.campaignTwilioAccount.id || "",
+      hasError: false,
+      saveDisabled: true
+    };
+  }
+
+  render() {
+    return (
+      <div>
+        {!this.props.campaign.isStarted ? (
+          <div>
+            Select the Twilio account to use for this campaign.
+            <GSForm
+              onSubmit={() => {
+                this.setState({
+                  hasError: !Number.isInteger(
+                    this.state.campaignTwilioAccountId
+                  )
+                });
+                if (!this.state.hasError) {
+                  this.props.onSubmit(
+                    this.props.serviceManagerInfo.data.multiTwilio.find(
+                      account => {
+                        return account.id == this.state.campaignTwilioAccountId;
+                      }
+                    ).id
+                  );
+                  this.setState({
+                    saveDisabled: true
+                  });
+                }
+              }}
+            >
+              <Select
+                error={this.state.hasError}
+                name="twilioAccount"
+                value={this.state.campaignTwilioAccountId}
+                onChange={event => {
+                  this.setState({
+                    campaignTwilioAccountId: event.target.value,
+                    saveDisabled: false
+                  });
+                }}
+                fullWidth
+              >
+                {this.props.serviceManagerInfo.data.multiTwilio.map(account => (
+                  <MenuItem key={account.id} value={account.id}>
+                    {account.friendlyName}
+                  </MenuItem>
+                ))}
+              </Select>
+              {this.state.hasError && (
+                <FormHelperText>
+                  Twilio Account is a required field
+                </FormHelperText>
+              )}
+              <Form.Submit
+                as={GSSubmitButton}
+                disabled={this.state.saveDisabled}
+                label="Save"
+              />
+            </GSForm>
+          </div>
+        ) : (
+          <div>
+            Twilio account used for this campaign:{" "}
+            {
+              this.props.serviceManagerInfo.data.campaignTwilioAccount
+                .friendlyName
+            }
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+CampaignConfig.propTypes = {
+  user: PropTypes.object,
+  campaign: PropTypes.object,
+  serviceManagerInfo: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -41,11 +41,11 @@ export const getMetadata = () => ({
 });
 
 export const getTwilio = async organization => {
-  const { authToken, accountSid } = await getMessageServiceConfig(
-    "twilio",
-    organization,
-    { obscureSensitiveInformation: false }
-  );
+  const { authToken, accountSid } =
+    organization.twilioAccountSwitchingCreds ||
+    (await getMessageServiceConfig("twilio", organization, {
+      obscureSensitiveInformation: false
+    }));
   if (accountSid && authToken) {
     return twilioLibrary.Twilio(accountSid, authToken); // eslint-disable-line new-cap
   }
@@ -238,7 +238,9 @@ export async function sendMessage({
   campaign,
   serviceManagerData
 }) {
-  const twilio = await exports.getTwilio(organization);
+  const twilio = await exports.getTwilio(
+    serviceManagerData.twilioAccountSwitching || organization
+  );
   const APITEST = /twilioapitest/.test(message.text);
   if (!twilio && !APITEST) {
     log.warn(

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -239,7 +239,8 @@ export async function sendMessage({
   serviceManagerData
 }) {
   const twilio = await exports.getTwilio(
-    serviceManagerData.twilioAccountSwitching || organization
+    (serviceManagerData && serviceManagerData.twilioAccountSwitching) ||
+      organization
   );
   const APITEST = /twilioapitest/.test(message.text);
   if (!twilio && !APITEST) {


### PR DESCRIPTION
## Description

Allows for users to switch between Twilio accounts per campaign.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [ ] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
