### PR TITLE
Fixes 2098 -- need to click twice on save button after assigning contacts to texter

### DIFF
--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -89,7 +89,7 @@ const styles = StyleSheet.create({
     backgroundColor: theme.colors.lightGray
   },
   input: {
-    width: 50,
+    width: 70,
     paddingLeft: 0,
     paddingRight: 0,
     marginRight: 10,

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -118,7 +118,7 @@ class TexterInputs extends GSFormField {
       contactsCount,
       displayName,
       onChange,
-      onDelete,
+      onRemove,
       texter,
       useDynamicAssignment
     } = this.props;
@@ -146,7 +146,7 @@ class TexterInputs extends GSFormField {
           <TextField
             {...dataTest("texterAssignment")}
             value={texter.assignment.needsMessageCount}
-            hintText="Contacts"
+            placeholder="Contacts"
             fullWidth
             onChange={({ target: { value } }) => {
               const {
@@ -156,7 +156,7 @@ class TexterInputs extends GSFormField {
               onChange({
                 id,
                 maxContacts,
-                contactsCount: value
+                needsMessageCount: value
               });
             }}
           />
@@ -172,24 +172,24 @@ class TexterInputs extends GSFormField {
         {useDynamicAssignment ? (
           <div className={css(styles.input)}>
             <TextField
-              hintText="Max"
+              placeholder="Max"
               fullWidth
               onChange={({ target: { value } }) => {
                 const {
                   id,
-                  assignment: { contactsCount: texterContactsCount }
+                  assignment: { needsMessageCount }
                 } = this.props.texter;
                 onChange({
                   id,
                   maxContacts: value,
-                  contactsCount: texterContactsCount
+                  needsMessageCount
                 });
               }}
             />
           </div>
         ) : null}
         <div className={css(styles.removeButton)}>
-          <IconButton onClick={onDelete(this.props.texter.id)}>
+          <IconButton onClick={() => onRemove(this.props.texter.id)}>
             <DeleteIcon />
           </IconButton>
         </div>
@@ -205,7 +205,7 @@ export default class CampaignTextersForm extends React.Component {
     snackbarMessage: ""
   };
 
-  onTexterChange = ({ id, maxContacts, contactsCount }) => {
+  onTexterChange = ({ id, maxContacts, needsMessageCount }) => {
     const existingFormValues = this.formValues();
     const newFormValues = {
       ...existingFormValues
@@ -214,12 +214,37 @@ export default class CampaignTextersForm extends React.Component {
     newFormValues.texters = newFormValues.texters.map(texter => {
       if (texter.id === id) {
         const newTexter = { ...texter };
+        newTexter.assignment = { ...texter.assignment };
         newTexter.assignment.maxContacts = maxContacts;
-        newTexter.assignment.needsMessageCount = contactsCount;
+        newTexter.assignment.needsMessageCount = needsMessageCount;
         return newTexter;
       }
       return texter;
     });
+
+    this.onChange(newFormValues, id);
+  };
+
+  onTexterRemove = id => {
+    const existingFormValues = this.formValues();
+    const newFormValues = {
+      ...existingFormValues
+    };
+
+    const newTexters = newFormValues.texters.map(texter => {
+      if (texter.id === id) {
+        if (!texter.assignment.messagedCount) {
+          return null;
+        }
+        const newTexter = { ...texter };
+        newTexter.assignment = { ...texter.assignment };
+        newTexter.assignment.needsMessageCount = 0;
+        return newTexter;
+      }
+      return texter;
+    });
+
+    newFormValues.texters = newTexters.filter(texter => texter);
 
     this.onChange(newFormValues, id);
   };
@@ -461,7 +486,7 @@ export default class CampaignTextersForm extends React.Component {
           useDynamicAssignment={this.props.useDynamicAssignment}
           contactsCount={this.formValues().contactsCount}
           onChange={this.onTexterChange}
-          onDelete={() => {}}
+          onRemove={this.onTexterRemove}
           displayName={this.getDisplayName(texter.id)}
         />
       );

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -113,9 +113,9 @@ const inlineStyles = {
 };
 
 export default class CampaignTextersForm extends React.Component {
+  focusedTexterId = null; // eslint-disable-line react/sort-comp
   state = {
     autoSplit: false,
-    focusedTexterId: null,
     snackbarOpen: false,
     snackbarMessage: ""
   };
@@ -378,12 +378,8 @@ export default class CampaignTextersForm extends React.Component {
               name={`texters[${index}].assignment.needsMessageCount`}
               hintText="Contacts"
               fullWidth
-              onFocus={() => this.setState({ focusedTexterId: texter.id })}
-              onBlur={() =>
-                this.setState({
-                  focusedTexterId: null
-                })
-              }
+              onFocus={() => (this.focusedTexterId = texter.id)}
+              onBlur={() => (this.focusedTexterId = null)}
             />
           </div>
           <div className={css(styles.slider)}>
@@ -401,12 +397,8 @@ export default class CampaignTextersForm extends React.Component {
                 name={`texters[${index}].assignment.maxContacts`}
                 hintText="Max"
                 fullWidth
-                onFocus={() => this.setState({ focusedTexterId: texter.id })}
-                onBlur={() =>
-                  this.setState({
-                    focusedTexterId: null
-                  })
-                }
+                onFocus={() => (this.focusedTexterId = texter.id)}
+                onBlur={() => (this.focusedTexterId = null)}
               />
             </div>
           ) : null}
@@ -421,7 +413,7 @@ export default class CampaignTextersForm extends React.Component {
                 if (messagedCount === 0) {
                   newFormValues.texters.splice(index, 1);
                 } else {
-                  await this.setState({ focusedTexterId: texter.id });
+                  this.focusedTexterId = texter.id;
                   newFormValues.texters[index] = {
                     ...texter,
                     assignment: {

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -122,7 +122,7 @@ export default class CampaignTextersForm extends React.Component {
 
   onChange = formValues => {
     const existingFormValues = this.formValues();
-    const changedTexterId = this.state.focusedTexterId;
+    const changedTexterId = this.focusedTexterId;
     const newFormValues = {
       ...formValues
     };
@@ -147,8 +147,8 @@ export default class CampaignTextersForm extends React.Component {
         newTexter.assignment.needsMessageCount,
         10
       );
-      let convertedMaxContacts = !!newTexter.assignment.maxContacts
-        ? parseInt(newTexter.assignment.maxContacts)
+      const convertedMaxContacts = !!newTexter.assignment.maxContacts
+        ? parseInt(newTexter.assignment.maxContacts, 10)
         : null;
 
       if (isNaN(convertedNeedsMessageCount)) {
@@ -214,7 +214,7 @@ export default class CampaignTextersForm extends React.Component {
       // 3. if we don't have extraTexterCapacity and auto-split is on, then fill the texters with assignments
       const factor = 1;
       let index = 0;
-      let skipsByIndex = new Array(newFormValues.texters.length).fill(0);
+      const skipsByIndex = new Array(newFormValues.texters.length).fill(0);
       if (newFormValues.texters.length === 1) {
         const messagedCount =
           newFormValues.texters[0].assignment.contactsCount -
@@ -445,7 +445,6 @@ export default class CampaignTextersForm extends React.Component {
   };
 
   render() {
-    const { organizationUuid, campaignId } = this.props;
     const assignedContacts = this.formValues().texters.reduce(
       (prev, texter) => prev + texter.assignment.contactsCount,
       0

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -151,7 +151,7 @@ class TexterInputs extends GSFormField {
         <div className={css(styles.input)}>
           <TextField
             {...dataTest("texterAssignment")}
-            {...(needsMessageCount && { value: needsMessageCount })}
+            value={needsMessageCount || ""}
             placeholder="Contacts"
             fullWidth
             onChange={({ target: { value } }) => {
@@ -174,7 +174,7 @@ class TexterInputs extends GSFormField {
         {useDynamicAssignment ? (
           <div className={css(styles.input)}>
             <TextField
-              {...(maxContacts && { value: maxContacts })}
+              value={maxContacts || ""}
               placeholder="Max"
               fullWidth
               onChange={({ target: { value } }) => {
@@ -481,6 +481,7 @@ export default class CampaignTextersForm extends React.Component {
       return (
         <TexterInputs
           name={`texters[${index}].assignment.needsMessageCount`}
+          key={`texters[${index}].assignment.needsMessageCount`}
           texter={texter}
           useDynamicAssignment={this.props.useDynamicAssignment}
           contactsCount={this.formValues().contactsCount}

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -172,6 +172,7 @@ class TexterInputs extends GSFormField {
         {useDynamicAssignment ? (
           <div className={css(styles.input)}>
             <TextField
+              value={texter.assignment.maxContacts}
               placeholder="Max"
               fullWidth
               onChange={({ target: { value } }) => {

--- a/src/components/CampaignTextersForm.jsx
+++ b/src/components/CampaignTextersForm.jsx
@@ -119,15 +119,21 @@ class TexterInputs extends GSFormField {
       displayName,
       onChange,
       onRemove,
-      texter,
+      texter: {
+        id,
+        assignment: {
+          contactsCount: texterContactsCount,
+          needsMessageCount,
+          maxContacts
+        }
+      },
       useDynamicAssignment
     } = this.props;
-    const messagedCount =
-      texter.assignment.contactsCount - texter.assignment.needsMessageCount;
+    const messagedCount = texterContactsCount - needsMessageCount;
     return (
       <div
         {...dataTest("texterRow")}
-        key={texter.id}
+        key={id}
         className={css(styles.texterRow)}
       >
         <div className={css(styles.leftSlider)}>
@@ -145,14 +151,10 @@ class TexterInputs extends GSFormField {
         <div className={css(styles.input)}>
           <TextField
             {...dataTest("texterAssignment")}
-            value={texter.assignment.needsMessageCount}
+            {...(needsMessageCount && { value: needsMessageCount })}
             placeholder="Contacts"
             fullWidth
             onChange={({ target: { value } }) => {
-              const {
-                id,
-                assignment: { maxContacts }
-              } = this.props.texter;
               onChange({
                 id,
                 maxContacts,
@@ -164,7 +166,7 @@ class TexterInputs extends GSFormField {
         <div className={css(styles.slider)}>
           <Slider
             maxValue={contactsCount}
-            value={texter.assignment.needsMessageCount}
+            value={needsMessageCount}
             color={theme.colors.green}
             direction={0}
           />
@@ -172,14 +174,10 @@ class TexterInputs extends GSFormField {
         {useDynamicAssignment ? (
           <div className={css(styles.input)}>
             <TextField
-              value={texter.assignment.maxContacts}
+              {...(maxContacts && { value: maxContacts })}
               placeholder="Max"
               fullWidth
               onChange={({ target: { value } }) => {
-                const {
-                  id,
-                  assignment: { needsMessageCount }
-                } = this.props.texter;
                 onChange({
                   id,
                   maxContacts: value,
@@ -190,7 +188,7 @@ class TexterInputs extends GSFormField {
           </div>
         ) : null}
         <div className={css(styles.removeButton)}>
-          <IconButton onClick={() => onRemove(this.props.texter.id)}>
+          <IconButton onClick={() => onRemove(id)}>
             <DeleteIcon />
           </IconButton>
         </div>


### PR DESCRIPTION
# Fixes #2098 

## Description

Calling `setState` in an `onBlur` handler seemed to prevent an `onFocus` handler from getting called. 

I refactored `CampaignTexterForm` so each texter row is an instance of a new component, `TexterInputs`. Each row manages its own state, so when one of the `TextFields` updates it calls on change with the id of the texter it represents. Managing current texter by handling `onBlur` and `onFocus` and setting the state caused unnecessary renders and seemed brittle.


# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
