### PR TITLE
Fix default auto optout documentation

### DIFF
--- a/docs/REFERENCE-best-practices-conformance-messaging.md
+++ b/docs/REFERENCE-best-practices-conformance-messaging.md
@@ -49,12 +49,12 @@ Additionally, you can enable a Spoke setting MESSAGE_HANDLERS=auto-optout (not d
 
 The default set of phrases that automatically opt-out the contact include (single words are activated only if the text begins with that word):
 
-   stop, unsubscribe, cancel, end, quit, remove me, remove my name, take me off the list, lose my number, delete my number
+   stop, remove me, remove my name, take me off the list, lose my number, don't contact me, delete my number, I opt out, stop2quit, stopall, unsubscribe, cancel, end, quit
 
 
 You can modify what triggers an auto-optout by preparing JSON in the following structure and then running in a node.js prompt Buffer.from(jsonString).toString(‘base64’) and setting the value of AUTO_OPTOUT_REGEX_LIST_BASE64 to that. (make sure it is valid json and valid regular expressions!).  The default setting is:
     ```
-    [{"regex": "^\\\\s*stop\\\\b|\\\\bremove me\\\\s*$|remove my name|\\\\btake me off th\\\\w+ list|\\\\blose my number|delete my number|^\\\\s*unsubscribe\\\\s*$|^\\\\s*cancel\\\\s*$|^\\\\s*end\\\\s*$|^\\\\s*quit\\\\s*$", "reason": "stop"}]
+    [{"regex": "^\\s*stop\\b|\\bremove me\\s*$|remove my name|\\btake me off th\\w+ list|\\blose my number|don\\W?t contact me|delete my number|I opt out|stop2quit|stopall|^\\s*unsubscribe\\s*$|^\\s*cancel\\s*$|^\\s*end\\s*$|^\\s*quit\\s*$", "reason": "stop"}]
     ```
 
 You can add multiple objects in the array to match different reasons. The default Spoke install does not include all the phrases MoveOn uses to trigger an auto-optout -- we also include offensive/hostile phrases, for example.


### PR DESCRIPTION
## Description


The documentation for the auto-output message handler is outdated. The default auto output regex list is defined here:
https://github.com/MoveOnOrg/Spoke/blob/06f743fff9d9764a5f900ee561eccda9ecd82dc2/src/extensions/message-handlers/auto-optout/index.js#L4-L5

When decoding the string from Base64 (e.g.: use this https://www.base64decode.org/), you will see that the value differs from what is currently in the documentation. This PR updates the documentation to reflect what the actual values of the default auto output regex list is.

The only file change related to this PR is in `docs/REFERENCE-best-practices-conformance-messaging.md`

I pulled in the other file changes from [this PR](https://github.com/MoveOnOrg/Spoke/pull/2090) to allow the automated GitHub Actions tests to run successfully.

# Checklist:

- [ ] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
