### PR TITLE
automatic TexterTodoList updates (when we have redis+postgres) (Fixes #207)

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -734,19 +734,21 @@ describe("ngpvan", () => {
     });
 
     it("calls failedContactLoad", async () => {
-      handleFailedContactLoad(job, payload, "fake_message");
-
-      expect(jobs.failedContactLoad.mock.calls).toEqual([
-        [
-          job,
-          null,
-          job.payload,
-          {
-            errors: ["fake_message"],
-            ...payload
-          }
-        ]
-      ]);
+      try {
+        await handleFailedContactLoad(job, payload, "fake_message");
+      } catch (err) {
+        expect(jobs.failedContactLoad.mock.calls).toEqual([
+          [
+            job,
+            null,
+            job.payload,
+            {
+              errors: ["fake_message"],
+              ...payload
+            }
+          ]
+        ]);
+      }
     });
   });
 

--- a/__test__/extensions/service-vendors/twilio.test.js
+++ b/__test__/extensions/service-vendors/twilio.test.js
@@ -33,6 +33,7 @@ describe("twilio", () => {
   let testCampaign;
   let testTexterUser;
   let testContacts;
+  let testAssignment;
   let organizationId;
   let organizationId2;
   let dbCampaignContact;
@@ -95,7 +96,11 @@ describe("twilio", () => {
     testCampaign = await createCampaign(testAdminUser, testOrganization);
     testContacts = await createContacts(testCampaign, 100);
     testTexterUser = await createTexter(testOrganization);
-    await assignTexter(testAdminUser, testTexterUser, testCampaign);
+    testAssignment = await assignTexter(
+      testAdminUser,
+      testTexterUser,
+      testCampaign
+    );
     dbCampaignContact = await getCampaignContact(testContacts[0].id);
     await createScript(testAdminUser, testCampaign);
     await startCampaign(testAdminUser, testCampaign);
@@ -277,6 +282,10 @@ describe("twilio", () => {
     const campaign = await cacheableData.campaign.load(testCampaign.id, {
       forceLoad: true
     });
+    // load assignment into cache
+    const assn = await cacheableData.assignment.load(
+      testAssignment.data.editCampaign.assignments[0].id
+    );
     await cacheableData.campaignContact.loadMany(campaign, org, {});
     queryLog = [];
     await cacheableData.message.save({

--- a/__test__/lambda.test.js
+++ b/__test__/lambda.test.js
@@ -1,5 +1,5 @@
 import { handler } from "../lambda.js";
-import { setupTest, cleanupTest } from "./test_helpers";
+import { cleanupTest } from "./test_helpers";
 
 beforeAll(async () => {
   await cleanupTest();
@@ -9,8 +9,8 @@ afterAll(
   global.DATABASE_SETUP_TEARDOWN_TIMEOUT
 );
 
-describe("AWS Lambda", async () => {
-  test("completes request to lambda", () => {
+describe("AWS Lambda", () => {
+  test("completes request to lambda", async () => {
     const fakeEvent = {
       resource: "/{proxy+}",
       path: "/",
@@ -51,21 +51,26 @@ describe("AWS Lambda", async () => {
       },
       isBase64Encoded: false
     };
-    handler(
-      fakeEvent,
-      {
-        succeed: response => {
-          expect(response.statusCode).toBe(200);
-          expect(response.headers["content-type"]).toBe(
-            "text/html; charset=utf-8"
-          );
-          // console.log('context.succeed response', response)
+
+    try {
+      await handler(
+        fakeEvent,
+        {
+          succeed: response => {
+            expect(response.statusCode).toBe(200);
+            expect(response.headers["content-type"]).toBe(
+              "text/html; charset=utf-8"
+            );
+            // console.log('context.succeed response', response)
+          }
+        },
+        (err, res) => {
+          console.log("result returned through callback", err, res);
         }
-      },
-      (err, res) => {
-        console.log("result returned through callback", err, res);
-      }
-    );
+      );
+    } catch (err) {
+      console.error(err);
+    }
     // console.log('lambda server', result)
   });
 });

--- a/__test__/lambda.test.js
+++ b/__test__/lambda.test.js
@@ -1,13 +1,4 @@
 import { handler } from "../lambda.js";
-import { cleanupTest } from "./test_helpers";
-
-beforeAll(async () => {
-  await cleanupTest();
-}, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
-afterAll(
-  async () => await cleanupTest(),
-  global.DATABASE_SETUP_TEARDOWN_TIMEOUT
-);
 
 describe("AWS Lambda", () => {
   test("completes request to lambda", async () => {

--- a/__test__/server/models/cacheable_queries/user.test.js
+++ b/__test__/server/models/cacheable_queries/user.test.js
@@ -1,0 +1,147 @@
+import {
+  createUser,
+  createTexter,
+  createInvite,
+  createOrganization,
+  setupTest,
+  cleanupTest
+} from "../../../test_helpers";
+
+import { r, cacheableData } from "../../../../src/server/models";
+
+describe("cacheable_queries.user", async () => {
+  let queryLog;
+  let testAdminUser;
+  let testInvite;
+  let testOrganization;
+  let testTexterUser;
+  let organizationId;
+  function spokeDbListener(data) {
+    if (
+      queryLog &&
+      (!queryLog.length ||
+        queryLog[queryLog.length - 1].__knexQueryUid != data.__knexQueryUid)
+    ) {
+      queryLog.push(data);
+    }
+  }
+
+  beforeEach(async () => {
+    await setupTest();
+    testAdminUser = await createUser({ auth0_id: "admin_auth_data" });
+    testInvite = await createInvite();
+    testOrganization = await createOrganization(testAdminUser, testInvite);
+    testTexterUser = await createTexter(testOrganization, {
+      auth0_id: "texter1_auth_data"
+    });
+    organizationId = testOrganization.data.createOrganization.id;
+
+    if (r.redis) {
+      await r.redis.flushdb();
+    }
+    queryLog = [];
+    r.knex.on("query", spokeDbListener);
+  });
+  afterEach(async () => {
+    await cleanupTest();
+  });
+  it("userHasRole texter has texter", async () => {
+    const texterRole = await cacheableData.user.userHasRole(
+      testTexterUser,
+      organizationId,
+      "TEXTER"
+    );
+    expect(texterRole).toBeTruthy();
+  });
+  it("userHasRole texter does not have texter for another org", async () => {
+    const texterRoleNo = await cacheableData.user.userHasRole(
+      testTexterUser,
+      organizationId + 100,
+      "TEXTER"
+    );
+    expect(texterRoleNo).not.toBeTruthy();
+  });
+  it("userHasRole texter does not have admin", async () => {
+    const adminRoleNo = await cacheableData.user.userHasRole(
+      testTexterUser,
+      organizationId,
+      "ADMIN"
+    );
+    expect(adminRoleNo).not.toBeTruthy();
+  });
+  it("userHasRole owner has admin", async () => {
+    const adminRoleYes = await cacheableData.user.userHasRole(
+      testAdminUser,
+      organizationId,
+      "ADMIN"
+    );
+    expect(adminRoleYes).toBeTruthy();
+  });
+  it("userOrgs", async () => {
+    const a = await cacheableData.user.userOrgs(testAdminUser.id, "ADMIN");
+    const b = await cacheableData.user.userOrgs(testAdminUser.id, "TEXTER");
+    const c = await cacheableData.user.userOrgs(testTexterUser.id, "TEXTER");
+    const d = await cacheableData.user.userOrgs(testTexterUser.id, "TEXTER");
+    expect(a).toEqual([
+      { id: 1, role: "OWNER", name: "Testy test organization" }
+    ]);
+    expect(b).toEqual([
+      { id: 1, name: "Testy test organization", role: "OWNER" }
+    ]);
+    expect(c).toEqual([
+      { id: 1, role: "TEXTER", name: "Testy test organization" }
+    ]);
+    expect(d).toEqual([
+      { id: 1, name: "Testy test organization", role: "TEXTER" }
+    ]);
+  });
+  it("orgRoles", async () => {
+    const a = await cacheableData.user.orgRoles(
+      testAdminUser.id,
+      organizationId
+    );
+    const b = await cacheableData.user.orgRoles(
+      testAdminUser.id,
+      organizationId + 100
+    );
+    const c = await cacheableData.user.orgRoles(
+      testTexterUser.id,
+      organizationId
+    );
+    expect(a).toEqual([
+      "SUSPENDED",
+      "TEXTER",
+      "VETTED_TEXTER",
+      "SUPERVOLUNTEER",
+      "ADMIN",
+      "OWNER"
+    ]);
+    expect(b).toEqual([]);
+    expect(c).toEqual(["SUSPENDED", "TEXTER"]);
+  });
+  it("addNotification is cleared with get", async () => {
+    const start = await cacheableData.user.getAndClearNotifications(
+      testAdminUser.id
+    );
+    expect(start).toEqual([]);
+    await cacheableData.user.addNotification(testAdminUser.id, 2);
+    const next = await cacheableData.user.getAndClearNotifications(
+      testAdminUser.id
+    );
+    if (r.redis) {
+      expect(next).toEqual(["2"]);
+      const nextAfter = await cacheableData.user.getAndClearNotifications(
+        testAdminUser.id
+      );
+      expect(nextAfter).toEqual([]);
+      await cacheableData.user.addNotification(testAdminUser.id, 1);
+      await cacheableData.user.addNotification(testAdminUser.id, 4);
+      const savingTwo = await cacheableData.user.getAndClearNotifications(
+        testAdminUser.id
+      );
+      expect(savingTwo).toEqual(["1", "4"]);
+    } else {
+      expect(next).toEqual([]);
+    }
+  });
+});

--- a/__test__/server/texter.test/texter.test.js
+++ b/__test__/server/texter.test/texter.test.js
@@ -156,11 +156,12 @@ it("should be able to receive a response and reply (using fakeService)", async (
       expect.objectContaining({
         send_status: "DELIVERED",
         text: `responding to ${message.text}`,
-        user_id: testTexterUser.id,
+        user_id: null,
         contact_number: testContact.cell,
         campaign_contact_id: testContact.id
       })
     );
+    expect(dbMessage[1].is_from_contact).toBeTruthy();
   });
 
   await waitForExpect(async () => {

--- a/__test__/test_helpers.js
+++ b/__test__/test_helpers.js
@@ -454,6 +454,9 @@ export async function assignTexter(admin, user, campaign, assignments) {
   mutation editCampaign($campaignId: String!, $campaign: CampaignInput!) {
     editCampaign(id: $campaignId, campaign: $campaign) {
       id
+      assignments {
+        id
+      }
     }
   }`;
   const context = getContext({ user: admin });

--- a/src/api/user.js
+++ b/src/api/user.js
@@ -16,7 +16,8 @@ export const schema = `
     assignment(campaignId: String): Assignment
     terms: Boolean
     profileComplete(organizationId: String): Boolean
-    cacheable: Boolean
+    notifications(organizationId: String): [Assignment]
+    notifiable: Boolean
   }
 
 type UsersList {

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -187,9 +187,11 @@ export class ContactController extends React.Component {
       // console.log('getContactData length', newIndex, getIds.length)
       this.setState({ loading: true });
       const contactData = await this.props.loadContacts(getIds);
-      const {
-        data: { getAssignmentContacts }
-      } = contactData;
+      let getAssignmentContacts;
+      if (contactData && contactData.data) {
+        getAssignmentContacts = contactData.data.getAssignmentContacts;
+      }
+
       if (getAssignmentContacts) {
         const newContactData = {};
         getAssignmentContacts.forEach((c, i) => {

--- a/src/extensions/service-vendors/fakeservice/index.js
+++ b/src/extensions/service-vendors/fakeservice/index.js
@@ -73,6 +73,7 @@ export async function sendMessage({
         id: undefined,
         service_id: `mockedresponse${Math.random()}`,
         is_from_contact: true,
+        user_id: null,
         text: `responding to ${message.text}`,
         send_status: "DELIVERED",
         media

--- a/src/server/api/message.js
+++ b/src/server/api/message.js
@@ -4,20 +4,14 @@ import { Message } from "../models";
 export const resolvers = {
   Message: {
     ...mapFieldsToModel(
-      [
-        "text",
-        "userNumber",
-        "contactNumber",
-        "createdAt",
-        "isFromContact",
-        "userId"
-      ],
+      ["text", "userNumber", "contactNumber", "createdAt", "isFromContact"],
       Message
     ),
     media: msg =>
       // Sometimes it's array, sometimes string. Maybe db vs. cache?
       typeof msg.media === "string" ? JSON.parse(msg.media) : msg.media || [],
     // cached messages don't have message.id -- why bother
-    id: msg => msg.id || `fake${Math.random()}`
+    id: msg => msg.id || `fake${Math.random()}`,
+    userId: msg => msg.user_id || null
   }
 };

--- a/src/server/api/user.js
+++ b/src/server/api/user.js
@@ -174,6 +174,129 @@ export async function getUsers(
   }
 }
 
+export const getUserTodos = async (
+  user,
+  { organizationId, withOutCounts },
+  { user: loggedInUser, queryFilter }
+) => {
+  const fields = [
+    "assignment.id",
+    "assignment.campaign_id",
+    "assignment.user_id",
+    "assignment.max_contacts",
+    "assignment.created_at",
+    "assignment_feedback.feedback",
+    "assignment_feedback.is_acknowledged",
+    "assignment_feedback.creator_id",
+    "campaign.use_dynamic_assignment"
+  ];
+  let query = r
+    .knexReadOnly("assignment")
+    .join("campaign", "assignment.campaign_id", "campaign.id")
+    .leftJoin(
+      "assignment_feedback",
+      "assignment.id",
+      "assignment_feedback.assignment_id"
+    )
+    .andWhere({
+      is_started: true
+    })
+    .andWhere("assignment.user_id", user.id);
+
+  if (/texter-feedback/.test(getConfig("TEXTER_SIDEBOXES"))) {
+    query = query.whereRaw(
+      `(
+          is_archived = false
+          OR (assignment_feedback.is_acknowledged = true
+              AND assignment_feedback.complete = true)
+          )`
+    );
+  } else {
+    query.andWhere("is_archived", false);
+  }
+
+  if (organizationId) {
+    query.where("organization_id", organizationId);
+  }
+
+  if (getConfig("FILTER_DUEBY", null, { truthy: 1 })) {
+    query = query.where("campaign.due_by", ">", new Date());
+  }
+
+  if (queryFilter) {
+    query = queryFilter(query);
+  }
+
+  if (withOutCounts) {
+    return await query.select(fields);
+  } else {
+    query
+      .leftOuterJoin("campaign_contact", function() {
+        this.on("campaign_contact.assignment_id", "assignment.id").andOn(
+          "campaign_contact.is_opted_out",
+          r.knex.raw("?", [false])
+        );
+        // https://github.com/knex/knex/issues/1003#issuecomment-287302118
+      })
+      .groupBy(
+        ...fields,
+        "campaign_contact.timezone_offset",
+        "campaign_contact.message_status"
+      )
+      .select(
+        ...fields,
+        "campaign_contact.timezone_offset",
+        "campaign_contact.message_status",
+        r.knexReadOnly.raw(
+          "SUM(CASE WHEN campaign_contact.id IS NOT NULL THEN 1 ELSE 0 END) as tz_status_count"
+        )
+      );
+    const result = await query;
+    const campaignIds = result
+      .filter(a => a.use_dynamic_assignment)
+      .map(a => a.campaign_id);
+    const campaignsWithUnassigned = {};
+    let hasUnassigned = [];
+    if (campaignIds.length) {
+      hasUnassigned = await r
+        .knex("campaign_contact")
+        .where({
+          is_opted_out: false,
+          message_status: "needsMessage"
+        })
+        .whereNull("assignment_id")
+        .whereIn("campaign_id", campaignIds)
+        .select("campaign_id")
+        .groupBy("campaign_id")
+        .havingRaw("count(1) > 0");
+      hasUnassigned.forEach(c => {
+        campaignsWithUnassigned[c.campaign_id] = 1;
+      });
+    }
+    const assignments = {};
+    for (const assn of result) {
+      if (!assignments[assn.id]) {
+        assignments[assn.id] = {
+          ...assn,
+          tzStatusCounts: {}
+        };
+        if (assn.use_dynamic_assignment && campaignIds.length) {
+          assignments[assn.id].hasUnassigned =
+            campaignsWithUnassigned[assn.campaign_id] || 0;
+        }
+      }
+      if (!assignments[assn.id].tzStatusCounts[assn.message_status]) {
+        assignments[assn.id].tzStatusCounts[assn.message_status] = [];
+      }
+      assignments[assn.id].tzStatusCounts[assn.message_status].push({
+        tz: assn.timezone_offset,
+        count: assn.tz_status_count
+      });
+    }
+    return Object.values(assignments);
+  }
+};
+
 export const resolvers = {
   UsersReturn: {
     __resolveType(obj) {
@@ -250,119 +373,21 @@ export const resolvers = {
         ? rolesEqualOrLess(user.role)
         : await cacheableData.user.orgRoles(user.id, organizationId);
     },
-    todos: async (user, { organizationId, withOutCounts }) => {
-      const fields = [
-        "assignment.id",
-        "assignment.campaign_id",
-        "assignment.user_id",
-        "assignment.max_contacts",
-        "assignment.created_at",
-        "assignment_feedback.feedback",
-        "assignment_feedback.is_acknowledged",
-        "assignment_feedback.creator_id",
-        "campaign.use_dynamic_assignment"
-      ];
-      let query = r
-        .knexReadOnly("assignment")
-        .join("campaign", "assignment.campaign_id", "campaign.id")
-        .leftJoin(
-          "assignment_feedback",
-          "assignment.id",
-          "assignment_feedback.assignment_id"
-        )
-        .andWhere({
-          is_started: true
-        })
-        .andWhere("assignment.user_id", user.id);
-
-      if (/texter-feedback/.test(getConfig("TEXTER_SIDEBOXES"))) {
-        query = query.whereRaw(
-          `(
-          is_archived = false
-          OR (assignment_feedback.is_acknowledged = true
-              AND assignment_feedback.complete = true)
-          )`
-        );
-      } else {
-        query.andWhere("is_archived", false);
+    todos: async (
+      user,
+      { organizationId, withOutCounts },
+      { user: loggedInUser }
+    ) => {
+      const assignments = await getUserTodos(
+        user,
+        { organizationId, withOutCounts },
+        { user: loggedInUser }
+      );
+      if (user.id === loggedInUser.id) {
+        // clears notifications
+        await cacheableData.user.getAndClearNotifications(user.id);
       }
-
-      if (organizationId) {
-        query.where("organization_id", organizationId);
-      }
-
-      if (getConfig("FILTER_DUEBY", null, { truthy: 1 })) {
-        query = query.where("campaign.due_by", ">", new Date());
-      }
-
-      if (withOutCounts) {
-        return await query.select(fields);
-      } else {
-        query
-          .leftOuterJoin("campaign_contact", function() {
-            this.on("campaign_contact.assignment_id", "assignment.id").andOn(
-              "campaign_contact.is_opted_out",
-              r.knex.raw("?", [false])
-            );
-            // https://github.com/knex/knex/issues/1003#issuecomment-287302118
-          })
-          .groupBy(
-            ...fields,
-            "campaign_contact.timezone_offset",
-            "campaign_contact.message_status"
-          )
-          .select(
-            ...fields,
-            "campaign_contact.timezone_offset",
-            "campaign_contact.message_status",
-            r.knexReadOnly.raw(
-              "SUM(CASE WHEN campaign_contact.id IS NOT NULL THEN 1 ELSE 0 END) as tz_status_count"
-            )
-          );
-        const result = await query;
-        const campaignIds = result
-          .filter(a => a.use_dynamic_assignment)
-          .map(a => a.campaign_id);
-        const campaignsWithUnassigned = {};
-        let hasUnassigned = [];
-        if (campaignIds.length) {
-          hasUnassigned = await r
-            .knex("campaign_contact")
-            .where({
-              is_opted_out: false,
-              message_status: "needsMessage"
-            })
-            .whereNull("assignment_id")
-            .whereIn("campaign_id", campaignIds)
-            .select("campaign_id")
-            .groupBy("campaign_id")
-            .havingRaw("count(1) > 0");
-          hasUnassigned.forEach(c => {
-            campaignsWithUnassigned[c.campaign_id] = 1;
-          });
-        }
-        const assignments = {};
-        for (const assn of result) {
-          if (!assignments[assn.id]) {
-            assignments[assn.id] = {
-              ...assn,
-              tzStatusCounts: {}
-            };
-            if (assn.use_dynamic_assignment && campaignIds.length) {
-              assignments[assn.id].hasUnassigned =
-                campaignsWithUnassigned[assn.campaign_id] || 0;
-            }
-          }
-          if (!assignments[assn.id].tzStatusCounts[assn.message_status]) {
-            assignments[assn.id].tzStatusCounts[assn.message_status] = [];
-          }
-          assignments[assn.id].tzStatusCounts[assn.message_status].push({
-            tz: assn.timezone_offset,
-            count: assn.tz_status_count
-          });
-        }
-        return Object.values(assignments);
-      }
+      return assignments;
     },
     profileComplete: async (user, { organizationId }, { loaders }) => {
       const org = await loaders.organization.load(organizationId);
@@ -379,6 +404,28 @@ export const resolvers = {
       }
       return true;
     },
-    cacheable: () => false // FUTURE: Boolean(r.redis) when full assignment data is cached
+    notifications: async (user, { organizationId }, { user: loggedInUser }) => {
+      if (user.id === loggedInUser.id) {
+        // if e.g. an ADMIN can run this for a user, then the admin will 'consume' the notifications
+        // so we block this for the admin
+        const updatedAssignmentIds = await cacheableData.user.getAndClearNotifications(
+          user.id
+        );
+        if (updatedAssignmentIds.length) {
+          return getUserTodos(
+            user,
+            { organizationId },
+            {
+              user: loggedInUser,
+              queryFilter: q => q.whereIn("assignment.id", updatedAssignmentIds)
+            }
+          );
+        }
+      }
+      return [];
+    },
+    // notifiable: we need Redis to store the notifications
+    //  and Postgres to support returning() in cacheableData.campaignContact.updateStatus
+    notifiable: () => Boolean(r.redis) && r.knex.client.config.client === "pg"
   }
 };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -28,10 +28,6 @@ process.on("uncaughtException", ex => {
 });
 const DEBUG = process.env.NODE_ENV === "development";
 
-if (!getConfig("SUPPRESS_SEED_CALLS", null, { truthy: 1 })) {
-  seedZipCodes();
-}
-
 if (!getConfig("SUPPRESS_DATABASE_AUTOCREATE", null, { truthy: 1 })) {
   createTablesIfNecessary().then(didCreate => {
     // seed above won't have succeeded if we needed to create first
@@ -42,8 +38,13 @@ if (!getConfig("SUPPRESS_DATABASE_AUTOCREATE", null, { truthy: 1 })) {
       r.k.migrate.latest();
     }
   });
-} else if (!getConfig("SUPPRESS_MIGRATIONS", null, { truthy: 1 })) {
-  r.k.migrate.latest();
+} else {
+  if (!getConfig("SUPPRESS_MIGRATIONS", null, { truthy: 1 })) {
+    r.k.migrate.latest();
+  }
+  if (!getConfig("SUPPRESS_SEED_CALLS", null, { truthy: 1 })) {
+    seedZipCodes();
+  }
 }
 
 setupUserNotificationObservers();

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -2,6 +2,7 @@ import { r, Message } from "../../models";
 import campaignCache from "./campaign";
 import campaignContactCache from "./campaign-contact";
 import orgCache from "./organization";
+import userCache from "./user";
 import organizationContactCache from "./organization-contact";
 import { getMessageHandlers } from "../../../extensions/message-handlers";
 import {

--- a/src/server/models/cacheable_queries/message.js
+++ b/src/server/models/cacheable_queries/message.js
@@ -2,7 +2,6 @@ import { r, Message } from "../../models";
 import campaignCache from "./campaign";
 import campaignContactCache from "./campaign-contact";
 import orgCache from "./organization";
-import userCache from "./user";
 import organizationContactCache from "./organization-contact";
 import { getMessageHandlers } from "../../../extensions/message-handlers";
 import {

--- a/src/server/seeds/seed-zip-codes.js
+++ b/src/server/seeds/seed-zip-codes.js
@@ -5,7 +5,12 @@ import fs from "fs";
 
 export async function seedZipCodes() {
   log.info("Checking if zip code is needed");
-  const hasZip = await r.getCount(r.knex("zip_code").limit(1));
+  let hasZip;
+  try {
+    hasZip = await r.getCount(r.knex("zip_code").limit(1));
+  } catch (err) {
+    return log.warn("zip_code table doesn't exist!");
+  }
 
   if (!hasZip) {
     log.info("Starting to seed zip codes");


### PR DESCRIPTION
# Fixes #207 

## Description

For a long time, we've wanted the TodoList to refresh automatically. This PR creates the backend infrastructure and a stub implementation on the frontend for auto-updating data. Future work can do browser notifications, e.g.

Depending on Redis and Postgres, the important thing is to make sure polling does not add any database calls which wouldn't scale if we have 100s or 1000s of texters. upon an incoming message update that yields a messageStatus of 'needsResponse' we get the assignmentId and add it to a new cache key that's specific to the user. 

Note that github is saying this is 500 changed lines, but several of them are movements that are registering as adds AND removes.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [na] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
