### PR TITLE
Add GitHub workflow to automatically build Spoke images

### DIFF
--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -27,7 +27,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ghcr.io/volsweep/Spoke
+            ghcr.io/moveonorg/spoke
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}

--- a/.github/workflows/build-image.yaml
+++ b/.github/workflows/build-image.yaml
@@ -1,0 +1,60 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - 'main'
+  release:
+    types:
+      - created
+    # `created` specifies a release that is NOT specified as a prerelease
+    # `published` would include prereleases
+  workflow_dispatch:
+
+jobs:
+  docker-build:
+    name: Build Docker image and and push to GHCR
+    runs-on: ubuntu-20.04
+    steps:
+      - name: ⚙️🐳 Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: ⚙️🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: ℹ️🐳 Set metadata
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: |
+            ghcr.io/volsweep/Spoke
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=ref,event=branch
+          # type=sha     Would tag the image with `sha-blahblahblah`
+          # type=sha,prefix={{branch}}-     Would tag the image with `gitbranch-blahblah`
+          flavor: |
+            latest=true
+          # Set to 'auto' if/when we want to stop tagging
+          # the most recent image as `latest`
+
+
+      - name: 🪵🐙 Login to GitHub Container Registry
+        id: login-ghcr
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🔨🐳 Build ➡️ Push to registries
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      - name: 🖨 Display image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
# Fixes #1056 

## Description

This workflow automatically builds, tags, and pushes the Spoke Docker image to GitHub Container Registry.
It will publish a tagged build for each release and a `latest` image on each commit.

To disable the behavior of overwriting `latest` on each commit, simply comment out the `push` trigger. This will cause the last tagged release to become `latest`.

# Checklist:

- [x] ~~I have manually tested my changes on desktop and mobile~~ n/a
- [x] ~~The test suite passes locally with my changes~~ n/a
- [x] ~~If my change is a UI change, I have attached a screenshot to the description section of this pull request~~ n/a
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] ~~I have made any necessary changes to the documentation~~ n/a
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~ n/a
- [x] ~~My PR is labeled [WIP] if it is in progress~~ n/a
