### PR TITLE
Fix csv-import contact loader errors

### DIFF
--- a/src/extensions/contact-loaders/csv-upload/react-component.js
+++ b/src/extensions/contact-loaders/csv-upload/react-component.js
@@ -45,16 +45,6 @@ export const ensureCamelCaseRequiredHeaders = columnHeader => {
   return columnHeader;
 };
 
-const innerStyles = {
-  button: {
-    margin: "24px 5px 24px 0",
-    fontSize: "10px"
-  },
-  nestedItem: {
-    fontSize: "12px"
-  }
-};
-
 export class CampaignContactsFormBase extends React.Component {
   state = {
     uploading: false,
@@ -89,7 +79,6 @@ export class CampaignContactsFormBase extends React.Component {
 
     event.preventDefault();
     const file = event.target.files[0];
-    console.log("file upload", file);
     this.setState({ uploading: true }, () => {
       parseCSV(
         file,
@@ -202,12 +191,10 @@ export class CampaignContactsFormBase extends React.Component {
       <List>
         <Divider />
         {stats.map((stat, index) => (
-          <ListItem
-            key={index}
-            leftIcon={this.props.icons.warning}
-            innerDivStyle={innerStyles.nestedItem}
-            primaryText={stat}
-          />
+          <ListItem key={index} dense={true}>
+            <ListItemIcon>{this.props.icons.warning}</ListItemIcon>
+            <ListItemText primary={stat} />
+          </ListItem>
         ))}
       </List>
     );
@@ -257,11 +244,10 @@ export class CampaignContactsFormBase extends React.Component {
           {this.renderValidationStats()}
           {contactUploadError && (
             <List>
-              <ListItem
-                id="uploadError"
-                primaryText={contactUploadError}
-                leftIcon={this.props.icons.error}
-              />
+              <ListItem id="uploadError">
+                <ListItemIcon>{this.props.icons.error}</ListItemIcon>
+                <ListItemText primary={contactUploadError} />
+              </ListItem>
             </List>
           )}
           <Form.Submit


### PR DESCRIPTION
## Description

Fixes clients-side react errors when a warning or error is reported by the csv-import contact loader after loading a CSV file.

To reproduce with spoke mainline, enable the csv-import contact loader (not the S3 version) and import a CSV file that generates a warning (e.g. duplicate phone number) or error (missing columns maybe?).

Expected: CSV import summary to be shown, including details of the warnings/errors

Actual: Nothing happens in the UI at all, react errors about unsupported MUI List element props show up in the console.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
