### PR TITLE
Eliminate exception when starting up against a new database

### DIFF
--- a/src/server/seeds/seed-zip-codes.js
+++ b/src/server/seeds/seed-zip-codes.js
@@ -3,7 +3,7 @@ import Papa from "papaparse";
 import { log, zipToTimeZone } from "../../lib";
 import fs from "fs";
 
-export async function seedZipCodes() {
+export async function seedZipCodesIfNecessary() {
   log.info("Checking if zip code is needed");
   const hasZip = await r.getCount(r.knex("zip_code").limit(1));
 

--- a/src/workers/job-processes.js
+++ b/src/workers/job-processes.js
@@ -24,8 +24,6 @@ import { setupUserNotificationObservers } from "../server/notifications";
 import { loadContactsFromDataWarehouseFragment } from "../extensions/contact-loaders/datawarehouse";
 import { loadContactS3PullProcessFile } from "../extensions/contact-loaders/s3-pull";
 
-export { seedZipCodes } from "../server/seeds/seed-zip-codes";
-
 /* For the 'legacy' job runner when JOBS_SAME_PROCESS is false:
    The main in both cases is to process jobs and send/receive messages
    on separate loop(s) from the web server.


### PR DESCRIPTION
# Fixes #1062 

## Description

Eliminate the `zip_code table doesn't exist` exception when starting Spoke against a newly created database. 

Previously the code checked whether to seed the zip_code table without regard for whether the database existed. The check involves querying the zip_code table. If it doesn't exist that causes an exception. This change puts some guards around seeding the zip_code table so that the code doesn't attempt it if it's also creating a new database.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
