### PR TITLE
Make Send Bulk button visible in the UI

### DIFF
--- a/src/components/AssignmentTexter/BulkSendButton.jsx
+++ b/src/components/AssignmentTexter/BulkSendButton.jsx
@@ -7,8 +7,10 @@ import Button from "@material-ui/core/Button";
 // immediate child is a Button or other type it recognizes. Can get rid of this if we remove material-ui
 const styles = StyleSheet.create({
   container: {
-    display: "inline-block",
-    marginLeft: 20
+    display: "block",
+    width: "25ex",
+    marginLeft: "auto",
+    marginRight: "auto"
   }
 });
 
@@ -33,6 +35,7 @@ export default class BulkSendButton extends Component {
           onClick={this.sendMessages}
           disabled={this.state.isSending}
           color="primary"
+          variant="contained"
         >
           {this.state.isSending
             ? "Sending..."

--- a/src/components/AssignmentTexter/BulkSendButton.jsx
+++ b/src/components/AssignmentTexter/BulkSendButton.jsx
@@ -48,7 +48,7 @@ export default class BulkSendButton extends Component {
 
 BulkSendButton.propTypes = {
   assignment: PropTypes.object,
-  onFinishContact: PropTypes.function,
-  bulkSendMessages: PropTypes.function,
-  setDisabled: PropTypes.function
+  onFinishContact: PropTypes.func,
+  bulkSendMessages: PropTypes.func,
+  setDisabled: PropTypes.func
 };


### PR DESCRIPTION
## Description

In Spoke v11 & 12, when bulk sending is enabled, the Send All button in the texter view has a transparent background and is overlaid over the home button in the top left corner of the page, and is essentially invisible. 

This gives the button a background colour so it's not transparent, and centres its container so it doesn't obscure the name of the campaign.

I feel like this is a bit of a work around from a usability POV, but I'm not familiar enough with React and Spoke to reorganise the components enough to do anything better at the moment.

<img width="719" alt="image" src="https://user-images.githubusercontent.com/88811770/160215652-4bcaf68c-abea-4711-a099-818f385cd9d6.png">

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
