### PR TITLE
Viewing all messages breakage

### DIFF
--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -63,10 +63,20 @@ export class ContactController extends React.Component {
       global.ASSIGNMENT_CONTACTS_SIDEBAR &&
       this.props.messageStatusFilter !== "needsMessage"
     ) {
+      const messageStatusFilter = this.props.messageStatusFilter;
+      let status = null;
+      if (messageStatusFilter === "needsMessageOrResponse") {
+        status = ["needsResponse", "needsMessage"];
+      } else if (messageStatusFilter === "allReplies") {
+        status = ["messaged", "needsMessage"];
+      } else if (messageStatusFilter === "needsResponseExpired") {
+        status = ["needsResponse"];
+      } else {
+        status = messageStatusFilter.split(",");
+      }
+
       startIndex = Math.max(
-        this.props.contacts.findIndex(
-          c => c.messageStatus === this.props.messageStatusFilter
-        ),
+        this.props.contacts.findIndex(c => status.includes(c.messageStatus)),
         0
       );
     }
@@ -476,7 +486,7 @@ export class ContactController extends React.Component {
       );
     }
     const initials = messageStatusFilter === "needsMessage";
-    const action = initials ? "messaged" : "replied to";
+    const action = initials ? "messaged" : "messaged and replied to";
     const emptyMessage =
       allContactsCount === 0
         ? "No current contacts"

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -269,31 +269,6 @@ export class ContactController extends React.Component {
     return this.state.currentContactIndex < this.contactCount() - 1;
   }
 
-  canRequestMore() {
-    const { assignment, campaign, messageStatusFilter } = this.props;
-    if (assignment.hasUnassignedContactsForTexter) {
-      if (
-        (messageStatusFilter === "needsMessage" ||
-          messageStatusFilter === "needsSecondPass") &&
-        !campaign.requestAfterReply
-      ) {
-        return true;
-      } else if (
-        messageStatusFilter === "needsResponse" &&
-        campaign.requestAfterReply
-      ) {
-        if (
-          assignment.unmessagedCount === 0 &&
-          assignment.unrepliedCount === 0 &&
-          assignment.secondpassCount === 0
-        ) {
-          return true;
-        }
-      }
-    }
-    return false;
-  }
-
   handleFinishContact = contactId => {
     if (this.hasNext()) {
       this.setState({ finishedContactId: null }, () => {

--- a/src/components/AssignmentTexter/ContactController.jsx
+++ b/src/components/AssignmentTexter/ContactController.jsx
@@ -460,7 +460,6 @@ export class ContactController extends React.Component {
         onFinishContact={this.handleFinishContact}
         refreshData={this.props.refreshData}
         onExitTexter={this.handleExitTexter}
-        messageStatusFilter={this.props.messageStatusFilter}
         organizationId={this.props.organizationId}
         location={this.props.location}
         updateCurrentContactById={this.updateCurrentContactById}

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -129,9 +129,10 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   getStartingMessageText() {
-    const { campaign, messageStatusFilter } = this.props;
+    const { contact, campaign, messageStatusFilter } = this.props;
     return (
-      messageStatusFilter === "needsMessage" &&
+      contact != null &&
+      contact.messageStatus === "needsMessage" &&
       this.props.getMessageTextFromScript(
         getTopMostParent(campaign.interactionSteps).script
       )

--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -129,7 +129,7 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   getStartingMessageText() {
-    const { contact, campaign, messageStatusFilter } = this.props;
+    const { contact, campaign } = this.props;
     return (
       contact != null &&
       contact.messageStatus === "needsMessage" &&
@@ -176,7 +176,7 @@ export class AssignmentTexterContactControls extends React.Component {
         evt.ctrlKey,
         evt.keyCode,
         this.state.messageReadOnly,
-        this.props.messageStatusFilter
+        this.props.contact.messageStatus
       );
     }
 
@@ -235,13 +235,12 @@ export class AssignmentTexterContactControls extends React.Component {
     // Allow initial sends to use any key, avoiding RSI injuries
     // the texter can distribute which button to press across the keyboard
     if (
-      this.props.messageStatusFilter === "needsMessage" &&
+      this.props.contact.messageStatus === "needsMessage" &&
       this.state.messageReadOnly &&
       !evt.ctrlKey &&
       !evt.metaKey &&
       !evt.altKey &&
-      (/[a-z,./;']/.test(evt.key) ||
-        evt.key === "Enter" ||
+      (evt.key === "Enter" ||
         evt.key === "Return" ||
         evt.key === "Space" ||
         evt.key === " " ||
@@ -934,7 +933,7 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   renderMessagingRowSendSkip(contact) {
-    const firstMessage = this.props.messageStatusFilter === "needsMessage";
+    const firstMessage = contact.messageStatus === "needsMessage";
     return (
       <div
         key="renderMessagingRowSendSkip"
@@ -959,7 +958,7 @@ export class AssignmentTexterContactControls extends React.Component {
   }
 
   renderMessageControls(enabledSideboxes) {
-    const { contact, messageStatusFilter, assignment, campaign } = this.props;
+    const { contact, assignment, campaign } = this.props;
     const {
       availableSteps,
       questionResponses,
@@ -1131,7 +1130,7 @@ export class AssignmentTexterContactControls extends React.Component {
 
   render() {
     const { enabledSideboxes } = this.props;
-    const firstMessage = this.props.messageStatusFilter === "needsMessage";
+    const firstMessage = this.props.contact.messageStatus === "needsMessage";
     const content = firstMessage
       ? this.renderFirstMessage(enabledSideboxes)
       : [
@@ -1199,7 +1198,6 @@ AssignmentTexterContactControls.propTypes = {
   // parent state
   disabled: PropTypes.bool,
   navigationToolbarChildren: PropTypes.object,
-  messageStatusFilter: PropTypes.string,
   enabledSideboxes: PropTypes.arrayOf(PropTypes.object),
   review: PropTypes.string,
 

--- a/src/components/AssignmentTexter/Demo.jsx
+++ b/src/components/AssignmentTexter/Demo.jsx
@@ -1,7 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
 
-import ContactController from "./ContactController";
 import Controls from "./Controls";
 import { applyScript } from "../../lib/scripts";
 
@@ -722,7 +721,6 @@ export function generateDemoTexterContact(testName) {
         currentUser={test.currentUser}
         navigationToolbarChildren={test.navigationToolbarChildren}
         enabledSideboxes={props.enabledSideboxes}
-        messageStatusFilter={test.messageStatusFilter}
         disabled={test.disabled}
         onMessageFormSubmit={() => async data => {
           console.log("logging data onMessageFormSubmit", data);
@@ -757,7 +755,6 @@ export function generateDemoTexterContact(testName) {
         onRefreshAssignmentContacts={logFunction}
         organizationId={"1"}
         ChildComponent={DemoAssignmentTexterContact}
-        messageStatusFilter={test.messageStatusFilter}
         currentUser={test.currentUser}
       />
     );

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -173,7 +173,7 @@ export class AssignmentTexterContact extends React.Component {
   };
 
   handleMessageFormSubmit = cannedResponseId => async ({ messageText }) => {
-    const { campaign, contact, messageStatusFilter } = this.props;
+    const { campaign, contact } = this.props;
     if (!messageText || messageText == "false") {
       // defensive code -- if somehow message form validation fails, don't send a dumb "false" message
       return;
@@ -186,7 +186,7 @@ export class AssignmentTexterContact extends React.Component {
       this.setState({ disabled: true });
       console.log("sendMessage", contact.id);
       if (
-        messageStatusFilter === "needsMessage" &&
+        contact.messageStatus === "needsMessage" &&
         (/fast=1/.test(document.location.search) ||
           (campaign.title && /f=1/.test(campaign.title)))
       ) {
@@ -396,7 +396,7 @@ export class AssignmentTexterContact extends React.Component {
     return (
       <div {...dataTest("assignmentTexterContactFirstDiv")}>
         {this.state.disabled &&
-        this.props.messageStatusFilter !== "needsMessage" ? (
+        this.props.contact.messageStatus !== "needsMessage" ? (
           <div className={css(styles.overlay)}>
             <CircularProgress color="primary" size={20} />
             {this.state.disabledText}
@@ -465,7 +465,6 @@ AssignmentTexterContact.propTypes = {
   mutations: PropTypes.object,
   refreshData: PropTypes.func,
   onExitTexter: PropTypes.func,
-  messageStatusFilter: PropTypes.string,
   organizationId: PropTypes.string,
   location: PropTypes.object,
   updateCurrentContactById: PropTypes.func

--- a/src/containers/AssignmentTexterContact.jsx
+++ b/src/containers/AssignmentTexterContact.jsx
@@ -412,7 +412,6 @@ export class AssignmentTexterContact extends React.Component {
           currentUser={this.props.currentUser}
           organizationId={this.props.organizationId}
           navigationToolbarChildren={this.props.navigationToolbarChildren}
-          messageStatusFilter={this.props.messageStatusFilter}
           disabled={this.state.disabled || this.state.disabledSend}
           enabledSideboxes={this.props.enabledSideboxes}
           review={this.props.location.query.review}

--- a/src/containers/TexterTodo.jsx
+++ b/src/containers/TexterTodo.jsx
@@ -265,10 +265,11 @@ const queries = {
     options: ownProps => {
       console.log("TexterTodo ownProps", ownProps);
       const messageStatus =
-        !global.ASSIGNMENT_CONTACTS_SIDEBAR ||
-        ownProps.messageStatus === "needsMessage"
-          ? ownProps.messageStatus
-          : "allReplies";
+        global.ASSIGNMENT_CONTACTS_SIDEBAR &&
+        ownProps.messageStatus !== "needsMessage" &&
+        ownProps.messageStatus !== "needsMessageOrResponse"
+          ? "allReplies"
+          : ownProps.messageStatus;
 
       // based on ?review=1 in location.search
       // exclude isOptedOut: false, validTimezone: true

--- a/src/extensions/texter-sideboxes/celebration-gif/react-component.js
+++ b/src/extensions/texter-sideboxes/celebration-gif/react-component.js
@@ -20,7 +20,7 @@ export const showSidebox = ({
   // Return 'popup' to force a popup on mobile screens (instead of letting it hide behind a button)
   if (
     (contact && finished) ||
-    (messageStatusFilter === "needsMessage" &&
+    (["needsMessage", "needsMessageOrResponse"].includes(messageStatusFilter) &&
       assignment.allContactsCount &&
       assignment.unmessagedCount === 0)
   ) {

--- a/src/extensions/texter-sideboxes/contact-reference/react-component.js
+++ b/src/extensions/texter-sideboxes/contact-reference/react-component.js
@@ -17,13 +17,12 @@ export const showSidebox = ({
   campaign,
   assignment,
   texter,
-  navigationToolbarChildren,
-  messageStatusFilter
+  navigationToolbarChildren
 }) => {
   // Return anything False-y to not show
   // Return anything Truth-y to show
   // Return 'popup' to force a popup on mobile screens (instead of letting it hide behind a button)
-  return contact && messageStatusFilter !== "needsMessage";
+  return contact && contact.messageStatus !== "needsMessage";
 };
 
 export class TexterSidebox extends React.Component {
@@ -95,8 +94,7 @@ TexterSidebox.propTypes = {
 
   // parent state
   disabled: type.bool,
-  navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string
+  navigationToolbarChildren: type.object
 };
 
 export const adminSchema = () => ({

--- a/src/extensions/texter-sideboxes/default-dynamicassignment/react-component.js
+++ b/src/extensions/texter-sideboxes/default-dynamicassignment/react-component.js
@@ -28,11 +28,10 @@ export const showSidebox = ({
   if (
     finished &&
     campaign.useDynamicAssignment &&
-    (assignment.hasUnassignedContactsForTexter ||
-      messageStatusFilter === "needsMessage" ||
-      assignment.unmessagedCount) &&
-    (messageStatusFilter === "needsMessage" ||
-      messageStatusFilter === "needsResponse")
+    assignment.hasUnassignedContactsForTexter &&
+    ["needsMessage", "needsMessageOrResponse", "needsResponse"].includes(
+      messageStatusFilter
+    )
   ) {
     return "popup";
   }

--- a/src/extensions/texter-sideboxes/default-editinitial/react-component.js
+++ b/src/extensions/texter-sideboxes/default-editinitial/react-component.js
@@ -6,8 +6,8 @@ import GSTextField from "../../../components/forms/GSTextField";
 
 export const displayName = () => "Allow editing of initial messages";
 
-export const showSidebox = ({ contact, messageStatusFilter }) =>
-  contact && messageStatusFilter === "needsMessage";
+export const showSidebox = ({ contact }) =>
+  contact && contact.messageStatus === "needsMessage";
 
 const defaultExpandText = "Sending Initial Messages";
 const defaultMessagePre =
@@ -84,8 +84,7 @@ TexterSidebox.propTypes = {
 
   // parent state
   disabled: type.bool,
-  navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string
+  navigationToolbarChildren: type.object
 };
 
 export const adminSchema = () => ({

--- a/src/extensions/texter-sideboxes/default-releasecontacts/react-component.js
+++ b/src/extensions/texter-sideboxes/default-releasecontacts/react-component.js
@@ -23,8 +23,8 @@ export const displayName = () => "Release Contacts";
 
 export const showSidebox = ({
   settingsData,
-  messageStatusFilter,
   assignment,
+  contact,
   campaign,
   finished,
   isSummary
@@ -33,12 +33,13 @@ export const showSidebox = ({
   // Return anything Truth-y to show
   // Return 'popup' to force a popup on mobile screens (instead of letting it hide behind a button)
   return (
-    (assignment.hasContacts || assignment.allContactsCount) &&
     !finished &&
     (campaign.useDynamicAssignment ||
       settingsData.releaseContactsNonDynamicToo) &&
+    (assignment.hasContacts || assignment.allContactsCount) &&
     (settingsData.releaseContactsReleaseConvos ||
-      (messageStatusFilter === "needsMessage" && assignment.unmessagedCount) ||
+      (contact.messageStatus === "needsMessage" &&
+        assignment.unmessagedCount) ||
       (isSummary && assignment.unmessagedCount))
   );
 };
@@ -62,16 +63,17 @@ export class TexterSideboxClass extends React.Component {
   };
 
   render() {
-    const { settingsData, messageStatusFilter, assignment } = this.props;
+    const { contact, settingsData, assignment } = this.props;
     const showReleaseConvos =
       settingsData.releaseContactsReleaseConvos &&
-      ((messageStatusFilter && messageStatusFilter !== "needsMessage") ||
+      (contact.messageStatus !== "needsMessage" ||
         assignment.unrepliedCount ||
         assignment.hasUnreplied);
     return (
       <div>
         {assignment.unmessagedCount ||
-        (messageStatusFilter === "needsMessage" && assignment.hasUnmessaged) ? (
+        (contact.messageStatus === "needsMessage" &&
+          assignment.hasUnmessaged) ? (
           <div className={css(styles.marginBottom)}>
             <div>
               {settingsData.releaseContactsBatchTitle
@@ -124,7 +126,6 @@ TexterSideboxClass.propTypes = {
 
   // parent state
   navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string,
   finished: type.bool
 };
 

--- a/src/extensions/texter-sideboxes/hide-media/react-component.js
+++ b/src/extensions/texter-sideboxes/hide-media/react-component.js
@@ -31,8 +31,7 @@ TexterSidebox.propTypes = {
 
   // parent state
   disabled: type.bool,
-  navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string
+  navigationToolbarChildren: type.object
 };
 
 export const adminSchema = () => ({});

--- a/src/extensions/texter-sideboxes/mobilize-event-shifter/react-component.js
+++ b/src/extensions/texter-sideboxes/mobilize-event-shifter/react-component.js
@@ -20,9 +20,9 @@ import {
 
 export const displayName = () => "Mobilize Event Shifter";
 
-export const showSidebox = ({ contact, messageStatusFilter, settingsData }) =>
+export const showSidebox = ({ contact, settingsData }) =>
   contact &&
-  messageStatusFilter !== "needsMessage" &&
+  contact.messageStatus !== "needsMessage" &&
   (settingsData.mobilizeEventShifterBaseUrl ||
     window.MOBILIZE_EVENT_SHIFTER_URL);
 
@@ -221,8 +221,7 @@ TexterSidebox.propTypes = {
 
   // parent state
   disabled: type.bool,
-  navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string
+  navigationToolbarChildren: type.object
 };
 
 export const adminSchema = () => ({

--- a/src/extensions/texter-sideboxes/tag-contact/react-component.js
+++ b/src/extensions/texter-sideboxes/tag-contact/react-component.js
@@ -19,15 +19,14 @@ import withMuiTheme from "../../../containers/hoc/withMuiTheme";
 
 export const displayName = () => "Tagging Contacts";
 
-export const showSidebox = ({ contact, campaign, messageStatusFilter }) => {
+export const showSidebox = ({ contact, campaign }) => {
   // Return anything False-y to not show
   // Return anything Truth-y to show
   // Return 'popup' to force a popup on mobile screens (instead of letting it hide behind a button)
-  // console.log("showsidebox", messageStatusFilter, contact, campaign);
   return (
     contact &&
     !contact.optOut &&
-    messageStatusFilter !== "needsMessage" &&
+    contact.messageStatus !== "needsMessage" &&
     campaign.organization.tags.length
   );
 };
@@ -150,7 +149,6 @@ TexterSideboxBase.propTypes = {
   // parent state
   disabled: type.bool,
   navigationToolbarChildren: type.object,
-  messageStatusFilter: type.string,
   onUpdateTags: type.func
 };
 

--- a/src/extensions/texter-sideboxes/texter-feedback/react-component.js
+++ b/src/extensions/texter-sideboxes/texter-feedback/react-component.js
@@ -350,7 +350,6 @@ TexterSideboxClassBase.propTypes = {
   // parent state
   disabled: PropTypes.bool,
   navigationToolbarChildren: PropTypes.object,
-  messageStatusFilter: PropTypes.string,
   onUpdateTags: PropTypes.func,
 
   mutations: PropTypes.object


### PR DESCRIPTION
# Fixes  #2140

## Description

Rolls up a bunch of fixes around `messageStatusFilter` not being used correctly in the texting view. I'd suggest commits 6c12c963b543bac05e818f07e45974fbd93ba7c8 and 9cb55da05f9cb029a6141b2e51e6c0b88354e6ce are correct and good to go, less sure about the rest.

It's probably more than 300 lines of changes, because `messageStatusFilter` was being incorrectly used in a bunch of places. Each commit in this PR is more-or less independent however and can be reviewed individually.

See screenshot in #2140 for comparison:

<img width="719" alt="image" src="https://user-images.githubusercontent.com/88811770/160226001-e73213ca-c8ac-430e-a4fe-caf35fb7ded2.png">

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] My PR is labeled [WIP] if it is in progress
