### PR TITLE
Bulk send sometimes sends the wrong message

### DIFF
--- a/src/server/api/mutations/bulkSendMessages.js
+++ b/src/server/api/mutations/bulkSendMessages.js
@@ -5,7 +5,7 @@ import { getConfig } from "../lib/config";
 import { applyScript } from "../../../lib/scripts";
 import { Assignment, User, r, cacheableData } from "../../models";
 
-import { getTopMostParent, log } from "../../../lib";
+import { log } from "../../../lib";
 
 import { sendMessage, findNewCampaignContact } from "./index";
 
@@ -58,10 +58,13 @@ export const bulkSendMessages = async (
       campaign_id: assignment.campaign_id
     })
     .where({
+      parent_interaction_id: null
+    })
+    .where({
       is_deleted: false
     });
 
-  const topmostParent = getTopMostParent(interactionSteps);
+  const topmostParent = interactionSteps[0];
 
   const texter = camelCaseKeys(await User.get(assignment.user_id));
   const customFields = Object.keys(JSON.parse(contacts[0].custom_fields));


### PR DESCRIPTION

## Description

Currently bulk sends in Spoke may send the wrong first message. This happens when the database returns an interaction step other than the root as the first step when querying all of a campaign's steps. Typically that doesn't happen very often, but I have seen it show up a few times in production now. Lucky all but one were caught before actually being sent.

This fixes the problem by updating the query used in `bulkSendMessages.js` to just return the root step directly, rather than use any of the methods in `interaction-step-helpers.js`.

I went to fix the issue in `interaction-step-helpers.js`, but the methods there don't seem to connect much with the reality of the current database schema (in particular `findParent` is I think broken in all cases), and I'm not sure what they should expect as input.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
