### PR TITLE
Fix "awaiting a reply" bugs

### DIFF
--- a/src/components/TexterStats.jsx
+++ b/src/components/TexterStats.jsx
@@ -61,7 +61,7 @@ class TexterStats extends React.Component {
     if (unrepliedCount) {
       bottomLinks.push(
         <span>
-          {unrepliedCount} contact{unrepliedCount > 1 && "s"}{" "}
+          {unrepliedCount} contact{unrepliedCount > 1 ? "s " : " "}
           <Link
             component={RouterLink}
             to={`/admin/${this.props.organizationId}/incoming?campaigns=${campaign.id}&texterId=${texter.id}&messageStatus=needsResponse`}

--- a/src/components/TexterStats.jsx
+++ b/src/components/TexterStats.jsx
@@ -61,7 +61,7 @@ class TexterStats extends React.Component {
     if (unrepliedCount) {
       bottomLinks.push(
         <span>
-          {unrepliedCount} contacts{" "}
+          {unrepliedCount} contact{unrepliedCount > 1 && "s"}{" "}
           <Link
             component={RouterLink}
             to={`/admin/${this.props.organizationId}/incoming?campaigns=${campaign.id}&texterId=${texter.id}&messageStatus=needsResponse`}

--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -486,6 +486,10 @@ export const resolvers = {
               "campaign_contact.assignment_id",
               "assignment.id"
             )
+            .where(
+              "user_organization.organization_id",
+              campaign.organization_id
+            )
             .select(
               ...fields,
               r.knex.raw(


### PR DESCRIPTION
# Fixes #2167 

## Description

Fixes the following bugs on the Texter Stats page:
1. When there is 1 contact awaiting a reply, it says "1 contacts awaiting a reply" on the Texter Stats page. There shouldn't be an "s" in the word contacts since there's only 1
2. The "awaiting a reply" number on the Texter Stats page will be wrong if any of the assignees to the texts awaiting replies are in multiple Spoke organizations
<img width="1440" alt="Screen Shot 2022-05-11 at 5 00 14 PM" src="https://user-images.githubusercontent.com/9382984/167966347-f99cc877-f051-4522-a9c0-31300875c2d5.png">

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
