### PR TITLE
Fix wrong service vendor error links

### DIFF
--- a/src/server/api/campaign.js
+++ b/src/server/api/campaign.js
@@ -256,7 +256,9 @@ export const resolvers = {
         .select("error_code", r.knex.raw("count(*) as error_count"))
         .groupBy("error_code")
         .orderByRaw("count(*) DESC");
-      const organization = loaders.organization.load(campaign.organization_id);
+      const organization = await loaders.organization.load(
+        campaign.organization_id
+      );
       return errorCounts.map(e => ({
         ...errorDescription(
           e.error_code,


### PR DESCRIPTION
# Fixes #2169

## Description

Fixes the issue where the error links on the Texter Stats page will display as the service vendor specified in the `DEFAULT_SERVICE` env variable even if the organization's service vendor is overridden by a different one in organization.features.

The cause of that issue was a promise that wasn't awaited in the `errorCounts` function.

Screenshot of correct error link now being displayed (when `DEFAULT_SERVICE` is `twilio` and organization.features has `"service":"bandwidth"`):
<img width="1440" alt="Screen Shot 2022-05-11 at 5 37 53 PM" src="https://user-images.githubusercontent.com/9382984/167969407-f26c4b2c-be58-480c-a20e-d2ce7ddf256d.png">

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
