### PR TITLE
Allow response to be changed after clicking the "Clear Response" button

### DIFF
--- a/src/components/AssignmentTexter/Controls.jsx
+++ b/src/components/AssignmentTexter/Controls.jsx
@@ -54,13 +54,6 @@ export class AssignmentTexterContactControls extends React.Component {
       props.campaign.interactionSteps
     );
 
-    let currentInteractionStep = null;
-    if (availableSteps.length > 0) {
-      currentInteractionStep = availableSteps[availableSteps.length - 1];
-      currentInteractionStep.question.filteredAnswerOptions =
-        currentInteractionStep.question.answerOptions;
-    }
-
     let contactListOpen =
       global.ASSIGNMENT_CONTACTS_SIDEBAR &&
       document.documentElement.clientWidth > 575;
@@ -86,7 +79,7 @@ export class AssignmentTexterContactControls extends React.Component {
       availableSteps,
       messageReadOnly: false,
       hideMedia: false,
-      currentInteractionStep,
+      currentInteractionStep: this.getCurrentInteractionStep(availableSteps),
       contactListOpen
     };
   }
@@ -127,6 +120,18 @@ export class AssignmentTexterContactControls extends React.Component {
       nextState.sideboxOpens[sb] = (nextState.sideboxOpens[sb] || 0) + 1;
     });
   }
+
+  getCurrentInteractionStep = availableSteps => {
+    let currentInteractionStep = null;
+
+    if (availableSteps.length > 0) {
+      currentInteractionStep = availableSteps[availableSteps.length - 1];
+      currentInteractionStep.question.filteredAnswerOptions =
+        currentInteractionStep.question.answerOptions;
+    }
+
+    return currentInteractionStep;
+  };
 
   getStartingMessageText() {
     const { contact, campaign } = this.props;
@@ -369,12 +374,15 @@ export class AssignmentTexterContactControls extends React.Component {
       questionResponses,
       interactionSteps
     );
-    // TODO sky: ? do we sometimes need to update state.currentInteractionStep?
-    // it doesn't seem to be able to change if we clear a response
     this.setState(
       {
         questionResponses,
-        availableSteps
+        availableSteps,
+
+        // Update currentInteractionStep if a response was cleared
+        currentInteractionStep: questionResponseValue
+          ? this.state.currentInteractionStep
+          : this.getCurrentInteractionStep(availableSteps)
       },
       () => {
         this.handleChangeScript(nextScript);


### PR DESCRIPTION
# Fixes #2171

## Description

Fixes a bug where when trying to change a question response, it is not possible to change the response after clicking the "Clear Response" button

Screenshot of bug:
![image](https://user-images.githubusercontent.com/9382984/168392840-20dc139e-00d4-4f74-aa07-c8538b4ebaf4.png)

Screenshot of fix:
![image](https://user-images.githubusercontent.com/9382984/168392753-f9358388-2247-4c4e-acef-070e456da1bd.png)

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#your-first-code-contribution), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
