### PR TITLE
Add disabled prop to GSSelectField

### DIFF
--- a/src/components/forms/GSSelectField.jsx
+++ b/src/components/forms/GSSelectField.jsx
@@ -18,7 +18,7 @@ export default class GSSelectField extends GSFormField {
   }
 
   render() {
-    const { name, label, onChange, style } = this.props;
+    const { name, label, onChange, style, disabled } = this.props;
     let { value } = this.props;
     const dataTest = { "data-test": this.props["data-test"] };
 
@@ -35,6 +35,7 @@ export default class GSSelectField extends GSFormField {
           {...dataTest}
           name={name}
           value={value}
+          disabled={disabled}
           onChange={event => {
             onChange(event.target.value);
           }}


### PR DESCRIPTION


## Description

Allows disabling GSSelectField with `disabled`

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
