### PR TITLE
regression bug: demo texting views failed. 

### DIFF
--- a/src/components/AssignmentTexter/Demo.jsx
+++ b/src/components/AssignmentTexter/Demo.jsx
@@ -699,63 +699,49 @@ export const assignmentSummaryTestProps = {
 
 export function generateDemoTexterContact(testName) {
   const test = tests(testName);
-  const DemoAssignmentTexterContact = function(props) {
-    console.log("DemoAssignmentTexterContact", props);
-    const getMessageTextFromScript = script => {
-      return script
-        ? applyScript({
-            contact: test.contact,
-            texter: test.texter,
-            customFields: test.assignment.campaign.customFields,
-            script
-          })
+  const getMessageTextFromScript = script => {
+    return script
+      ? applyScript({
+          contact: test.contact,
+          texter: test.texter,
+          customFields: test.assignment.campaign.customFields,
+          script
+        })
         : null;
-    };
-
-    return (
-      <Controls
-        contact={test.contact}
-        campaign={test.assignment.campaign}
-        texter={test.texter}
-        assignment={test.assignment}
-        currentUser={test.currentUser}
-        navigationToolbarChildren={test.navigationToolbarChildren}
-        enabledSideboxes={props.enabledSideboxes}
-        disabled={test.disabled}
-        onMessageFormSubmit={() => async data => {
-          console.log("logging data onMessageFormSubmit", data);
-
-          props.onFinishContact(1);
-        }}
-        onOptOut={logFunction}
-        onQuestionResponseChange={logFunction}
-        onCreateCannedResponse={logFunction}
-        onExitTexter={logFunction}
-        onEditStatus={logFunction}
-        onUpdateTags={async data => logFunction(data)}
-        refreshData={logFunction}
-        getMessageTextFromScript={getMessageTextFromScript}
-      />
-    );
   };
 
   const DemoTexterTest = function(props) {
-    console.log("DemoTexterTest", test);
+    console.log("DemoTexterTest", test, props);
     return (
       <Controls
-        assignment={test.assignment}
+        handleNavigateNext={logFunction}
+        handleNavigatePrevious={logFunction}
+
+        contact={test.contact ? test.contact : null}
         campaign={test.assignment.campaign}
-        contacts={test.contact ? [{ id: test.contact.id }] : []}
-        allContactsCount={test.navigationToolbarChildren.total}
-        refreshData={logFunction}
-        loadContacts={contactIds => {
-          console.log("loadContacts", contactIds);
-          return { data: { getAssignmentContacts: [test.contact] } };
-        }}
-        onRefreshAssignmentContacts={logFunction}
-        organizationId={"1"}
-        ChildComponent={DemoAssignmentTexterContact}
+        assignment={test.assignment}
         currentUser={test.currentUser}
+        texter={test.texter}
+        organizationId={"1"}
+
+        disabled={test.disabled}
+        navigationToolbarChildren={test.navigationToolbarChildren}
+        enabledSideboxes={props.enabledSideboxes}
+        review={test.review}
+
+        onMessageFormSubmit={() => async data => {
+          console.log("logging data onMessageFormSubmit", data);
+        }}
+        onOptOut={logFunction}
+        onUpdateTags={async data => logFunction(data)}
+        onQuestionResponseChange={logFunction}
+        onCreateCannedResponse={logFunction}
+        onFinishContact={logFunction}
+        onExitTexter={logFunction}
+        onEditStatus={logFunction}
+        refreshData={logFunction}
+        getMessageTextFromScript={getMessageTextFromScript}
+        updateCurrentContactById={logFunction}
       />
     );
   };


### PR DESCRIPTION
This accomodates the Controls.jsx refactor

## Description

before 12.0 you could visit `/demo/text` `/demo/reply` and `/demo/reply2` to see sample screens for testing the interface.  This seems to have failed during a refactor -- pity, it probably would have helped the person refactoring

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [ ] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
