### PR TITLE
Fix: auto-optout if Redis is not enabled

### DIFF
--- a/__test__/extensions/message-handlers/auto-optout.test.js
+++ b/__test__/extensions/message-handlers/auto-optout.test.js
@@ -1,6 +1,18 @@
 import { postMessageSave } from "../../../src/extensions/message-handlers/auto-optout";
-import { cacheableData } from "../../../src/server/models";
+import { cacheableData, r } from "../../../src/server/models";
+
+import {
+  setupTest,
+  cleanupTest,
+  createStartedCampaign
+} from "../../test_helpers";
+
 const sendMessage = require("../../../src/server/api/mutations/sendMessage");
+
+const CacheableMessage = require("../../../src/server/models/cacheable_queries/message");
+const saveMessage = CacheableMessage.default.save;
+
+const AutoOptout = require("../../../src/extensions/message-handlers/auto-optout");
 
 describe("Auto Opt-Out Tests", () => {
   let message;
@@ -22,7 +34,7 @@ describe("Auto Opt-Out Tests", () => {
       is_from_contact: true,
       contact_number: "+123456",
       campaign_contact_id: 1,
-      text: 'please stop'
+      text: "please stop"
     };
   });
 
@@ -76,4 +88,87 @@ describe("Auto Opt-Out Tests", () => {
 
     expect(sendMessage.sendRawMessage).not.toHaveBeenCalled();
   });
-})
+});
+
+describe("Tests for Auto Opt-Out's members getting called from messageCache.save", () => {
+  let contacts;
+  let organization;
+  let texter;
+
+  let service;
+  let messageServiceSID;
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  beforeEach(async () => {
+    await cleanupTest();
+    await setupTest();
+    jest.restoreAllMocks();
+    const startedCampaign = await createStartedCampaign();
+    ({
+      testContacts: contacts,
+      testOrganization: {
+        data: { createOrganization: organization }
+      },
+      testTexterUser: texter
+    } = startedCampaign);
+
+    service = "twilio";
+    messageServiceSID = "message_service_sid_vicious";
+
+    const messageToContact = {
+      is_from_contact: false,
+      contact_number: contacts[0].cell,
+      campaign_contact_id: contacts[0].id,
+      send_status: "SENT",
+      text: "Hey now!",
+      service,
+      messageservice_sid: messageServiceSID
+    };
+    await saveMessage({
+      messageInstance: messageToContact,
+      contact: contacts[0],
+      organization,
+      texter
+    });
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  it("gets called", async () => {
+    const message = {
+      is_from_contact: true,
+      contact_number: contacts[0].cell,
+      service,
+      messageservice_sid: messageServiceSID,
+      text: "stop2quit",
+      send_status: "DELIVERED"
+    };
+
+    jest.spyOn(AutoOptout, "preMessageSave").mockResolvedValue(null);
+    jest.spyOn(AutoOptout, "postMessageSave").mockResolvedValue(null);
+
+    await saveMessage({
+      messageInstance: message
+    });
+
+    expect(AutoOptout.preMessageSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messageToSave: expect.objectContaining({
+          text: "stop2quit",
+          contact_number: contacts[0].cell
+        })
+      })
+    );
+
+    expect(AutoOptout.postMessageSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: expect.objectContaining({
+          text: "stop2quit",
+          contact_number: contacts[0].cell
+        })
+      })
+    );
+  });
+});

--- a/__test__/server/models/cacheable_queries/campaign-contact.test.js
+++ b/__test__/server/models/cacheable_queries/campaign-contact.test.js
@@ -78,6 +78,7 @@ describe("CampaignContactCache", () => {
         send_status: "SENT",
         text: "Hey now!",
         service,
+        messageservice_sid: null, // necessary for sqlite tests to pass
         user_number: texter.cell
       };
       await saveMessage({

--- a/__test__/server/models/cacheable_queries/campaign-contact.test.js
+++ b/__test__/server/models/cacheable_queries/campaign-contact.test.js
@@ -1,0 +1,101 @@
+import {
+  setupTest,
+  cleanupTest,
+  createStartedCampaign
+} from "../../../test_helpers";
+import { r } from "../../../../src/server/models";
+
+const CacheableMessage = require("../../../../src/server/models/cacheable_queries/message");
+const saveMessage = CacheableMessage.default.save;
+
+const CacheableCampaignContact = require("../../../../src/server/models/cacheable_queries/campaign-contact");
+const lookupByCell = CacheableCampaignContact.default.lookupByCell;
+
+describe("CampaignContactCache", () => {
+  let contacts;
+  let organization;
+  let texter;
+  let campaign;
+
+  let service;
+  let messageServiceSID;
+
+  afterEach(async () => {
+    await cleanupTest();
+    if (r.redis) r.redis.flushdb();
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  beforeEach(async () => {
+    await cleanupTest();
+    await setupTest();
+    jest.restoreAllMocks();
+    const startedCampaign = await createStartedCampaign();
+    ({
+      testContacts: contacts,
+      testOrganization: {
+        data: { createOrganization: organization }
+      },
+      testTexterUser: texter,
+      testCampaign: campaign
+    } = startedCampaign);
+
+    service = "twilio";
+    messageServiceSID = "message_service_sid_vicious";
+  }, global.DATABASE_SETUP_TEARDOWN_TIMEOUT);
+
+  describe("lookupByCell", () => {
+    it("finds campaign_contact_id and campaign_id when there is a messageServiceSID", async () => {
+      const message = {
+        is_from_contact: false,
+        contact_number: contacts[0].cell,
+        campaign_contact_id: contacts[0].id,
+        send_status: "SENT",
+        text: "Hey now!",
+        service,
+        messageservice_sid: messageServiceSID
+      };
+      await saveMessage({
+        messageInstance: message,
+        contact: contacts[0],
+        organization,
+        texter
+      });
+      const foundMessage = await lookupByCell(
+        contacts[0].cell,
+        service,
+        messageServiceSID
+      );
+      expect(Number(foundMessage.campaign_id)).toBe(Number(campaign.id));
+      expect(Number(foundMessage.campaign_contact_id)).toBe(
+        Number(contacts[0].id)
+      );
+    });
+    it("finds campaign_contact_id and campaign_id when there is a userNumber", async () => {
+      const message = {
+        is_from_contact: false,
+        contact_number: contacts[0].cell,
+        campaign_contact_id: contacts[0].id,
+        send_status: "SENT",
+        text: "Hey now!",
+        service,
+        user_number: texter.cell
+      };
+      await saveMessage({
+        messageInstance: message,
+        contact: contacts[0],
+        organization,
+        texter
+      });
+      const foundMessage = await lookupByCell(
+        contacts[0].cell,
+        service,
+        null, // messageServiceSid
+        texter.cell
+      );
+      expect(Number(foundMessage.campaign_id)).toBe(Number(campaign.id));
+      expect(Number(foundMessage.campaign_contact_id)).toBe(
+        Number(contacts[0].id)
+      );
+    });
+  });
+});

--- a/src/extensions/message-handlers/auto-optout/index.js
+++ b/src/extensions/message-handlers/auto-optout/index.js
@@ -103,7 +103,7 @@ export const postMessageSave = async ({
       cell: message.contact_number,
       campaignContactId: message.campaign_contact_id,
       assignmentId: (contact && contact.assignment_id) || null,
-      campaign: campaign,
+      campaign,
       noReply: true,
       reason: handlerContext.autoOptOutReason,
       // RISKY: we depend on the contactUpdates in preMessageSave

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -377,11 +377,10 @@ const campaignContactCache = {
       );
       // console.log('lookupByCell cache', cell, service, messageServiceSid, cellData)
       if (cellData) {
-        // eslint-disable-next-line camelcase
         const [
-          campaign_contact_id,
-          _,
-          timezone_offset,
+          campaign_contact_id, // eslint-disable-line camelcase
+          _, // eslint-disable-line no-unused-vars
+          timezone_offset, // eslint-disable-line camelcase
           ...rest
         ] = cellData.split(":");
         return {

--- a/src/server/models/cacheable_queries/campaign-contact.js
+++ b/src/server/models/cacheable_queries/campaign-contact.js
@@ -415,16 +415,14 @@ const campaignContactCache = {
         .whereNull("messageservice_sid")
         .where("user_number", userNumber);
     }
-    if (r.redis) {
-      // we get the campaign_id so we can cache errorCount and needsResponseCount
-      messageQuery = messageQuery
-        .join(
-          "campaign_contact",
-          "campaign_contact.id",
-          "message.campaign_contact_id"
-        )
-        .select("campaign_contact_id", "campaign_id");
-    }
+    // we get the campaign_id so we can cache errorCount and needsResponseCount
+    messageQuery = messageQuery
+      .join(
+        "campaign_contact",
+        "campaign_contact.id",
+        "message.campaign_contact_id"
+      )
+      .select("campaign_contact_id", "campaign_id");
     const [lastMessage] = await messageQuery;
     if (lastMessage) {
       return {


### PR DESCRIPTION
# Fixes #2186 

## Description

The reported issue was that auto-optout is not working if redis is not enabled.

I found the root cause in `lookupByCell` in [src/server/models/cacheable_queries/campaign-contact.js](https://github.com/lperson/Spoke/blob/36e55956c170add240523c9d75c490cd85adbde6/src/server/models/cacheable_queries/campaign-contact.js#L418-L427). 

We were not joining to `campaign_contact` when redis is enabled. Because of that, in [src/server/models/cacheable_queries/message.js](https://github.com/lperson/Spoke/blob/36e55956c170add240523c9d75c490cd85adbde6/src/server/models/cacheable_queries/message.js#L309-L318), neither `organization` nor `campaignId` was defined, which in turn prevented any message handlers from being called.

I added tests to show:
* `lookupByCell` always does the join to `campaign_contact`
* `auto-optout`'s members get called when we save a message

I also tested manually in the UI to show that if somebody responds with opt-out words, they do in fact get opted out.

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [ ] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [ ] I have made any necessary changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
