### PR TITLE
Per-org VAN settings redux

### DIFF
--- a/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/ngpvan.test.js
@@ -469,6 +469,7 @@ describe("ngpvan", () => {
         ["NGP_VAN_API_BASE_URL", organization],
         ["NGP_VAN_TIMEOUT", organization],
         ["NGP_VAN_APP_NAME", organization],
+        ["NGP_VAN_API_KEY_ENCRYPTED", organization, {}],
         ["NGP_VAN_API_KEY", organization],
         ["NGP_VAN_DATABASE_MODE", organization],
         ["NGP_VAN_EXPORT_JOB_TYPE_ID", organization],

--- a/__test__/extensions/contact-loaders/ngpvan/util.test.js
+++ b/__test__/extensions/contact-loaders/ngpvan/util.test.js
@@ -63,7 +63,7 @@ describe("ngpvan/util", () => {
     });
   });
 
-  describe(".getAuth", () => {
+  describe(".getAuth", async () => {
     let oldNgpVanAppName;
     let oldNgpVanApiKey;
     beforeAll(async () => {
@@ -120,12 +120,13 @@ describe("ngpvan/util", () => {
       }
 
       try {
-        auth = Van.getAuth(organization);
+        auth = await Van.getAuth(organization);
       } catch (caughtException) {
         error = caughtException;
       } finally {
         expect(config.getConfig.mock.calls).toEqual([
           ["NGP_VAN_APP_NAME", organization],
+          ["NGP_VAN_API_KEY_ENCRYPTED", organization, {}],
           ["NGP_VAN_API_KEY", organization],
           ["NGP_VAN_DATABASE_MODE", organization]
         ]);

--- a/__test__/extensions/service-vendors/twilio.test.js
+++ b/__test__/extensions/service-vendors/twilio.test.js
@@ -842,7 +842,6 @@ describe("config functions", () => {
             ]);
             expect(configFunctions.getConfig.mock.calls).toEqual([
               ["TWILIO_AUTH_TOKEN_ENCRYPTED", organization, expectedConfigOpts],
-              ["TWILIO_AUTH_TOKEN_ENCRYPTED", organization, expectedConfigOpts],
               ["TWILIO_ACCOUNT_SID", organization, expectedConfigOpts],
               ["TWILIO_ACCOUNT_SID", organization, expectedConfigOpts],
               ["TWILIO_MESSAGE_SERVICE_SID", organization, expectedConfigOpts]

--- a/docs/REFERENCE-NGPVAN_user_guide.md
+++ b/docs/REFERENCE-NGPVAN_user_guide.md
@@ -15,30 +15,27 @@ This is a user guide for integrating with VAN. Though the integration is referre
 
 To request an API Key, go to the API integrations page from the sidebar menu, and click request API key. Request a 'Spoke Main Branch' API key.
 
-You can use this integration with one API key for your whole Spoke build, or with different API keys for each organization in a multi-organization setup. Either way, you will likely want to set NGP_VAN_WEBHOOK_BASE_URL globally to the base URL for wherever you host spoke (i.e. the same value as BASE_URL).
-
-Regardless of whether you are using one key for your whole build or per-org keys, if you would like to use data from MyCampaign (as opposed to my voters), append |1 to the end of the API key you are given when saving it to your database or as an environment variable.
+You can use this integration with one API key for your whole Spoke build, or with different API keys for each organization in a multi-organization setup. Either way, you will likely want to set `NGP_VAN_WEBHOOK_BASE_URL` globally to the base URL for wherever you host spoke (i.e. the same value as `BASE_URL`).
 
 ### Setting a single API key for your whole build
 
-Set the NGP_VAN_API_KEY environment variable to your API key, and the NGP_VAN_APP_NAME to the associated user name (usually something like NY001.spoke.api or similar).
+Set the `NGP_VAN_API_KEY` environment variable to your API key, and the `NGP_VAN_APP_NAME` to the associated user name (usually something like NY001.spoke.api or similar).
+
+If you would like to use data from MyCampaign (as opposed to MyVoters), set `NGP_VAN_DATABASE_MODE` to `1`.
 
 If you are using Redis, you may need to clear the cache when you add or make changes to the API key; you can do this from your Redis CLI with FLUSHDB (though this is not recommended in the middle of high amounts of active use) or by deleting the in individual associate keys [TODO: what are the proper keys to clear here?]
 
 ### Using different API keys for each organization
 
-You can set individual API keys for some or all of your organizations by editing the features column in the organziation table of your database directly. This column is in JSON format so if no other features are set for the organization, you would set the value to 
-
-{"NGP_VAN_API_KEY":"[key]", "NGP_VAN_APP_NAME":"[app_name]"}
-
-After saving this change in your database, if you are using Redis, you should clear the cache for this organization by going to Settings in Spoke and clicking the "Clear Cached Organization and Extension Caches"
-button.
+You can set individual API keys for some or all of your organizations by enabling the NGPVAN service manager. The service manager will add options to the organization settings page allowing you to override the `NGP_VAN_API_KEY`, `NGP_VAN_APP_NAME`, and `NGP_VAN_DATABASE_MODE` variables. API keys are encrypted before being stored in the database.
 
 When organizations do not have these variables individually set, if these variables are globally set, Spoke will fall back to using those credentials.
 
+To enable per-organiziation VAN keys, add `ngpvan` to the list in your `SERVICE_MANAGERS` environment variable.
+
 ## The Contact Loader
 
-The contact loader allows you to choose a saved list (but not a saved search) in VAN as your contact source. All the fields that are available for your contacts in VAN will be available for personalization in Spoke, including handy things like polling location and district (though those fields will of course only be as accurate as they were in VAN). To use the contact loader, ngpvan must appear in the list in your CONTACT_LOADERS envirornment variable.
+The contact loader allows you to choose a saved list (but not a saved search) in VAN as your contact source. All the fields that are available for your contacts in VAN will be available for personalization in Spoke, including handy things like polling location and district (though those fields will of course only be as accurate as they were in VAN). To use the contact loader, `ngpvan` must appear in the list in your `CONTACT_LOADERS` envirornment variable.
 
 Loading lists from VAN in Spoke does <b>not</b> involve the SMS button in VAN. Instead, make a folder or folders in VAN where you plan to save the lists you would like to use. Edit that folder, and give the API User for the key you requested access to that folder as you would any other user. Going forward, any list you save to that folder will show up in Spoke--select NGPVAN as the Contact Load Method and start typing the list name, then select it from the typeahead when it appears.
 
@@ -48,12 +45,12 @@ Can't find your list? These are common reasons folks run into issues:
 
 * Is this a saved list, and not a saved search?
 * Did you save it in a folder where the proper API user has access?
-* If the list is over 75,000 people, it will not appear by default. You can cut it into smaller lists, or change the maximum list size by changing NGP_VAN_MAXIMUM_LIST_SIZE. For large lists, you also run a bigger risk of the request to VAN to load the list timing out; you can change the maximum timeout length with NGP_VAN_TIMEOUT.
+* If the list is over 75,000 people, it will not appear by default. You can cut it into smaller lists, or change the maximum list size by changing `NGP_VAN_MAXIMUM_LIST_SIZE`. For large lists, you also run a bigger risk of the request to VAN to load the list timing out; you can change the maximum timeout length with `NGP_VAN_TIMEOUT`.
 * If none of the above issues seem to apply in your case, there may be a caching issue, particularly if you just set up the VAN integration. Clearing the cache in Settings --> External configuration sometimes helps, as does logging out and back in.
 
 ## The Action Handler
 
-The action handler allows you to sync data back to VAN as part of your script. Data saves to VAN are triggered in the same way answers to questions you incorporate in your script are saved in Spoke, i.e. when the texter selects an answer to a question you have constructed, and then sends a subsequent message, clicks Skip, or opts the contact out. To use the action handler, ngpvan must appear in the list in your ACTION_HANDLERS envirornment variable.
+The action handler allows you to sync data back to VAN as part of your script. Data saves to VAN are triggered in the same way answers to questions you incorporate in your script are saved in Spoke, i.e. when the texter selects an answer to a question you have constructed, and then sends a subsequent message, clicks Skip, or opts the contact out. To use the action handler, `ngpvan` must appear in the list in your `ACTION_HANDLERS` envirornment variable.
 
 For each question answer, you can select an appropriate action by selecting NGPVAN from the dropdown and starting to type. Your options will be drawn from Canvass Response Codes, Activist Codes, and Survey Question answers you have set up in VAN.
 
@@ -61,4 +58,4 @@ An important note: by far the easiest way to use the Action Handler is when you 
 
 ## The Message Handler
 
-The message handler will simply mark every contact you message as messaged in VAN, in that contact's Contact History. By default the contact result will be 'Texted' but this can be modified via changing DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT in your environment variables. To use the message handler, ngpvan must appear in the list in your MESSAGE_HANLDERS environment variable, <b>and</b> you must be using the NGPVAN action handler (see above, including the caveat about using the handlers when loading from a CSV).
+The message handler will simply mark every contact you message as messaged in VAN, in that contact's Contact History. By default the contact result will be 'Texted' but this can be modified via changing `DEFAULT_NGP_VAN_INITIAL_TEXT_CANVASS_RESULT` in your environment variables. To use the message handler, `ngpvan` must appear in the list in your `MESSAGE_HANLDERS` environment variable, <b>and</b> you must be using the NGPVAN action handler (see above, including the caveat about using the handlers when loading from a CSV).

--- a/src/extensions/action-handlers/ngpvan-action.js
+++ b/src/extensions/action-handlers/ngpvan-action.js
@@ -1,4 +1,4 @@
-import { getConfig } from "../../server/api/lib/config";
+import { getConfig, hasConfig } from "../../server/api/lib/config";
 import Van from "../contact-loaders/ngpvan/util";
 import {
   getCountryCode,
@@ -93,7 +93,7 @@ export const postCanvassResponse = async (contact, organization, bodyInput) => {
     retries: 0,
     timeout: Van.getNgpVanTimeout(organization),
     headers: {
-      Authorization: Van.getAuth(organization),
+      Authorization: await Van.getAuth(organization),
       "Content-Type": "application/json"
     },
     body: JSON.stringify(body),
@@ -127,7 +127,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
       headers: {
-        Authorization: Van.getAuth(organization)
+        Authorization: await Van.getAuth(organization)
       }
     }
   )
@@ -145,7 +145,7 @@ async function getContactTypeIdAndInputTypeId(organization) {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
       headers: {
-        Authorization: Van.getAuth(organization)
+        Authorization: await Van.getAuth(organization)
       }
     }
   )
@@ -228,7 +228,7 @@ export async function getClientChoiceData(organization) {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
       headers: {
-        Authorization: Van.getAuth(organization)
+        Authorization: await Van.getAuth(organization)
       }
     }
   )
@@ -246,7 +246,7 @@ export async function getClientChoiceData(organization) {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
       headers: {
-        Authorization: Van.getAuth(organization)
+        Authorization: await Van.getAuth(organization)
       }
     }
   )
@@ -264,7 +264,7 @@ export async function getClientChoiceData(organization) {
       method: "GET",
       timeout: Van.getNgpVanTimeout(organization),
       headers: {
-        Authorization: Van.getAuth(organization)
+        Authorization: await Van.getAuth(organization)
       }
     }
   )
@@ -371,8 +371,9 @@ export async function getClientChoiceData(organization) {
 // process.env.ACTION_HANDLERS
 export async function available(organization) {
   let result =
-    !!getConfig("NGP_VAN_API_KEY", organization) &&
-    !!getConfig("NGP_VAN_APP_NAME", organization);
+    (hasConfig("NGP_VAN_API_KEY", organization) ||
+      hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)) &&
+    hasConfig("NGP_VAN_APP_NAME", organization);
 
   if (!result) {
     // eslint-disable-next-line no-console

--- a/src/extensions/contact-loaders/ngpvan/util.js
+++ b/src/extensions/contact-loaders/ngpvan/util.js
@@ -1,13 +1,19 @@
-import { getConfig } from "../../../server/api/lib/config";
+import {
+  getConfig,
+  getConfigDecrypt,
+  hasConfig
+} from "../../../server/api/lib/config";
 
 export const DEFAULT_NGP_VAN_API_BASE_URL = "https://api.securevan.com";
 export const DEFAULT_NGP_VAN_DATABASE_MODE = 0;
 export const DEFAULT_NGPVAN_TIMEOUT = 32000;
 
 export default class Van {
-  static getAuth = organization => {
+  static getAuth = async organization => {
     const appName = getConfig("NGP_VAN_APP_NAME", organization);
-    const apiKey = getConfig("NGP_VAN_API_KEY", organization);
+    const apiKey = hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)
+      ? await getConfigDecrypt("NGP_VAN_API_KEY_ENCRYPTED", organization)
+      : getConfig("NGP_VAN_API_KEY", organization);
     const databaseMode = getConfig("NGP_VAN_DATABASE_MODE", organization);
 
     if (!appName || !apiKey) {

--- a/src/extensions/message-handlers/ngpvan/index.js
+++ b/src/extensions/message-handlers/ngpvan/index.js
@@ -1,4 +1,4 @@
-import { getConfig } from "../../../server/api/lib/config";
+import { getConfig, hasConfig } from "../../../server/api/lib/config";
 const Van = require("../../../extensions/action-handlers/ngpvan-action");
 
 import { getActionChoiceData } from "../../../extensions/action-handlers";
@@ -21,8 +21,9 @@ export const serverAdministratorInstructions = () => {
 };
 
 export const available = organization =>
-  !!getConfig("NGP_VAN_API_KEY", organization) &&
-  !!getConfig("NGP_VAN_APP_NAME", organization);
+  (hasConfig("NGP_VAN_API_KEY", organization) ||
+    hasConfig("NGP_VAN_API_KEY_ENCRYPTED", organization)) &&
+  hasConfig("NGP_VAN_APP_NAME", organization);
 
 // export const preMessageSave = async () => {};
 

--- a/src/extensions/secret-manager/crypto.js
+++ b/src/extensions/secret-manager/crypto.js
@@ -11,26 +11,28 @@ const crypto = require("crypto");
 const secret = process.env.SESSION_SECRET || global.SESSION_SECRET;
 const algorithm = "aes-256-cbc";
 
-if (!secret) {
-  throw new Error(
-    "The SESSION_SECRET environment variable must be set to use crypto functions!"
-  );
-}
-
 // The encryption key must be exactly 32 (bytes). We pad the SESSION_SECRET to
 // 32 characters because in the default development environment it is shorter.
 // In production environments the SESSION_SECRET should be a long random sring.
-if (secret.length < 32) {
+if (secret && secret.length < 32) {
   // eslint-disable-next-line no-console
   console.warn(
     "Using short (insecure) SESSION_SECRET. Fine for testing, bad for production."
   );
 }
-const key = Buffer.concat([Buffer.from(secret)], 32);
+
+const getKey = () => {
+  if (!secret) {
+    throw new Error(
+      "The SESSION_SECRET environment variable must be set to use crypto functions!"
+    );
+  }
+  return Buffer.concat([Buffer.from(secret)], 32);
+};
 
 const symmetricEncrypt = value => {
   const iv = crypto.randomBytes(16);
-  const cipher = crypto.createCipheriv(algorithm, key, iv);
+  const cipher = crypto.createCipheriv(algorithm, getKey(), iv);
   let encrypted = cipher.update(value, "utf8", "buffer");
   encrypted = Buffer.concat([encrypted, cipher.final("buffer")]);
   return iv.toString("hex") + ":" + encrypted.toString("hex");
@@ -40,7 +42,7 @@ const symmetricDecrypt = encrypted => {
   let parts = encrypted.split(":");
   const iv = Buffer.from(parts.shift(), "hex");
   const encryptedValue = Buffer.from(parts.join(":"), "hex");
-  const decipher = crypto.createDecipheriv(algorithm, key, iv);
+  const decipher = crypto.createDecipheriv(algorithm, getKey(), iv);
   let decrypted = decipher.update(encryptedValue, "buffer", "utf8");
   return decrypted + decipher.final("utf8");
 };

--- a/src/extensions/secret-manager/default-encrypt/index.js
+++ b/src/extensions/secret-manager/default-encrypt/index.js
@@ -1,7 +1,12 @@
 import { symmetricDecrypt, symmetricEncrypt } from "../crypto";
 
 export async function getSecret(name, token, organization) {
-  return symmetricDecrypt(token);
+  try {
+    return symmetricDecrypt(token);
+  } catch (e) {
+    // Can't decrypt, return value as-is.
+    return token;
+  }
 }
 
 export async function convertSecret(name, organization, secretValue) {

--- a/src/extensions/service-managers/ngpvan/index.js
+++ b/src/extensions/service-managers/ngpvan/index.js
@@ -27,7 +27,7 @@ export async function getOrganizationData({ organization, user, loaders }) {
     data: {
       NGP_VAN_API_KEY_ENCRYPTED: NGP_VAN_API_KEY_ENCRYPTED && "<Encrypted>",
       NGP_VAN_APP_NAME,
-      NGP_VAN_DATABASE_MODE: NGP_VAN_DATABASE_MODE.toString()
+      NGP_VAN_DATABASE_MODE: String(NGP_VAN_DATABASE_MODE)
     },
     // fullyConfigured: null means (more) configuration is optional -- maybe not required to be enabled
     // fullyConfigured: true means it is fully enabled and configured for operation
@@ -54,7 +54,7 @@ export async function onOrganizationUpdateSignal({
     data: {
       NGP_VAN_API_KEY_ENCRYPTED: NGP_VAN_API_KEY_ENCRYPTED && "<Encrypted>",
       NGP_VAN_APP_NAME,
-      NGP_VAN_DATABASE_MODE: NGP_VAN_DATABASE_MODE.toString()
+      NGP_VAN_DATABASE_MODE: String(NGP_VAN_DATABASE_MODE)
     },
     fullyConfigured: true
   };

--- a/src/extensions/service-managers/ngpvan/index.js
+++ b/src/extensions/service-managers/ngpvan/index.js
@@ -1,0 +1,61 @@
+import { getFeatures } from "../../../server/api/lib/config";
+import { cacheableData } from "../../../server/models";
+
+export const name = "ngpvan";
+
+export const metadata = () => ({
+  displayName: "NGPVAN Integration",
+  description: "Used to set NGPVAN credentials per-organization",
+  canSpendMoney: false,
+  moneySpendingOperations: [],
+  supportsOrgConfig: true,
+  supportsCampaignConfig: false
+});
+
+export async function getOrganizationData({ organization, user, loaders }) {
+  // MUST NOT RETURN SECRETS!
+  const features = getFeatures(organization);
+  const {
+    NGP_VAN_API_KEY_ENCRYPTED,
+    NGP_VAN_APP_NAME,
+    NGP_VAN_DATABASE_MODE
+  } = features;
+  return {
+    // data is any JSON-able data that you want to send.
+    // This can/should map to the return value if you implement onOrganizationUpdateSignal()
+    // which will then get updated data in the Settings component on-save
+    data: {
+      NGP_VAN_API_KEY_ENCRYPTED: NGP_VAN_API_KEY_ENCRYPTED && "<Encrypted>",
+      NGP_VAN_APP_NAME,
+      NGP_VAN_DATABASE_MODE: NGP_VAN_DATABASE_MODE.toString()
+    },
+    // fullyConfigured: null means (more) configuration is optional -- maybe not required to be enabled
+    // fullyConfigured: true means it is fully enabled and configured for operation
+    // fullyConfigured: false means more configuration is REQUIRED (i.e. manager is necessary and needs more configuration for Spoke campaigns to run)
+    fullyConfigured: null
+  };
+}
+
+export async function onOrganizationUpdateSignal({
+  organization,
+  user,
+  updateData
+}) {
+  const updatedFeatures = await cacheableData.organization.setFeatures(
+    organization.id,
+    updateData
+  );
+  const {
+    NGP_VAN_API_KEY_ENCRYPTED,
+    NGP_VAN_APP_NAME,
+    NGP_VAN_DATABASE_MODE
+  } = updatedFeatures;
+  return {
+    data: {
+      NGP_VAN_API_KEY_ENCRYPTED: NGP_VAN_API_KEY_ENCRYPTED && "<Encrypted>",
+      NGP_VAN_APP_NAME,
+      NGP_VAN_DATABASE_MODE: NGP_VAN_DATABASE_MODE.toString()
+    },
+    fullyConfigured: true
+  };
+}

--- a/src/extensions/service-managers/ngpvan/react-component.js
+++ b/src/extensions/service-managers/ngpvan/react-component.js
@@ -1,0 +1,85 @@
+/* eslint no-console: 0 */
+import PropTypes from "prop-types";
+import React from "react";
+import Form from "react-formal";
+import * as yup from "yup";
+import GSForm from "../../../components/forms/GSForm";
+import GSTextField from "../../../components/forms/GSTextField";
+import GSSelectField from "../../../components/forms/GSSelectField";
+import GSSubmitButton from "../../../components/forms/GSSubmitButton";
+
+export class OrgConfig extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    const formSchema = yup.object({
+      NGP_VAN_API_KEY_ENCRYPTED: yup
+        .string()
+        .max(64)
+        .notRequired()
+        .nullable(),
+      NGP_VAN_APP_NAME: yup
+        .string()
+        .max(32)
+        .notRequired()
+        .nullable(),
+      NGP_VAN_DATABASE_MODE: yup
+        .number()
+        .oneOf([0, 1, null])
+        .nullable()
+        .transform(val => (isNaN(val) ? null : val))
+    });
+    return (
+      <div>
+        <GSForm
+          schema={formSchema}
+          defaultValue={this.props.serviceManagerInfo.data}
+          onSubmit={x => {
+            this.props.onSubmit(x);
+          }}
+        >
+          <Form.Field
+            as={GSTextField}
+            label="NGPVAN API Key"
+            name="NGP_VAN_API_KEY_ENCRYPTED"
+            fullWidth
+          />
+          <Form.Field
+            as={GSTextField}
+            label="NGPVAN App Name"
+            name="NGP_VAN_APP_NAME"
+            fullWidth
+          />
+          <Form.Field
+            as={GSSelectField}
+            label="NGP VAN Database Mode"
+            name="NGP_VAN_DATABASE_MODE"
+            choices={[
+              { value: "", label: "" },
+              { value: "0", label: "My Voters" },
+              { value: "1", label: "My Campaign" }
+            ]}
+            style={{ width: "100%" }}
+          />
+          <Form.Submit
+            as={GSSubmitButton}
+            label="Save"
+            style={this.props.inlineStyles.dialogButton}
+          />
+        </GSForm>
+      </div>
+    );
+  }
+}
+
+OrgConfig.propTypes = {
+  organizationId: PropTypes.string,
+  serviceManagerInfo: PropTypes.object,
+  inlineStyles: PropTypes.object,
+  styles: PropTypes.object,
+  saveLabel: PropTypes.string,
+  onSubmit: PropTypes.func
+};

--- a/src/extensions/service-vendors/twilio/index.js
+++ b/src/extensions/service-vendors/twilio/index.js
@@ -4,7 +4,11 @@ import Twilio, { twiml } from "twilio";
 import urlJoin from "url-join";
 import { log } from "../../../lib";
 import { getFormattedPhoneNumber } from "../../../lib/phone-format";
-import { getConfig, hasConfig } from "../../../server/api/lib/config";
+import {
+  getConfig,
+  getConfigDecrypt,
+  hasConfig
+} from "../../../server/api/lib/config";
 import {
   cacheableData,
   Log,
@@ -1040,14 +1044,10 @@ export const getServiceConfig = async (
     if (hasEncryptedToken) {
       authToken = obscureSensitiveInformation
         ? "<Encrypted>"
-        : await getSecret(
+        : await getConfigDecrypt(
             "TWILIO_AUTH_TOKEN_ENCRYPTED",
-            getConfig(
-              "TWILIO_AUTH_TOKEN_ENCRYPTED",
-              organization,
-              getConfigOptions
-            ),
-            organization
+            organization,
+            getConfigOptions
           );
     } else {
       const hasUnencryptedToken = hasConfig(

--- a/src/server/api/lib/config.js
+++ b/src/server/api/lib/config.js
@@ -1,4 +1,5 @@
 import fs from "fs";
+import { getSecret } from "../../../extensions/secret-manager";
 
 // This is for centrally loading config from different environment sources
 // Especially for large config values (or many) some environments (like AWS Lambda) limit
@@ -58,6 +59,17 @@ export function getConfig(key, organization, opts) {
     return false;
   }
   return opts && opts.default;
+}
+
+// Ideally, decryption would happen automatically in getConfig(), but because
+// the secret manager is async, getConfig would need to be async as well and a
+// lot of code would need to be updated.
+export async function getConfigDecrypt(key, organization, opts) {
+  let value = getConfig(key, organization, opts);
+  if (key.endsWith("_ENCRYPTED")) {
+    value = await getSecret(key, value, organization);
+  }
+  return value;
 }
 
 export function hasConfig(key, organization, options = {}) {

--- a/src/server/models/cacheable_queries/organization.js
+++ b/src/server/models/cacheable_queries/organization.js
@@ -68,9 +68,6 @@ const organizationCache = {
     return dbResult;
   },
   setFeatures: async (id, newFeatures) => {
-    console.log("SET FEATURES");
-    console.log(id);
-    console.log(newFeatures);
     if (!id || !newFeatures) {
       return;
     }


### PR DESCRIPTION
# Fixes #1693 

## Description

This is a rework of #1813, implementing a per-organization VAN credential interface as a service manager. A few notes:
- I added a `setFeatures` method to cacheable organization. This mirrors the setFeatures method available on campaigns, and should make it easier for future extensions to store organization config without duplicating a bunch of code.
- Decrypting keys stored in the database is a bit trickier than it was in #1813, because the secret manager is now `async`, but `getConfig` is not. Potentially, we should make getConfig async, but I thought that was too far to go in this PR.

![CleanShot 2022-08-01 at 13 09 13](https://user-images.githubusercontent.com/18371709/182204731-c1eb8bac-666a-42a4-ba31-f982530597f0.png)

# Checklist:

- [x] I have manually tested my changes on desktop and mobile
- [x] The test suite passes locally with my changes
- [x] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [x] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [x] I have made any necessary changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR is labeled [WIP] if it is in progress
