### PR TITLE
Fix password reset issue when PASSPORT_STRATEGY isn't explicitly set

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "twilio": "^3.40.0",
     "url-join": "^4.0.1",
     "us-area-codes": "^1.0.0",
-    "uuid": "^3.1.0",
+    "uuid": "^9.0.0",
     "wait-for-expect": "^1.1.1",
     "webpack": "4",
     "webpack-manifest-plugin": "^2.0.4",

--- a/src/extensions/service-vendors/fakeservice/index.js
+++ b/src/extensions/service-vendors/fakeservice/index.js
@@ -5,7 +5,7 @@ import {
   r,
   cacheableData
 } from "../../../server/models";
-import uuid from "uuid";
+import { v4 as uuidv4 } from 'uuid';
 
 // This 'fakeservice' allows for fake-sending messages
 // that end up just in the db appropriately and then using sendReply() graphql
@@ -141,7 +141,7 @@ export async function buyNumbersInAreaCode(organization, areaCode, limit) {
       area_code: areaCode,
       phone_number: `+1${areaCode}XYZ${last4}`,
       service: "fakeservice",
-      service_id: uuid.v4()
+      service_id: uuidv4()
     });
   }
 

--- a/src/server/api/schema.js
+++ b/src/server/api/schema.js
@@ -665,7 +665,7 @@ const rootMutations = {
 
       const organization = await loaders.organization.load(organizationId);
 
-      const passportStrategy = getConfig("PASSPORT_STRATEGY", organization);
+      const passportStrategy = getConfig("PASSPORT_STRATEGY", organization) || "auth0";
       if (passportStrategy === "auth0") {
         const { email } = await r
           .knex("user")

--- a/yarn.lock
+++ b/yarn.lock
@@ -17098,6 +17098,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
+  integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==
+
 v8flags@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"


### PR DESCRIPTION
# Fixes #1870 

## Description
When the PASSPORT_STRATEGY env var isn't explicitly set, it's defaulted to "auth0":
https://github.com/MoveOnOrg/Spoke/blob/2e8c479ef7e4071bc903bdf882334488b50f2910/src/server/middleware/render-index.js#L92

The password reset function doesn't take this into account, thus leading to the bug described in #1870 when the PASSPORT_STRATEGY env var isn't explicitly set.

This PR adds tests to `__test__/server/api/people.test.js` to cover this case, and also updates the `uuid` dependency to take advantage of the `uuidValidate` function for easier testing.

# Checklist:

- [X] I have manually tested my changes on desktop and mobile
- [X] The test suite passes locally with my changes
- [X] If my change is a UI change, I have attached a screenshot to the description section of this pull request
- [X] [My change is 300 lines of code or less](https://github.com/MoveOnOrg/Spoke/blob/main/CONTRIBUTING.md#submitting-your-pull-request), or has a documented reason in the description why it’s longer
- [X] I have made any necessary changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] My PR is labeled [WIP] if it is in progress
